### PR TITLE
Warehouse benchmarking toolchain (Snowflake + Databricks)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,17 +27,29 @@ server = ["fastapi>=0.115", "uvicorn>=0.30"]
 # Oracle is a v1 target and an OPTIONAL extra, not a core dependency: only an Oracle
 # deployment needs the driver, and `oracledb` in thin mode needs no Oracle client libraries.
 oracle = ["oracledb>=2"]
-# The warehouse benchmark path (scripts/grade_warehouse.py, load_databricks.py, run_genie.py,
-# run_ai_query.py, capture_rows.py). Extras rather than core dependencies: only someone
-# reproducing the vendor comparison needs a Databricks or Snowflake driver. They are declared
-# because these scripts produced published numbers, and a `uv sync` that quietly prunes a
-# driver turns every one of them into a ModuleNotFoundError at the first connect.
+# The warehouse benchmark path: any script under `scripts/` that connects to Snowflake or
+# Databricks. Stated as a RULE rather than a list or a count, both of which this comment has
+# already got wrong -- it named five scripts when far more needed the drivers, because every
+# batch that added one had to remember to come back and edit prose. To see the current set:
+#
+#   grep -lE '\b(snowflake|databricks)' scripts/*.py
+#
+# Extras rather than core dependencies: only someone reproducing the vendor comparison needs a
+# Databricks or Snowflake driver. They are declared because these scripts produced published
+# numbers, and a `uv sync` that quietly prunes a driver turns every one of them into a
+# ModuleNotFoundError at the first connect.
+#
+# `cryptography` and `requests` are DIRECT imports of `run_cortex.py` -- key-pair auth and the
+# Cortex REST call. The connector happens to pull both today, which is exactly the reliance the
+# paragraph above says not to take: a transitive dependency is not a promise.
 databricks = ["databricks-sdk>=0.30", "databricks-sql-connector>=3"]
-snowflake = ["snowflake-connector-python>=3"]
+snowflake = ["snowflake-connector-python>=3", "cryptography>=42", "requests>=2.31"]
 warehouse = [
     "databricks-sdk>=0.30",
     "databricks-sql-connector>=3",
     "snowflake-connector-python>=3",
+    "cryptography>=42",
+    "requests>=2.31",
     "sqlglot>=25",
 ]
 ontology = [

--- a/scripts/add_relationships_spider2.py
+++ b/scripts/add_relationships_spider2.py
@@ -1,0 +1,195 @@
+"""Fold declared keys into semantic views that were generated before the keys existed.
+
+Autopilot reads constraints once, at generation time: a view built over a schema with no
+FOREIGN KEYs has an empty `relationships (...)` clause forever, and Cortex Analyst then
+refuses every question needing a join. Rebuilding those views through the wizard would also
+discard the AI-written table and column descriptions, which are part of what is being
+measured.
+
+So this edits the view instead. `GET_DDL` returns the whole definition; the keys now declared
+on the tables are spliced in as `primary key (...)` on each table entry and a
+`relationships (...)` block, and the result is replayed as CREATE OR REPLACE. Descriptions,
+sample values, facts and dimensions all survive verbatim.
+
+  uv run python scripts/add_relationships_spider2.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from collections import defaultdict
+
+import snowflake.connector
+
+
+def declared_keys(cur, database: str) -> tuple[dict, dict]:
+    """({schema: {table: pk_column}}, {schema: [(child, col, parent, col), ...]})"""
+    cur.execute(f"SHOW PRIMARY KEYS IN DATABASE {database}")
+    names = [d[0] for d in cur.description]
+    s, t, c = names.index("schema_name"), names.index("table_name"), names.index("column_name")
+    primary: dict[str, dict[str, str]] = defaultdict(dict)
+    for row in cur.fetchall():
+        primary[row[s]].setdefault(row[t], row[c])
+
+    cur.execute(f"SHOW IMPORTED KEYS IN DATABASE {database}")
+    names = [d[0] for d in cur.description]
+    idx = {n: names.index(n) for n in (
+        "fk_schema_name", "fk_table_name", "fk_column_name", "pk_table_name", "pk_column_name"
+    )}
+    foreign: dict[str, list[tuple]] = defaultdict(list)
+    for row in cur.fetchall():
+        foreign[row[idx["fk_schema_name"]]].append((
+            row[idx["fk_table_name"]],
+            row[idx["fk_column_name"]],
+            row[idx["pk_table_name"]],
+            row[idx["pk_column_name"]],
+        ))
+    return primary, foreign
+
+
+def splice(ddl: str, primary: dict[str, str], foreign: list[tuple]) -> str | None:
+    """Add primary keys and a relationships block to a semantic view's DDL."""
+    if "\n\trelationships (" in ddl:
+        return None  # already has them; leave it alone
+
+    # A semantic view will only accept a relationship whose target column is that table's
+    # declared key, so the key each parent needs is dictated by what points at it -- not by
+    # whatever SHOW PRIMARY KEYS happens to report. Where two columns of one table are
+    # referenced, only the first can be the key and the other relationships are dropped.
+    keys: dict[str, str] = {}
+    for _, _, parent, parent_column in sorted(foreign):
+        keys.setdefault(parent, primary.get(parent) or parent_column)
+        if keys[parent] != parent_column and primary.get(parent) == keys[parent]:
+            keys[parent] = parent_column  # prefer a key something actually references
+
+    def add_pk(match: re.Match) -> str:
+        qualified, rest = match.group(1), match.group(2)
+        table = qualified.rsplit(".", 1)[-1].strip('"')
+        column = keys.get(table) or primary.get(table)
+        if not column:
+            return match.group(0)
+        # Autopilot sometimes writes a composite key that sweeps foreign key columns in
+        # alongside the real one (SQLITE-SAKILA's STORE gets (MANAGER_STAFF_ID, STORE_ID)).
+        # A relationship has to name the whole key, so the key is narrowed to the column
+        # that actually identifies the row.
+        rest = re.sub(r"^ primary key \([^)]*\)", "", rest)
+        return f"\t\t{qualified} primary key ({column}){rest}"
+
+    # Only the table entries: three dotted parts. A dimension or fact line is TABLE.COLUMN.
+    ddl = re.sub(r'\t\t((?:[\w"-]+\.){2}[\w"-]+)([^\n]*)(?=\n)', add_pk, ddl)
+
+    used: set[str] = set()
+    edges: dict[str, set[str]] = defaultdict(set)
+
+    def reaches(start: str, goal: str) -> bool:
+        seen, stack = set(), [start]
+        while stack:
+            node = stack.pop()
+            if node == goal:
+                return True
+            if node in seen:
+                continue
+            seen.add(node)
+            stack.extend(edges[node])
+        return False
+
+    lines = []
+    for child, child_col, parent, parent_col in sorted(foreign):
+        if keys.get(parent) != parent_col:
+            continue  # points at a column the parent cannot declare as its key
+        # Semantic views reject cycles, and Sakila has a real one: STORE names its manager
+        # in STAFF, STAFF names the store it works at. Keep the first edge, drop the one
+        # that closes the loop -- a join path in one direction beats none in either.
+        if reaches(parent, child):
+            continue
+        edges[child].add(parent)
+        name = f"{child}_TO_{parent}"
+        suffix = 2
+        while name in used:
+            name = f"{child}_TO_{parent}_{suffix}"
+            suffix += 1
+        used.add(name)
+        lines.append(f"\t\t{name} as {child}({child_col}) references {parent}({parent_col})")
+    if not lines:
+        return None
+
+    block = "\trelationships (\n" + ",\n".join(lines) + "\n\t)\n"
+    # The clause sits between the tables block and facts/dimensions, as Snowflake writes it.
+    for anchor in ("\tfacts (", "\tdimensions (", "\tmetrics ("):
+        position = ddl.find(anchor)
+        if position != -1:
+            return ddl[:position] + block + ddl[position:]
+    return ddl.rstrip().rstrip(";") + "\n" + block
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--database", default="SPIDER2")
+    p.add_argument("--view", default="SPIDER2_SV")
+    p.add_argument("--connection", default=os.environ.get("SNOWFLAKE_CONNECTION", "bench_key"))
+    p.add_argument("--warehouse", default=os.environ.get("SNOWFLAKE_WAREHOUSE", "BENCH_WH"))
+    p.add_argument("--schema", action="append", dest="schemas")
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+
+    con = snowflake.connector.connect(connection_name=args.connection)
+    cur = con.cursor()
+    cur.execute(f"USE WAREHOUSE {args.warehouse}")
+    primary, foreign = declared_keys(cur, args.database)
+
+    cur.execute(f"SHOW SEMANTIC VIEWS IN DATABASE {args.database}")
+    names = [d[0] for d in cur.description]
+    s, n = names.index("schema_name"), names.index("name")
+    views = [r[s] for r in cur.fetchall() if r[n] == args.view]
+    if args.schemas:
+        views = [v for v in views if v in set(args.schemas)]
+
+    print(f"{'schema':30} {'relationships':>13}")
+    changed = 0
+    try:
+        for schema in sorted(views):
+            cur.execute(
+                f"SELECT GET_DDL('SEMANTIC_VIEW', '{args.database}.\"{schema}\".{args.view}')"
+            )
+            ddl = cur.fetchone()[0]
+            # A view built through the wizard can end up stored in one schema over another
+            # schema's tables (one mis-click, and it is invisible afterwards). Splicing this
+            # schema's keys into someone else's tables would fail loudly at best and
+            # mislabel a relationship at worst.
+            body = ddl[ddl.index("tables ("):]
+            referenced = {
+                r.strip('"')
+                for r in re.findall(rf'{args.database}\.([A-Za-z0-9_-]+|"[^"]+")\.', body)
+            }
+            if referenced != {schema}:
+                print(f"{schema:30} {'WRONG TABLES: ' + ','.join(sorted(referenced)):>13}")
+                continue
+
+            patched = splice(ddl, primary.get(schema, {}), foreign.get(schema, []))
+            if patched is None:
+                print(f"{schema:30} {'unchanged':>13}")
+                continue
+            count = patched.count(" references ")
+            if args.dry_run:
+                print(f"{schema:30} {count:13}  (dry)")
+                continue
+            cur.execute(f'USE SCHEMA {args.database}."{schema}"')
+            try:
+                cur.execute(patched)
+            except Exception as exc:
+                print(f"{schema:30} {'FAILED':>13}  {str(exc).splitlines()[-1][:90]}")
+                continue
+            changed += 1
+            print(f"{schema:30} {count:13}")
+    finally:
+        cur.close()
+        con.close()
+
+    print(f"\n{changed} semantic views rewritten")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/align_fk_types_snowflake.py
+++ b/scripts/align_fk_types_snowflake.py
@@ -1,0 +1,181 @@
+"""Cast a foreign-key column to its referenced column's type, so the constraint can exist.
+
+Spider declares some join columns with types that disagree across the two sides of the key
+(concert.Stadium_ID as TEXT against stadium.Stadium_ID as NUMBER), and reading a
+type-violating table as text widens a few more. Snowflake refuses a FOREIGN KEY whose types
+differ, so those relationships would be missing from the semantic view -- and a missing
+relationship is the difference between an answer and a refusal.
+
+Rebuilding the child table with the column cast to the parent's type states what the schema
+already means. Gold and prediction both run against the result, so the comparison stays fair.
+
+  uv run python scripts/align_fk_types_snowflake.py --database SPIDER
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import snowflake.connector
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
+
+from mnemiq.eval.spider import load_keys, load_spider  # noqa: E402
+
+_DEFAULT_SPIDER = os.environ.get(
+    "MNEMIQ_SPIDER_DIR", os.path.expanduser("~/src/dataset/spider/spider_data")
+)
+
+
+def column_types(cur, database: str, schema: str) -> dict[tuple[str, str], str]:
+    cur.execute(
+        f"""SELECT table_name, column_name, data_type, numeric_precision, numeric_scale
+            FROM {database}.INFORMATION_SCHEMA.COLUMNS
+            WHERE table_schema = '{schema}'"""
+    )
+    out = {}
+    for table, column, dtype, precision, scale in cur.fetchall():
+        if dtype == "NUMBER" and precision is not None:
+            dtype = f"NUMBER({precision},{scale or 0})"
+        out[(table.upper(), column.upper())] = dtype
+    return out
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--spider", default=_DEFAULT_SPIDER)
+    p.add_argument("--database", default="SPIDER")
+    p.add_argument("--connection", default=os.environ.get("SNOWFLAKE_CONNECTION", "bench_key"))
+    p.add_argument("--warehouse", default=os.environ.get("SNOWFLAKE_WAREHOUSE", "BENCH_WH"))
+    args = p.parse_args()
+
+    root = os.path.expanduser(args.spider)
+    keys = load_keys(root)
+    wanted = sorted({c.db_id for c in load_spider(root)})
+
+    con = snowflake.connector.connect(connection_name=args.connection)
+    cur = con.cursor()
+    cur.execute(f"USE WAREHOUSE {args.warehouse}")
+
+    aligned, failed, skipped = 0, [], []
+    try:
+        for db_id in wanted:
+            schema = db_id.upper()
+            foreign = keys.get(db_id, {}).get("foreign", [])
+            if not foreign:
+                continue
+            types = column_types(cur, args.database, schema)
+
+            # Group by child table: one rebuild per table, however many of its columns move.
+            recasts: dict[str, dict[str, str]] = {}
+            for table, column, ref_table, ref_column in foreign:
+                child_key = (table.upper(), column.upper())
+                parent_key = (ref_table.upper(), ref_column.upper())
+                child = types.get(child_key)
+                parent = types.get(parent_key)
+                if not child or not parent or child == parent:
+                    continue
+
+                # An id is a number. When only one side reads as text -- usually because its
+                # table hit the type-violation fallback -- move that side to the numeric type
+                # rather than degrading both to text.
+                child_numeric = child.startswith(("NUMBER", "FLOAT", "INT"))
+                parent_numeric = parent.startswith(("NUMBER", "FLOAT", "INT"))
+                if child_numeric and not parent_numeric:
+                    recasts.setdefault(ref_table.upper(), {})[ref_column.upper()] = child
+                else:
+                    recasts.setdefault(table.upper(), {})[column.upper()] = parent
+
+            for table, columns in recasts.items():
+                cur.execute(
+                    f"""SELECT column_name FROM {args.database}.INFORMATION_SCHEMA.COLUMNS
+                        WHERE table_schema = '{schema}' AND table_name = '{table}'
+                        ORDER BY ordinal_position"""
+                )
+                names = [r[0] for r in cur.fetchall()]
+                # TO_VARCHAR here for the same reason the probe below has it, and it MUST be
+                # the same expression as the probe: a probe that certifies
+                # `TRY_CAST(TO_VARCHAR(x) AS t)` while the rewrite runs `TRY_CAST(x AS t)` has
+                # verified something adjacent to what executes. On a numeric source -- which
+                # reaches here whenever child and parent are both numeric and unequal, say
+                # NUMBER(38,0) against FLOAT -- the probe would pass and the bare TRY_CAST
+                # would then be handed a non-string, which Snowflake does not accept.
+                projection = ", ".join(
+                    f'TRY_CAST(TO_VARCHAR("{n}") AS {columns[n]}) AS "{n}"'
+                    if n in columns else f'"{n}"'
+                    for n in names
+                )
+                # CHECK THE CAST LOSES NOTHING BEFORE OVERWRITING THE TABLE. `TRY_CAST`
+                # returns NULL where it cannot convert, and `CREATE OR REPLACE` then makes
+                # those NULLs the table -- silently, and counted as `aligned`. The population
+                # here is the one the docstring names: tables that hit the type-violation
+                # fallback and read as text hold precisely the values that violate the numeric
+                # type. `infer_keys_spider2` guards the identical rewrite; this did not.
+                #
+                # Fractional values are rejected for the same reason it rejects them: TRY_CAST
+                # rounds 3.5 to 4 rather than failing, so a fractional column converts
+                # "cleanly" while changing every value. An identifier has no fractional part.
+                # TO_VARCHAR around every source, because Snowflake's TRY_CAST takes a STRING
+                # expression and `recasts` can hold a numeric column: NUMBER(38,0) against
+                # FLOAT are both numeric and not equal, so they reach the `else` branch above
+                # and this would ask TRY_CAST to read a number. Rendering to text first is
+                # value-preserving for the question being asked and valid for any source type.
+                #
+                # The whole probe is inside a try. It is a SAFETY check, so it must not be the
+                # thing that stops the run: an unreadable probe means this table cannot be
+                # shown to convert losslessly, which is a reason to leave it alone and say so,
+                # not a reason to abandon the tables after it. The first version of this ran
+                # outside the try below and would have aborted `main()` on any probe error.
+                lossy = []
+                for name, target in columns.items():
+                    try:
+                        cur.execute(
+                            f'SELECT COUNT("{name}"), '
+                            f'COUNT(TRY_CAST(TO_VARCHAR("{name}") AS {target})), '
+                            f'COUNT_IF(TRY_CAST(TO_VARCHAR("{name}") AS FLOAT) IS NOT NULL AND '
+                            f'  TRY_CAST(TO_VARCHAR("{name}") AS FLOAT) '
+                            f'  <> TRUNC(TRY_CAST(TO_VARCHAR("{name}") AS FLOAT))) '
+                            f'FROM {args.database}.{schema}."{table}"'
+                        )
+                        non_null, converted, fractional = cur.fetchone()
+                    except Exception as exc:
+                        lossy.append(f"{name} (probe failed: {str(exc).splitlines()[-1][:50]})")
+                        continue
+                    if non_null != converted:
+                        lossy.append(f"{name} ({non_null - converted} would become NULL)")
+                    elif target.upper().startswith("NUMBER") and fractional:
+                        lossy.append(f"{name} ({fractional} fractional, TRY_CAST would round)")
+                if lossy:
+                    skipped.append(f"{schema}.{table}: {', '.join(lossy)}")
+                    continue
+
+                sql = (
+                    f'CREATE OR REPLACE TABLE {args.database}.{schema}."{table}" AS '
+                    f'SELECT {projection} FROM {args.database}.{schema}."{table}"'
+                )
+                try:
+                    cur.execute(sql)
+                    aligned += len(columns)
+                    print(f"  {schema}.{table}: {', '.join(columns)} -> parent types")
+                except Exception as exc:
+                    failed.append(f"{schema}.{table}: {str(exc).splitlines()[-1][:70]}")
+    finally:
+        cur.close()
+        con.close()
+
+    print(f"\naligned {aligned} columns")
+    for line in failed:
+        print(f"  FAILED {line}")
+    # Reported, not silent: a skipped table keeps its data and loses its relationship, and the
+    # operator has to know which. Left un-aligned is a missing constraint; aligned lossily is
+    # a table of NULLs where values used to be.
+    for line in skipped:
+        print(f"  SKIPPED (cast would lose data) {line}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fix_keys_snowflake.py
+++ b/scripts/fix_keys_snowflake.py
@@ -1,0 +1,148 @@
+"""Rebuild BIRD's primary/foreign keys in Snowflake, correctly, from a clean slate.
+
+The first replay ran before column names were upper-cased and added the FOREIGN KEY before the
+UNIQUE its target needed, so every key pointing at a non-primary column was silently dropped --
+card_games ended with none at all, and Cortex Analyst cannot infer a relationship it was never
+told about.
+
+This drops every existing constraint in the database and re-adds them in dependency order:
+primary keys, then a unique key on any column a foreign key targets, then the foreign keys.
+
+  uv run python scripts/fix_keys_snowflake.py --connection bench_key
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import snowflake.connector
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from add_keys_snowflake import keys_for  # noqa: E402
+from bird_to_parquet import sqlite_dbs  # noqa: E402
+
+_DEFAULT_MINIDEV = os.environ.get(
+    "MNEMIQ_MINIDEV_DIR", os.path.expanduser("~/src/dataset/bird-minidev/minidev/MINIDEV")
+)
+
+
+def drop_existing(cur, database: str, schema: str) -> int:
+    """Remove every table constraint in the schema, so the rebuild is idempotent.
+
+    The schema is quoted. Spider 2.0-lite ids carry hyphens (DB-IMDB, SQLITE-SAKILA) and reach
+    this shared function from the key builders; an unquoted hyphen parses as subtraction, so
+    the ALTER raises into the bare `except` below and the constraints outlive the rebuild.
+
+    PRECONDITION, since a quoted identifier is case-exact where an unquoted one folds to upper:
+    `schema` must arrive spelled as the catalog stores it. Today it always does -- callers
+    either upper-case a db id themselves or read the name back from
+    `INFORMATION_SCHEMA.SCHEMATA`. A future caller passing `card_games` fails at the SELECT
+    below, not at the ALTER: `constraint_schema = '{schema}'` is a plain string comparison
+    against a catalog holding `CARD_GAMES`, so it returns no rows, the loop never runs, and
+    the function reports zero dropped having looked at nothing.
+    """
+    dropped = 0
+    cur.execute(
+        f"""SELECT constraint_name, constraint_type, table_name
+            FROM {database}.INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+            WHERE constraint_schema = '{schema}'"""
+    )
+    # Foreign keys first: a primary or unique key cannot be dropped while one references it.
+    order = {"FOREIGN KEY": 0, "UNIQUE": 1, "PRIMARY KEY": 2}
+    for name, kind, table in sorted(cur.fetchall(), key=lambda r: order.get(r[1], 3)):
+        try:
+            cur.execute(
+                f'ALTER TABLE {database}."{schema}"."{table}" DROP CONSTRAINT "{name}"'
+            )
+            dropped += 1
+        except Exception:
+            pass
+    return dropped
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--minidev", default=_DEFAULT_MINIDEV)
+    p.add_argument("--databases-subdir", default="dev_databases")
+    p.add_argument("--database", default="BENCH")
+    p.add_argument("--connection", default=os.environ.get("SNOWFLAKE_CONNECTION", "bench_key"))
+    p.add_argument("--warehouse", default=os.environ.get("SNOWFLAKE_WAREHOUSE", "BENCH_WH"))
+    p.add_argument("--db", action="append", dest="dbs")
+    args = p.parse_args()
+
+    root = os.path.join(os.path.expanduser(args.minidev), args.databases_subdir)
+    allowed = set(args.dbs) if args.dbs else None
+    databases = [(d, path) for d, path in sqlite_dbs(root) if allowed is None or d in allowed]
+
+    con = snowflake.connector.connect(connection_name=args.connection)
+    cur = con.cursor()
+    cur.execute(f"USE WAREHOUSE {args.warehouse}")
+
+    print(f"{'database':26} {'PK':>4} {'FK want':>8} {'FK got':>7}")
+    total_missing = []
+    try:
+        for db_id, sqlite_path in databases:
+            schema = db_id.upper()
+            primary, foreign = keys_for(sqlite_path)
+            drop_existing(cur, args.database, schema)
+
+            pk_done = 0
+            for table, columns in primary.items():
+                cols = ", ".join(f'"{c.upper()}"' for c in columns)
+                try:
+                    cur.execute(
+                        f'ALTER TABLE {args.database}."{schema}"."{table.upper()}" '
+                        f"ADD PRIMARY KEY ({cols})"
+                    )
+                    pk_done += 1
+                except Exception:
+                    pass
+
+            # Every column a foreign key points at needs a primary or unique key first.
+            targets = {
+                (rt, rc) for _, _, rt, rc in foreign
+                if primary.get(rt, [None])[:1] != [rc]
+            }
+            for ref_table, ref_column in targets:
+                try:
+                    cur.execute(
+                        f'ALTER TABLE {args.database}."{schema}"."{ref_table.upper()}" '
+                        f'ADD UNIQUE ("{ref_column.upper()}")'
+                    )
+                except Exception:
+                    pass
+
+            fk_done, missing = 0, []
+            for table, column, ref_table, ref_column in foreign:
+                try:
+                    cur.execute(
+                        f'ALTER TABLE {args.database}."{schema}"."{table.upper()}" '
+                        f'ADD FOREIGN KEY ("{column.upper()}") '
+                        f'REFERENCES {args.database}."{schema}"."{ref_table.upper()}" '
+                        f'("{ref_column.upper()}")'
+                    )
+                    fk_done += 1
+                except Exception as exc:
+                    missing.append(
+                        f"{schema}: {table}.{column} -> {ref_table}.{ref_column}: "
+                        f"{str(exc).splitlines()[-1][:70]}"
+                    )
+
+            total_missing += missing
+            flag = "" if fk_done == len(foreign) else "  <-- incomplete"
+            print(f"{db_id:26} {pk_done:4} {len(foreign):8} {fk_done:7}{flag}")
+    finally:
+        cur.close()
+        con.close()
+
+    if total_missing:
+        print(f"\n{len(total_missing)} foreign keys still could not be added:")
+        for line in total_missing[:15]:
+            print(f"  {line}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/infer_keys_spider2.py
+++ b/scripts/infer_keys_spider2.py
@@ -1,0 +1,345 @@
+"""Infer join keys for the Spider 2.0-lite schemas that declare none, and apply them.
+
+Twenty of the thirty local Spider 2.0-lite databases ship without a single FOREIGN KEY in
+their SQLite DDL. Cortex Analyst builds a semantic view's relationships from declared
+constraints only, so on those twenty it refuses every multi-table question outright
+("the provided semantic model does not define any relationships between the tables") --
+the answer is a deferral, not a wrong query, and the benchmark measures nothing.
+
+This script recovers the joins the DDL omits:
+
+  1. candidate key = a column named ID / <TABLE>_ID / <TABLE>ID that is unique and non-null
+     in the actual data;
+  2. candidate FK = a column in another table with the same name (or <PARENT>_ID form);
+  3. accept only if every non-null child value exists in the parent -- referential
+     integrity checked against the data, not guessed from the name.
+
+This is an enrichment Snowflake gets and mnemiq does not: mnemiq reads the same FK-less
+DDL and has to infer the joins itself at query time. Runs using it must be reported as a
+separate, Snowflake-favourable condition.
+
+  uv run python scripts/infer_keys_spider2.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from collections import defaultdict
+
+import snowflake.connector
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from fix_keys_snowflake import drop_existing  # noqa: E402
+
+# Types that can plausibly carry a key. Floats and booleans are excluded: a float join key
+# is a coincidence, not a relationship.
+_KEY_TYPES = {"TEXT", "NUMBER", "FIXED"}
+# A nullable integer column arrives from Parquet as FLOAT. It cannot identify rows, but it
+# can still reference them, so it is allowed on the child side and retyped before the key
+# is declared.
+_CHILD_TYPES = _KEY_TYPES | {"FLOAT", "REAL", "DOUBLE"}
+
+
+def fetch_columns(cur, database: str, schema: str) -> dict[str, list[tuple[str, str]]]:
+    cur.execute(
+        f"""SELECT table_name, column_name, data_type
+            FROM {database}.INFORMATION_SCHEMA.COLUMNS
+            WHERE table_schema = %s
+            ORDER BY table_name, ordinal_position""",
+        (schema,),
+    )
+    columns: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for table, column, dtype in cur.fetchall():
+        columns[table].append((column, dtype))
+    return columns
+
+
+def key_shaped(table: str, column: str) -> bool:
+    """Does this column name look like it identifies rows of `table`?"""
+    singular = re.sub(r"(?<=[A-Z])S$", "", table)  # ORDERS -> ORDER
+    return column in {
+        "ID",
+        f"{table}_ID",
+        f"{singular}_ID",
+        f"{table}ID",
+        f"{singular}ID",
+        f"{table}_KEY",
+        f"{singular}_KEY",
+    }
+
+
+def id_shaped(column: str) -> bool:
+    """A name that reads like an identifier, whatever table it sits on."""
+    return bool(re.search(r"(^|_)(ID|KEY|CODE|NO|NUM)(_|$)|ID$", column))
+
+
+def unique_non_null(cur, database: str, schema: str, table: str, column: str) -> bool:
+    cur.execute(
+        f'SELECT COUNT(*), COUNT("{column}"), COUNT(DISTINCT "{column}") '
+        f'FROM {database}."{schema}"."{table}"'
+    )
+    total, non_null, distinct = cur.fetchone()
+    return total > 0 and non_null == total and distinct == total
+
+
+def align_column(cur, database: str, schema: str, table: str, column: str, target: str) -> bool:
+    """Rebuild `table` with `column` cast to `target`, if the cast is lossless.
+
+    SQLite stores integers and their text spellings interchangeably, so one side of a join
+    lands as NUMBER and the other as TEXT. Snowflake refuses a FOREIGN KEY across a type
+    mismatch, and a missing relationship is the difference between an answer and a refusal.
+    The cast is checked for loss first -- a column that does not convert cleanly is left
+    alone and its relationship is simply not declared.
+    """
+    cur.execute(
+        f'SELECT COUNT("{column}"), COUNT(TRY_CAST("{column}" AS {target})), '
+        f'COUNT_IF(TRY_CAST("{column}" AS FLOAT) IS NOT NULL '
+        f'         AND TRY_CAST("{column}" AS FLOAT) <> TRUNC(TRY_CAST("{column}" AS FLOAT))) '
+        f'FROM {database}."{schema}"."{table}"'
+    )
+    non_null, converted, fractional = cur.fetchone()
+    if non_null != converted:
+        return False
+    # TRY_CAST rounds 3.5 to 4 rather than failing, so a fractional column would convert
+    # "cleanly" and silently change its values. An identifier has no fractional part.
+    if target.startswith("NUMBER") and fractional:
+        return False
+
+    cur.execute(
+        f"""SELECT column_name FROM {database}.INFORMATION_SCHEMA.COLUMNS
+            WHERE table_schema = %s AND table_name = %s ORDER BY ordinal_position""",
+        (schema, table),
+    )
+    names = [r[0] for r in cur.fetchall()]
+    projection = ", ".join(
+        f'TRY_CAST("{n}" AS {target}) AS "{n}"' if n == column else f'"{n}"' for n in names
+    )
+    cur.execute(
+        f'CREATE OR REPLACE TABLE {database}."{schema}"."{table}" AS '
+        f'SELECT {projection} FROM {database}."{schema}"."{table}"'
+    )
+    return True
+
+
+def contained(
+    cur,
+    database: str,
+    schema: str,
+    child: tuple[str, str],
+    parent: tuple[str, str],
+    *,
+    max_orphan_rate: float = 0.05,
+) -> bool:
+    """Does the child column reference the parent key, in the data?
+
+    Not a strict subset test. These databases carry real referential noise -- IPL's
+    PLAYER_MATCH names 124 player ids out of 12,495 rows that PLAYER does not contain -- and
+    demanding zero orphans throws away a relationship the schema plainly has. Snowflake does
+    not enforce foreign keys anyway; the constraint is a statement about meaning, which the
+    semantic view reads. A few percent of dangling rows is dirt, a third of them is a
+    coincidence, so the cut is at 5%.
+    """
+    ct, cc = child
+    pt, pc = parent
+    cur.execute(
+        # Both halves must range over the SAME rows. `COUNT(c."cc")` skips NULLs, while a NULL
+        # child makes the correlated predicate NULL, so EXISTS is false and the row counted as
+        # an orphan -- a nullable key with 500 NULLs and 500 present values scored 500/500 = 1.0
+        # and was rejected, though every value it has resolves. Orphans are counted among
+        # non-null children only.
+        f'SELECT COUNT(c."{cc}"), COUNT_IF(c."{cc}" IS NOT NULL AND NOT EXISTS ('
+        f'  SELECT 1 FROM {database}."{schema}"."{pt}" p '
+        f'  WHERE TRIM(CAST(p."{pc}" AS VARCHAR)) = TRIM(CAST(c."{cc}" AS VARCHAR)))) '
+        f'FROM {database}."{schema}"."{ct}" c'
+    )
+    non_null, orphans = cur.fetchone()
+    # A column of all NULLs contains nothing and proves nothing -- reject it.
+    if not non_null:
+        return False
+    return orphans / non_null <= max_orphan_rate
+
+
+def infer(cur, database: str, schema: str) -> tuple[list[tuple[str, str]], list[tuple]]:
+    columns = fetch_columns(cur, database, schema)
+
+    # A column name that appears on more than one table is the shape a shared key has.
+    shared = defaultdict(set)
+    for table, cols in columns.items():
+        for column, _ in cols:
+            shared[column].add(table)
+
+    parents: list[tuple[str, str]] = []
+    for table, cols in columns.items():
+        for column, dtype in cols:
+            if dtype.upper() not in _CHILD_TYPES:
+                continue
+            named_for_table = key_shaped(table, column)
+            shared_id = id_shaped(column) and len(shared[column]) > 1
+            # A column carried by most of the schema's tables is that schema's join key even
+            # when its name says nothing (STACKING keys every table on NAME).
+            widely_shared = len(shared[column]) >= max(3, len(columns) - 1)
+            if not (named_for_table or shared_id or widely_shared):
+                continue
+            # A parent is an entity, not a bridge. DB-IMDB's M_GENRE(INDEX, MID, GID, ID)
+            # holds nothing but keys, and every other M_* table's ids sit inside it, so
+            # taking it as a parent invents relationships between link tables. Require at
+            # least one column carrying an attribute.
+            if not any(c != column and not id_shaped(c) and c != "INDEX" for c, _ in cols):
+                continue
+            try:
+                if unique_non_null(cur, database, schema, table, column):
+                    parents.append((table, column))
+                    break  # one identifying column per table is enough
+            except Exception:
+                continue
+
+    foreign: list[tuple] = []
+    for parent_table, parent_column in parents:
+        for child_table, cols in columns.items():
+            if child_table == parent_table:
+                continue
+            for child_column, dtype in cols:
+                if dtype.upper() not in _CHILD_TYPES:
+                    continue
+                if child_column != parent_column and not key_shaped(parent_table, child_column):
+                    continue
+                if (child_table, child_column) in parents:
+                    continue  # its own identity, not a reference
+                try:
+                    if contained(
+                        cur, database, schema,
+                        (child_table, child_column), (parent_table, parent_column),
+                    ):
+                        foreign.append(
+                            (child_table, child_column, parent_table, parent_column)
+                        )
+                except Exception:
+                    continue
+    return parents, foreign
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--database", default="SPIDER2")
+    p.add_argument("--connection", default=os.environ.get("SNOWFLAKE_CONNECTION", "bench_key"))
+    p.add_argument("--warehouse", default=os.environ.get("SNOWFLAKE_WAREHOUSE", "BENCH_WH"))
+    p.add_argument("--schema", action="append", dest="schemas")
+    p.add_argument(
+        "--only-keyless",
+        action="store_true",
+        default=True,
+        help="skip schemas that already declare a foreign key (the default)",
+    )
+    p.add_argument("--all-schemas", dest="only_keyless", action="store_false")
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+
+    con = snowflake.connector.connect(connection_name=args.connection)
+    cur = con.cursor()
+    cur.execute(f"USE WAREHOUSE {args.warehouse}")
+
+    cur.execute(
+        f"""SELECT schema_name FROM {args.database}.INFORMATION_SCHEMA.SCHEMATA
+            WHERE schema_name NOT IN ('INFORMATION_SCHEMA', 'PUBLIC')
+            ORDER BY schema_name"""
+    )
+    schemas = [r[0] for r in cur.fetchall()]
+    if args.schemas:
+        schemas = [s for s in schemas if s in set(args.schemas)]
+
+    if args.only_keyless:
+        cur.execute(f"SHOW IMPORTED KEYS IN DATABASE {args.database}")
+        names = [d[0] for d in cur.description]
+        index = names.index("fk_schema_name")
+        have = {r[index] for r in cur.fetchall()}
+        schemas = [s for s in schemas if s not in have]
+
+    print(f"{len(schemas)} schemas to infer keys for")
+    print(f"{'schema':30} {'PK':>4} {'FK found':>9} {'FK applied':>11}")
+    total_fk = 0
+    try:
+        for schema in schemas:
+            parents, foreign = infer(cur, args.database, schema)
+            if args.dry_run:
+                print(f"{schema:30} {len(parents):4} {len(foreign):9} {'(dry)':>11}")
+                for row in foreign:
+                    print(f"    {row[0]}.{row[1]} -> {row[2]}.{row[3]}")
+                continue
+
+            # Align the two sides of every mismatched pair before declaring anything: the
+            # rebuild drops constraints, so it has to happen first.
+            types = {
+                (t, c): d.upper()
+                for t, cols in fetch_columns(cur, args.database, schema).items()
+                for c, d in cols
+            }
+            aligned = 0
+            for child_table, child_column, parent_table, parent_column in foreign:
+                child_type = types.get((child_table, child_column))
+                parent_type = types.get((parent_table, parent_column))
+                if child_type == parent_type:
+                    continue
+                # Bring both sides to one type: numeric where the values allow it, text
+                # otherwise. Whichever side already holds the target is left untouched.
+                for target, label in (("NUMBER(38,0)", "NUMBER"), ("VARCHAR", "TEXT")):
+                    sides = [
+                        s for s, t in (
+                            ((child_table, child_column), child_type),
+                            ((parent_table, parent_column), parent_type),
+                        )
+                        if t != label
+                    ]
+                    try:
+                        if all(
+                            align_column(cur, args.database, schema, s[0], s[1], target)
+                            for s in sides
+                        ):
+                            for s in sides:
+                                types[s] = label
+                            aligned += len(sides)
+                            break
+                    except Exception:
+                        continue
+
+            drop_existing(cur, args.database, schema)
+            pk_done = 0
+            for table, column in parents:
+                try:
+                    cur.execute(
+                        f'ALTER TABLE {args.database}."{schema}"."{table}" '
+                        f'ADD PRIMARY KEY ("{column}")'
+                    )
+                    pk_done += 1
+                except Exception:
+                    pass
+
+            fk_done = 0
+            for child_table, child_column, parent_table, parent_column in foreign:
+                try:
+                    cur.execute(
+                        f'ALTER TABLE {args.database}."{schema}"."{child_table}" '
+                        f'ADD FOREIGN KEY ("{child_column}") '
+                        f'REFERENCES {args.database}."{schema}"."{parent_table}" '
+                        f'("{parent_column}")'
+                    )
+                    fk_done += 1
+                except Exception:
+                    pass
+            total_fk += fk_done
+            print(
+                f"{schema:30} {pk_done:4} {len(foreign):9} {fk_done:11}"
+                + (f"   ({aligned} columns retyped)" if aligned else "")
+            )
+    finally:
+        cur.close()
+        con.close()
+
+    print(f"\n{total_fk} inferred foreign keys applied")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/keys_spider2_snowflake.py
+++ b/scripts/keys_spider2_snowflake.py
@@ -1,0 +1,143 @@
+"""Replay Spider 2.0-lite's primary and foreign keys into Snowflake from the SQLite schemas.
+
+Unlike Spider 1.0 there is no tables.json here, so the keys come from SQLite's own pragmas.
+Cortex Analyst infers a semantic view's relationships from declared constraints, and without
+them it refuses every question that needs a join -- the failure mode BIRD hit at 5/5 deferred.
+
+  uv run python scripts/keys_spider2_snowflake.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import sqlite3
+import sys
+
+import snowflake.connector
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from fix_keys_snowflake import drop_existing  # noqa: E402
+
+_DEFAULT_ROOT = os.environ.get(
+    "MNEMIQ_SPIDER2_DIR", os.path.expanduser("~/src/dataset/spider2-lite")
+)
+
+
+def keys_from_sqlite(path: str) -> tuple[dict[str, list[str]], list[tuple]]:
+    con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    try:
+        tables = [
+            name
+            for (name,) in con.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+            if not name.lower().startswith("sqlite_")
+        ]
+        primary: dict[str, list[str]] = {}
+        foreign: list[tuple] = []
+        for table in tables:
+            pk = [r[1] for r in con.execute(f'PRAGMA table_info("{table}")') if r[5]]
+            if pk:
+                primary[table] = pk
+            for fk in con.execute(f'PRAGMA foreign_key_list("{table}")'):
+                ref_table, from_col, to_col = fk[2], fk[3], fk[4]
+                if to_col is None:
+                    target = [
+                        r[1] for r in con.execute(f'PRAGMA table_info("{ref_table}")') if r[5]
+                    ]
+                    if not target:
+                        continue
+                    to_col = target[0]
+                foreign.append((table, from_col, ref_table, to_col))
+    finally:
+        con.close()
+    return primary, foreign
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--root", default=_DEFAULT_ROOT)
+    p.add_argument("--database", default="SPIDER2")
+    p.add_argument("--connection", default=os.environ.get("SNOWFLAKE_CONNECTION", "bench_key"))
+    p.add_argument("--warehouse", default=os.environ.get("SNOWFLAKE_WAREHOUSE", "BENCH_WH"))
+    args = p.parse_args()
+
+    # `databases/`, which is where `spider2_db_path` puts them -- the glob used to sit one
+    # level above that, matched nothing, ran its loop zero times and exited 0. A key-replay
+    # script that silently replays no keys is the failure its own docstring describes, since
+    # Cortex Analyst then refuses every join question and nothing says why.
+    root = os.path.expanduser(args.root)
+    files = sorted(glob.glob(os.path.join(root, "databases", "*.sqlite")))
+    if not files:
+        print(f"no .sqlite under {os.path.join(root, 'databases')} -- nothing to replay",
+              file=sys.stderr)
+        return 2
+    con = snowflake.connector.connect(connection_name=args.connection)
+    cur = con.cursor()
+    cur.execute(f"USE WAREHOUSE {args.warehouse}")
+
+    print(f"{'database':30} {'PK':>4} {'FK want':>8} {'FK got':>7}")
+    shortfall = []
+    try:
+        for path in files:
+            db_id = os.path.basename(path)[:-7]
+            schema = f'"{db_id.upper()}"'
+            primary, foreign = keys_from_sqlite(path)
+            drop_existing(cur, args.database, db_id.upper())
+
+            pk_done = 0
+            for table, columns in primary.items():
+                cols = ", ".join(f'"{c.upper()}"' for c in columns)
+                try:
+                    cur.execute(
+                        f'ALTER TABLE {args.database}.{schema}."{table.upper()}" '
+                        f"ADD PRIMARY KEY ({cols})"
+                    )
+                    pk_done += 1
+                except Exception:
+                    pass
+
+            targets = {
+                (rt, rc) for _, _, rt, rc in foreign
+                if [c.lower() for c in primary.get(rt, [])][:1] != [rc.lower()]
+            }
+            for ref_table, ref_column in targets:
+                try:
+                    cur.execute(
+                        f'ALTER TABLE {args.database}.{schema}."{ref_table.upper()}" '
+                        f'ADD UNIQUE ("{ref_column.upper()}")'
+                    )
+                except Exception:
+                    pass
+
+            fk_done = 0
+            for table, column, ref_table, ref_column in foreign:
+                try:
+                    cur.execute(
+                        f'ALTER TABLE {args.database}.{schema}."{table.upper()}" '
+                        f'ADD FOREIGN KEY ("{column.upper()}") '
+                        f'REFERENCES {args.database}.{schema}."{ref_table.upper()}" '
+                        f'("{ref_column.upper()}")'
+                    )
+                    fk_done += 1
+                except Exception:
+                    pass
+
+            flag = "" if fk_done == len(foreign) else "  <-- incomplete"
+            if fk_done != len(foreign):
+                shortfall.append((db_id, len(foreign) - fk_done))
+            print(f"{db_id:30} {pk_done:4} {len(foreign):8} {fk_done:7}{flag}")
+    finally:
+        cur.close()
+        con.close()
+
+    if shortfall:
+        total = sum(n for _, n in shortfall)
+        print(f"\n{total} foreign keys not applied, across {len(shortfall)} databases")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/keys_spider_snowflake.py
+++ b/scripts/keys_spider_snowflake.py
@@ -1,0 +1,129 @@
+"""Replay Spider's primary and foreign keys into Snowflake from tables.json.
+
+Spider declares its keys in `tables.json` rather than in the SQLite files, as index pairs into
+a global column list. Cortex Analyst infers a semantic view's relationships from declared
+constraints, so without this every join question is unanswerable -- the same failure BIRD hit.
+
+Runs from a clean slate: drop every constraint, then primary keys, then a unique key on any
+column a foreign key targets, then the foreign keys.
+
+  uv run python scripts/keys_spider_snowflake.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import snowflake.connector
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
+
+from fix_keys_snowflake import drop_existing  # noqa: E402
+from mnemiq.eval.spider import load_keys, load_spider  # noqa: E402
+
+_DEFAULT_SPIDER = os.environ.get(
+    "MNEMIQ_SPIDER_DIR", os.path.expanduser("~/src/dataset/spider/spider_data")
+)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--spider", default=_DEFAULT_SPIDER)
+    p.add_argument("--database", default="SPIDER")
+    p.add_argument("--connection", default=os.environ.get("SNOWFLAKE_CONNECTION", "bench_key"))
+    p.add_argument("--warehouse", default=os.environ.get("SNOWFLAKE_WAREHOUSE", "BENCH_WH"))
+    p.add_argument("--split", default="dev")
+    args = p.parse_args()
+
+    root = os.path.expanduser(args.spider)
+    keys = load_keys(root)
+    wanted = sorted({c.db_id for c in load_spider(root, split=args.split)})
+
+    con = snowflake.connector.connect(connection_name=args.connection)
+    cur = con.cursor()
+    cur.execute(f"USE WAREHOUSE {args.warehouse}")
+
+    print(f"{'database':30} {'PK':>4} {'FK want':>8} {'FK got':>7}")
+    missing: list[str] = []
+    # A failed PRIMARY KEY or UNIQUE is the CAUSE of a failed FOREIGN KEY -- Snowflake will not
+    # reference a column that carries neither. Both used to be swallowed whole while the
+    # foreign key they enable reported its own error, so the operator read the symptom and
+    # never the reason. Collected with their messages and printed FIRST, above the failures
+    # they explain.
+    unapplied: list[str] = []
+    try:
+        for db_id in wanted:
+            schema = db_id.upper()
+            spec = keys.get(db_id, {"primary": {}, "foreign": []})
+            primary, foreign = spec["primary"], spec["foreign"]
+            drop_existing(cur, args.database, schema)
+
+            pk_done = 0
+            for table, columns in primary.items():
+                cols = ", ".join(f'"{c.upper()}"' for c in columns)
+                try:
+                    cur.execute(
+                        f'ALTER TABLE {args.database}.{schema}."{table.upper()}" '
+                        f"ADD PRIMARY KEY ({cols})"
+                    )
+                    pk_done += 1
+                except Exception as exc:
+                    unapplied.append(
+                        f"{schema}: PRIMARY KEY {table}({', '.join(columns)}): "
+                        f"{str(exc).splitlines()[-1][:60]}"
+                    )
+
+            targets = {
+                (rt, rc) for _, _, rt, rc in foreign
+                if [c.lower() for c in primary.get(rt, [])][:1] != [rc.lower()]
+            }
+            for ref_table, ref_column in targets:
+                try:
+                    cur.execute(
+                        f'ALTER TABLE {args.database}.{schema}."{ref_table.upper()}" '
+                        f'ADD UNIQUE ("{ref_column.upper()}")'
+                    )
+                except Exception as exc:
+                    unapplied.append(
+                        f"{schema}: UNIQUE {ref_table}.{ref_column}: "
+                        f"{str(exc).splitlines()[-1][:60]}"
+                    )
+
+            fk_done = 0
+            for table, column, ref_table, ref_column in foreign:
+                try:
+                    cur.execute(
+                        f'ALTER TABLE {args.database}.{schema}."{table.upper()}" '
+                        f'ADD FOREIGN KEY ("{column.upper()}") '
+                        f'REFERENCES {args.database}.{schema}."{ref_table.upper()}" '
+                        f'("{ref_column.upper()}")'
+                    )
+                    fk_done += 1
+                except Exception as exc:
+                    missing.append(
+                        f"{schema}: {table}.{column} -> {ref_table}.{ref_column}: "
+                        f"{str(exc).splitlines()[-1][:60]}"
+                    )
+
+            flag = "" if fk_done == len(foreign) else "  <-- incomplete"
+            print(f"{db_id:30} {pk_done:4} {len(foreign):8} {fk_done:7}{flag}")
+    finally:
+        cur.close()
+        con.close()
+
+    if unapplied:
+        print(f"\n{len(unapplied)} keys the foreign keys below depend on could not be added:")
+        for line in unapplied[:12]:
+            print(f"  {line}")
+    if missing:
+        print(f"\n{len(missing)} foreign keys could not be added:")
+        for line in missing[:12]:
+            print(f"  {line}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/load_snowflake.py
+++ b/scripts/load_snowflake.py
@@ -1,0 +1,131 @@
+"""Load the BIRD Parquet export into Snowflake: one schema per db_id, one table per file.
+
+Reads the Parquet tree produced by scripts/bird_to_parquet.py:
+
+    out/<db_id>/<table>.parquet   ->   <database>.<DB_ID>.<TABLE>
+
+Connection comes from ~/.snowflake/config.toml (a named connection) unless overridden by
+SNOWFLAKE_* environment variables. Browser SSO, key-pair, and password all work -- whatever
+the connection is already configured for.
+
+Examples:
+  uv run python scripts/load_snowflake.py --connection bench
+  uv run python scripts/load_snowflake.py --db financial --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import snowflake.connector
+
+
+def parquet_tree(root: str, allowed: set[str] | None) -> list[tuple[str, list[str]]]:
+    """[(db_id, [parquet paths])] for each database directory under `root`."""
+    found: list[tuple[str, list[str]]] = []
+    for db_id in sorted(os.listdir(root)):
+        db_dir = os.path.join(root, db_id)
+        if not os.path.isdir(db_dir) or (allowed is not None and db_id not in allowed):
+            continue
+        files = sorted(f for f in os.listdir(db_dir) if f.endswith(".parquet"))
+        if files:
+            found.append((db_id, [os.path.join(db_dir, f) for f in files]))
+    return found
+
+
+def load_db(cur, database: str, db_id: str, files: list[str], *, dry_run: bool) -> int:
+    # Quote the schema: Spider 2.0-lite has db_ids with hyphens (Db-IMDB, sqlite-sakila)
+    # that are not bare identifiers.
+    schema = f'"{db_id.upper()}"'
+    stage = f"{database}.{schema}.BIRD_STG"
+    fmt = f"{database}.{schema}.PARQUET_FMT"
+
+    def run(sql: str) -> None:
+        if dry_run:
+            print(f"    {sql.strip().splitlines()[0][:110]}")
+            return
+        cur.execute(sql)
+
+    run(f"CREATE SCHEMA IF NOT EXISTS {database}.{schema}")
+    # INFER_SCHEMA takes a *named* file format, not an inline one -- so the format is an object.
+    # REPLACE_INVALID_CHARACTERS: Spider's SQLite carries a few latin-1 byte sequences that
+    # are not valid UTF-8. Without this, COPY aborts the whole table on the first one.
+    run(f"CREATE OR REPLACE FILE FORMAT {fmt} TYPE = PARQUET REPLACE_INVALID_CHARACTERS = TRUE")
+    run(f"CREATE STAGE IF NOT EXISTS {stage} FILE_FORMAT = {fmt}")
+
+    for path in files:
+        table = os.path.splitext(os.path.basename(path))[0].upper()
+        qualified = f"{database}.{schema}.\"{table}\""
+
+        # PUT needs a forward-slashed absolute URI; AUTO_COMPRESS off, Parquet is already compressed.
+        run(f"PUT 'file://{os.path.abspath(path)}' @{stage} OVERWRITE = TRUE AUTO_COMPRESS = FALSE")
+
+        # INFER_SCHEMA reads the column names and types straight out of the Parquet footer,
+        # so the Snowflake table mirrors the SQLite table without a hand-written DDL.
+        run(
+            f"""CREATE OR REPLACE TABLE {qualified} USING TEMPLATE (
+                    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
+                    FROM TABLE(INFER_SCHEMA(
+                        LOCATION => '@{stage}/{os.path.basename(path)}',
+                        FILE_FORMAT => '{fmt}')))"""
+        )
+        run(
+            f"""COPY INTO {qualified}
+                FROM '@{stage}/{os.path.basename(path)}'
+                FILE_FORMAT = {fmt}
+                MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE"""
+        )
+
+    return len(files)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--out", default="out", help="Parquet root from bird_to_parquet.py")
+    p.add_argument("--database", default="BENCH")
+    p.add_argument("--warehouse", default=os.environ.get("SNOWFLAKE_WAREHOUSE", "BENCH_WH"))
+    p.add_argument(
+        "--connection",
+        default=os.environ.get("SNOWFLAKE_CONNECTION", "bench"),
+        help="named connection in ~/.snowflake/config.toml",
+    )
+    p.add_argument("--db", action="append", dest="dbs", help="restrict to these db_ids")
+    p.add_argument("--dry-run", action="store_true", help="print the SQL, connect to nothing")
+    args = p.parse_args()
+
+    if not os.path.isdir(args.out):
+        print(f"no such directory: {args.out} -- run scripts/bird_to_parquet.py first", file=sys.stderr)
+        return 1
+
+    databases = parquet_tree(args.out, set(args.dbs) if args.dbs else None)
+    if not databases:
+        print(f"no Parquet files under {args.out}", file=sys.stderr)
+        return 1
+
+    con = cur = None
+    if not args.dry_run:
+        con = snowflake.connector.connect(connection_name=args.connection)
+        cur = con.cursor()
+        cur.execute(f"USE WAREHOUSE {args.warehouse}")
+        cur.execute(f"CREATE DATABASE IF NOT EXISTS {args.database}")
+
+    total = 0
+    try:
+        for db_id, files in databases:
+            print(f"  {db_id}", flush=True)
+            total += load_db(cur, args.database, db_id, files, dry_run=args.dry_run)
+            print(f"  {db_id:24} {len(files):3} tables loaded", flush=True)
+    finally:
+        if con is not None:
+            cur.close()
+            con.close()
+
+    verb = "would load" if args.dry_run else "loaded"
+    print(f"{verb} {total} tables into {args.database} across {len(databases)} schemas")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/report_warehouse.py
+++ b/scripts/report_warehouse.py
@@ -1,0 +1,159 @@
+"""Turn graded vendor runs into one comparison page against mnemiq's published numbers.
+
+Reads any number of graded JSONL files (from grade_warehouse.py) and emits a single HTML
+report: one row per run, with every bucket the grader writes and both of its metrics.
+
+No per-database or per-difficulty breakdown. An earlier version of this docstring promised
+both, and the only function that could have produced them was defined and never called --
+`grade_warehouse.py` prints the per-database table today.
+
+  uv run python scripts/report_warehouse.py \
+      --run "Snowflake Cortex Analyst=eval-reports/cortex-graded.jsonl" \
+      --out eval-reports/comparison.html
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import html
+import json
+import os
+
+# The mnemiq baseline is PASSED IN, not hardcoded. It used to be
+# `{"exact_match": 40.5, "got_the_facts": 52.2}` sourced in a comment to "the mnemiq README",
+# and neither figure appears in that README or anywhere else in the repo -- so a number nobody
+# could re-derive was rendered into a published comparison page as this engine's own result.
+# Omitted from the page entirely when not supplied, which is the honest default: a comparison
+# with a missing baseline is incomplete, a comparison with an invented one is wrong.
+
+# MUST match what `grade_warehouse.py` writes and counts. It emits a `correct_facts` bucket
+# (right facts, non-identical result set) and puts it in its own denominator; this file left it
+# out of both, so every such row vanished from the counts, the denominator shrank, and the
+# inflated accuracy went into the HTML directly beneath the mnemiq baseline.
+_BUCKETS = ("correct", "correct_facts", "wrong", "deferred", "error", "gold_failed")
+# `gold_failed` is excluded from the denominator -- the gold query itself did not run, so the
+# question was never posed. Every other bucket is a posed question with an answer or a refusal.
+_SCORED = ("correct", "correct_facts", "wrong", "deferred", "error")
+
+
+def load(path: str) -> list[dict]:
+    with open(path) as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+def summarize(rows: list[dict]) -> dict:
+    counts = collections.Counter(r["bucket"] for r in rows)
+    scored = sum(counts[b] for b in _SCORED)
+    facts = counts["correct"] + counts["correct_facts"]
+    return {
+        "counts": counts,
+        "scored": scored,
+        # The same two metrics `grade_warehouse.py` prints, over the same denominator. Reporting
+        # one number called "accuracy" hid which of them it was.
+        "exact_match": 100 * counts["correct"] / scored if scored else 0.0,
+        "got_the_facts": 100 * facts / scored if scored else 0.0,
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--run",
+        action="append",
+        dest="runs",
+        required=True,
+        metavar="LABEL=PATH",
+        help="a graded JSONL, labelled for the report; repeatable",
+    )
+    p.add_argument("--out", default="eval-reports/comparison.html")
+    p.add_argument("--baseline-exact", type=float,
+                   help="mnemiq exact-match %% to show alongside; omitted if unset")
+    p.add_argument("--baseline-facts", type=float,
+                   help="mnemiq got-the-facts %% to show alongside; omitted if unset")
+    p.add_argument("--baseline-n", type=int, help="questions behind those two figures")
+    p.add_argument("--baseline-source", default="",
+                   help="where they came from -- a run id, a report, a commit")
+    args = p.parse_args()
+
+    runs = []
+    for spec in args.runs:
+        label, _, path = spec.partition("=")
+        if not os.path.exists(path):
+            print(f"skipping {label}: no such file {path}")
+            continue
+        rows = load(path)
+        runs.append((label, rows, summarize(rows)))
+
+    if not runs:
+        print("no graded runs found")
+        return 1
+
+    for label, rows, summary in runs:
+        counts = summary["counts"]
+        print(f"\n{label}")
+        print(f"  {'bucket':14}{'n':>6}{'% of scored':>13}")
+        for bucket in _BUCKETS:
+            n = counts[bucket]
+            share = (
+                "excluded"
+                if bucket == "gold_failed"
+                else f"{100 * n / summary['scored']:.1f}%" if summary["scored"] else "-"
+            )
+            print(f"  {bucket:14}{n:6}{share:>13}")
+        print(f"  exact-match   {summary['exact_match']:.1f}%   "
+              f"got-the-facts {summary['got_the_facts']:.1f}%   "
+              f"of {summary['scored']} scored")
+
+    rows_html = "\n".join(
+        f"<tr><td>{html.escape(label)}</td>"
+        f"<td class='num'>{s['counts']['correct']}</td>"
+        f"<td class='num'>{s['counts']['correct_facts']}</td>"
+        f"<td class='num'>{s['counts']['wrong']}</td>"
+        f"<td class='num'>{s['counts']['deferred']}</td>"
+        f"<td class='num'>{s['counts']['error']}</td>"
+        f"<td class='num'>{s['counts']['gold_failed']}</td>"
+        f"<td class='num'>{s['exact_match']:.1f}%</td>"
+        f"<td class='num'><strong>{s['got_the_facts']:.1f}%</strong></td></tr>"
+        for label, _, s in runs
+    )
+
+    # Rendered only when the caller supplies BOTH figures, and it says where they came from.
+    # A baseline is a claim about this engine's own result; if it cannot be attributed it does
+    # not belong on a page that compares vendors to it.
+    if args.baseline_exact is not None and args.baseline_facts is not None:
+        n = f", {args.baseline_n} questions" if args.baseline_n else ""
+        src = f" (source: {html.escape(args.baseline_source)})" if args.baseline_source else ""
+        baseline_html = (
+            f"<p>mnemiq baseline: {args.baseline_exact}% exact-match, "
+            f"{args.baseline_facts}% got-the-facts{n}.{src}</p>"
+        )
+    else:
+        baseline_html = (
+            "<p><em>No mnemiq baseline supplied "
+            "(--baseline-exact / --baseline-facts).</em></p>"
+        )
+
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+    with open(args.out, "w") as fh:
+        fh.write(
+            "<title>Warehouse Bench Results</title>"
+            "<style>body{font-family:system-ui;margin:2rem;max-width:60rem}"
+            "table{border-collapse:collapse;width:100%}"
+            "th,td{border-bottom:1px solid #ddd;padding:.5rem .7rem;text-align:left}"
+            ".num{text-align:right;font-variant-numeric:tabular-nums}</style>"
+            "<h1>BIRD mini-dev — vendor comparison</h1>"
+            + baseline_html +
+            "<table><thead><tr><th>run</th><th class='num'>correct</th>"
+            "<th class='num'>correct facts</th><th class='num'>wrong</th>"
+            "<th class='num'>deferred</th><th class='num'>error</th>"
+            "<th class='num'>gold failed</th><th class='num'>exact-match</th>"
+            "<th class='num'>got-the-facts</th></tr></thead>"
+            f"<tbody>{rows_html}</tbody></table>"
+        )
+    print(f"\nreport -> {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_cortex.py
+++ b/scripts/run_cortex.py
@@ -1,0 +1,245 @@
+"""Ask Snowflake Cortex Analyst every BIRD mini-dev question, one semantic model per db_id.
+
+Cortex Analyst has no batch interface -- this is one REST call per question, authenticated
+with the key-pair JWT. Results are checkpointed to JSONL, so an interrupted run resumes
+without re-paying for the questions already answered.
+
+  uv run python scripts/run_cortex.py --limit 20 --db financial
+  uv run python scripts/run_cortex.py                      # all 500
+
+Each db_id needs its own semantic object. Snowflake is deprecating stage-hosted YAML
+semantic *models* in favour of native semantic *views*, so views are the default here:
+BENCH.<DB_ID>.BIRD_SV. Pass --semantic-model-file to use a YAML model instead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+import tomllib
+
+import requests
+from cryptography.hazmat.primitives import serialization
+from snowflake.connector.auth import AuthByKeyPair
+
+from mnemiq.eval.bird import load_bird
+from mnemiq.eval.spider import load_spider
+from mnemiq.eval.spider2 import load_spider2_local
+from mnemiq.eval.warehouse import VendorResult, append_result, load_results
+
+_DEFAULT_MINIDEV = os.environ.get(
+    "MNEMIQ_MINIDEV_DIR", os.path.expanduser("~/src/dataset/bird-minidev/minidev/MINIDEV")
+)
+
+
+def read_connection(name: str) -> dict:
+    """One named connection out of ~/.snowflake/config.toml."""
+    path = os.path.expanduser("~/.snowflake/config.toml")
+    with open(path, "rb") as fh:
+        config = tomllib.load(fh)
+    try:
+        return config["connections"][name]
+    except KeyError:
+        raise SystemExit(f"no [connections.{name}] in {path}")
+
+
+class CortexClient:
+    """Cortex Analyst REST, with a JWT that is refreshed before it expires."""
+
+    def __init__(self, account: str, user: str, private_key_file: str, *, timeout: int = 120):
+        self.account = account
+        self.user = user
+        self.timeout = timeout
+        # AuthByKeyPair wants a parsed key or DER bytes -- handing it the PEM file's bytes
+        # fails with an ASN.1 parsing error, so deserialize here.
+        with open(os.path.expanduser(private_key_file), "rb") as fh:
+            self._key = serialization.load_pem_private_key(fh.read(), password=None)
+        self.url = f"https://{account}.snowflakecomputing.com/api/v2/cortex/analyst/message"
+        self._token = ""
+        self._token_expires = 0.0
+        self._session = requests.Session()
+
+    def _jwt(self) -> str:
+        # AuthByKeyPair mints a short-lived JWT; regenerate a minute before it lapses so a
+        # long run never fails halfway on an expired token.
+        if time.time() < self._token_expires:
+            return self._token
+        lifetime = 3600
+        auth = AuthByKeyPair(private_key=self._key, lifetime_in_seconds=lifetime)
+        self._token = auth.prepare(account=self.account.split(".")[0], user=self.user)
+        self._token_expires = time.time() + lifetime - 60
+        return self._token
+
+    def ask(self, question: str, semantic: str, *, is_view: bool) -> tuple[dict, int]:
+        # A semantic view is referenced by qualified name; a legacy model by its stage path.
+        target = {"semantic_view": semantic} if is_view else {"semantic_model_file": semantic}
+        started = time.monotonic()
+        response = self._session.post(
+            self.url,
+            headers={
+                "Authorization": f"Bearer {self._jwt()}",
+                "X-Snowflake-Authorization-Token-Type": "KEYPAIR_JWT",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            json={
+                **target,
+                "messages": [
+                    {"role": "user", "content": [{"type": "text", "text": question}]}
+                ],
+            },
+            timeout=self.timeout,
+        )
+        elapsed = int((time.monotonic() - started) * 1000)
+        if response.status_code >= 400:
+            raise RuntimeError(f"HTTP {response.status_code}: {response.text[:400]}")
+        return response.json(), elapsed
+
+
+def extract(payload: dict) -> tuple[str | None, str | None]:
+    """(sql, clarification) out of a Cortex Analyst message.
+
+    A `statement` block is an answer. Text with no statement alongside it is the model saying
+    it cannot answer -- a deferral, which is a different outcome from a wrong query.
+    """
+    blocks = (payload.get("message") or {}).get("content") or []
+    sql = next((b.get("statement") for b in blocks if b.get("type") == "sql"), None)
+    if sql:
+        return sql, None
+    text = " ".join(b.get("text", "") for b in blocks if b.get("type") == "text").strip()
+    return None, text or "empty response"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--minidev", default=_DEFAULT_MINIDEV)
+    p.add_argument(
+        "--benchmark",
+        default="bird",
+        choices=["bird", "spider", "spider2"],
+        help="which question set to ask; spider reads --spider-dir and has no evidence hints, "
+        "spider2 reads --spider2-dir (the 135 local* instances)",
+    )
+    # A DIRECTORY, not the jsonl. `load_spider2_local` appends `repo/spider2-lite/
+    # spider2-lite.jsonl` itself, so passing the file made it open a path UNDER that file and
+    # raise before the first question -- `--benchmark spider2` could never have run. Same
+    # variable and default as `run_spider2.py` and `keys_spider2_snowflake.py`.
+    p.add_argument(
+        "--spider2-dir",
+        default=os.environ.get(
+            "MNEMIQ_SPIDER2_DIR", os.path.expanduser("~/src/dataset/spider2-lite")
+        ),
+    )
+    p.add_argument(
+        "--no-knowledge",
+        action="store_true",
+        help="spider2 only: drop the external_knowledge document the benchmark supplies",
+    )
+    p.add_argument(
+        "--spider-dir",
+        default=os.environ.get(
+            "MNEMIQ_SPIDER_DIR", os.path.expanduser("~/src/dataset/spider/spider_data")
+        ),
+    )
+    p.add_argument("--split", default="dev", help="spider only")
+    p.add_argument("--connection", default=os.environ.get("SNOWFLAKE_CONNECTION", "bench_key"))
+    p.add_argument("--database", default="BENCH")
+    p.add_argument(
+        "--semantic-pattern",
+        default="{database}.{schema}.BIRD_SV",
+        help="semantic object, formatted with database/schema/db_id. Default is a semantic "
+        "view's qualified name; with --semantic-model-file give a stage path instead, "
+        "e.g. @{database}.{schema}.BIRD_STG/{db_id}.yaml",
+    )
+    p.add_argument(
+        "--semantic-model-file",
+        action="store_true",
+        help="treat --semantic-pattern as a legacy stage-hosted YAML model, not a view",
+    )
+    p.add_argument("--limit", type=int)
+    p.add_argument("--db", action="append", dest="dbs")
+    p.add_argument("--difficulty", choices=["simple", "moderate", "challenging"])
+    p.add_argument("--no-evidence", action="store_true", help="drop BIRD's per-question hint")
+    p.add_argument("--results", default="eval-reports/cortex-results.jsonl")
+    p.add_argument("--refresh", action="store_true", help="ignore the checkpoint and re-ask")
+    args = p.parse_args()
+
+    if args.benchmark == "spider2":
+        cases = load_spider2_local(
+            os.path.expanduser(args.spider2_dir),
+            limit=args.limit,
+            db_ids=args.dbs,
+            with_knowledge=not args.no_knowledge,
+        )
+    elif args.benchmark == "spider":
+        cases = load_spider(
+            os.path.expanduser(args.spider_dir),
+            split=args.split,
+            limit=args.limit,
+            db_ids=args.dbs,
+        )
+    else:
+        cases = load_bird(
+            os.path.expanduser(args.minidev),
+            limit=args.limit,
+            db_ids=args.dbs,
+            difficulty=args.difficulty,
+            with_evidence=not args.no_evidence,
+        )
+    done = {} if args.refresh else load_results(args.results)
+    remaining = [c for c in cases if c.id not in done]
+    print(
+        f"{len(cases)} cases, {len(done)} already answered, {len(remaining)} to ask",
+        flush=True,
+    )
+    if not remaining:
+        return 0
+
+    conn = read_connection(args.connection)
+    client = CortexClient(conn["account"], conn["user"], conn["private_key_file"])
+
+    counts = {"sql": 0, "deferred": 0, "error": 0}
+    for index, case in enumerate(remaining, 1):
+        schema = case.db_id.upper()
+        # Spider 2.0-lite has hyphenated db_ids (DB-IMDB, SQLITE-SAKILA); an unquoted
+        # hyphen is a minus sign to the SQL parser, so quote anything not [A-Z0-9_].
+        if not schema.replace("_", "").isalnum():
+            schema = f'"{schema}"'
+        semantic = args.semantic_pattern.format(
+            database=args.database, schema=schema, db_id=case.db_id
+        )
+        result = VendorResult(
+            case_id=case.id,
+            db_id=case.db_id,
+            question=case.question,
+            gold_sql=case.gold_sql,
+            difficulty=(case.tags or [""])[0],
+        )
+        try:
+            payload, elapsed = client.ask(
+                case.question, semantic, is_view=not args.semantic_model_file
+            )
+            result.latency_ms = elapsed
+            result.sql, result.deferral = extract(payload)
+            result.raw = {"request_id": payload.get("request_id")}
+        except Exception as exc:  # network, auth, throttling -- recorded, not fatal
+            result.error = f"{type(exc).__name__}: {exc}"
+
+        counts[result.outcome] += 1
+        append_result(args.results, result)
+        print(
+            f"  [{index:3}/{len(remaining)}] {result.outcome:9} {case.id:14} {case.db_id}",
+            flush=True,
+        )
+
+    print(
+        f"\nasked {len(remaining)}: {counts['sql']} sql, "
+        f"{counts['deferred']} deferred, {counts['error']} error"
+    )
+    print(f"results -> {args.results}")
+    return 1 if counts["error"] == len(remaining) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_cortex_complete.py
+++ b/scripts/run_cortex_complete.py
@@ -1,0 +1,172 @@
+"""Raw-LLM tier: ask SNOWFLAKE.CORTEX.COMPLETE for SQL, with no semantic layer at all.
+
+This is the one-shot baseline. The model gets the schema DDL and the question -- nothing more,
+no curated descriptions, no relationships, no verified queries. It isolates the model from the
+product machinery around it, and is the tier directly comparable to mnemiq's proposer.
+
+  uv run python scripts/run_cortex_complete.py --db financial --limit 20
+  uv run python scripts/run_cortex_complete.py --model claude-4-sonnet
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import time
+
+import snowflake.connector
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
+
+from mnemiq.eval.bird import load_bird  # noqa: E402
+from mnemiq.eval.warehouse import VendorResult, append_result, load_results  # noqa: E402
+
+_DEFAULT_MINIDEV = os.environ.get(
+    "MNEMIQ_MINIDEV_DIR", os.path.expanduser("~/src/dataset/bird-minidev/minidev/MINIDEV")
+)
+
+_PROMPT = """You are a Snowflake SQL expert. Write one SQL query that answers the question.
+
+Schema of database {database}.{schema}:
+{ddl}
+
+Question: {question}
+
+Reply with only the SQL query, no explanation and no markdown fences. Reference tables as \
+{database}.{schema}.TABLE_NAME."""
+
+
+def schema_ddl(cur, database: str, schema: str) -> str:
+    """CREATE TABLE-shaped text for every table in the schema, plus its foreign keys.
+
+    The same structural facts the semantic-layer tier gets -- columns, types, keys -- so the
+    two tiers differ by the product's machinery, not by what they were told about the data.
+    """
+    cur.execute(
+        f"""SELECT table_name, column_name, data_type
+            FROM {database}.INFORMATION_SCHEMA.COLUMNS
+            WHERE table_schema = '{schema}'
+            ORDER BY table_name, ordinal_position"""
+    )
+    tables: dict[str, list[str]] = {}
+    for table, column, dtype in cur.fetchall():
+        tables.setdefault(table, []).append(f"  {column} {dtype}")
+
+    lines = [f"CREATE TABLE {t} (\n" + ",\n".join(cols) + "\n);" for t, cols in tables.items()]
+
+    cur.execute(f"SHOW IMPORTED KEYS IN SCHEMA {database}.{schema}")
+    rows = cur.fetchall()
+    if rows:
+        columns = {desc[0].lower(): i for i, desc in enumerate(cur.description)}
+        seen = set()
+        for row in rows:
+            fk = (
+                row[columns["fk_table_name"]],
+                row[columns["fk_column_name"]],
+                row[columns["pk_table_name"]],
+                row[columns["pk_column_name"]],
+            )
+            if fk in seen:
+                continue
+            seen.add(fk)
+            lines.append(f"-- {fk[0]}.{fk[1]} references {fk[2]}.{fk[3]}")
+    return "\n".join(lines)
+
+
+def extract_sql(text: str) -> str | None:
+    """The model was asked for bare SQL; strip fences anyway and take the statement."""
+    if not text:
+        return None
+    fenced = re.search(r"```(?:sql)?\s*(.+?)```", text, re.S | re.I)
+    body = (fenced.group(1) if fenced else text).strip()
+    if not re.search(r"\bselect\b|\bwith\b", body, re.I):
+        return None
+    return body.rstrip().rstrip(";")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--minidev", default=_DEFAULT_MINIDEV)
+    p.add_argument("--connection", default=os.environ.get("SNOWFLAKE_CONNECTION", "bench_key"))
+    p.add_argument("--database", default="BENCH")
+    p.add_argument("--warehouse", default=os.environ.get("SNOWFLAKE_WAREHOUSE", "BENCH_WH"))
+    p.add_argument("--model", default="claude-4-sonnet")
+    p.add_argument("--limit", type=int)
+    p.add_argument("--db", action="append", dest="dbs")
+    p.add_argument("--no-evidence", action="store_true")
+    p.add_argument("--results", default="eval-reports/cortex-complete-results.jsonl")
+    p.add_argument("--refresh", action="store_true")
+    args = p.parse_args()
+
+    cases = load_bird(
+        os.path.expanduser(args.minidev),
+        limit=args.limit,
+        db_ids=args.dbs,
+        with_evidence=not args.no_evidence,
+    )
+    done = {} if args.refresh else load_results(args.results)
+    remaining = [c for c in cases if c.id not in done]
+    print(f"{len(cases)} cases, {len(done)} answered, {len(remaining)} to ask", flush=True)
+    if not remaining:
+        return 0
+
+    con = snowflake.connector.connect(connection_name=args.connection)
+    cur = con.cursor()
+    cur.execute(f"USE WAREHOUSE {args.warehouse}")
+
+    ddl_cache: dict[str, str] = {}
+    counts = {"sql": 0, "deferred": 0, "error": 0}
+    try:
+        for index, case in enumerate(remaining, 1):
+            schema = case.db_id.upper()
+            if schema not in ddl_cache:
+                ddl_cache[schema] = schema_ddl(cur, args.database, schema)
+
+            prompt = _PROMPT.format(
+                database=args.database,
+                schema=schema,
+                ddl=ddl_cache[schema],
+                question=case.question,
+            )
+            result = VendorResult(
+                case_id=case.id,
+                db_id=case.db_id,
+                question=case.question,
+                gold_sql=case.gold_sql,
+                difficulty=(case.tags or [""])[0],
+            )
+            started = time.monotonic()
+            try:
+                cur.execute(
+                    "SELECT SNOWFLAKE.CORTEX.COMPLETE(%s, %s)", (args.model, prompt)
+                )
+                answer = cur.fetchone()[0]
+                result.latency_ms = int((time.monotonic() - started) * 1000)
+                result.sql = extract_sql(answer)
+                if not result.sql:
+                    result.deferral = (answer or "")[:400]
+            except Exception as exc:
+                result.error = f"{type(exc).__name__}: {exc}"[:400]
+
+            counts[result.outcome] += 1
+            append_result(args.results, result)
+            print(
+                f"  [{index:3}/{len(remaining)}] {result.outcome:9} {case.id:14} {case.db_id}",
+                flush=True,
+            )
+    finally:
+        cur.close()
+        con.close()
+
+    print(
+        f"\nasked {len(remaining)}: {counts['sql']} sql, "
+        f"{counts['deferred']} no-sql, {counts['error']} error"
+    )
+    print(f"results -> {args.results}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/strip_sample_values.py
+++ b/scripts/strip_sample_values.py
@@ -1,0 +1,84 @@
+"""Remove sample values from a semantic view whose own samples break Snowflake's parser.
+
+Autopilot embeds a few real values per column to help Cortex Analyst. When one of those
+values only looks numeric -- F1 lap times are `1:32.713` -- Snowflake's own YAML reader
+rejects the model it wrote, and every question against the view fails with
+
+    Semantic model failed validation with error: Invalid semantic model yaml:
+    Malformed numeric value '1:32.713'
+
+The view is otherwise fine, so this drops the `sample_values (...)` clauses and leaves
+tables, relationships, descriptions and metrics untouched. BIRD hit the same bug on two of
+its eleven databases.
+
+  uv run python scripts/strip_sample_values.py --database SPIDER2 --schema F1
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+
+# A quoted SQL string list: 'plain', 'with '' an escaped quote'.
+#
+# UNROLLED, because the readable form `(?:'(?:[^']|'')*'(?:,\s*)?)*` backtracks exponentially
+# -- GitHub code scanning flags it py/redos, high. It is ambiguous twice over: a run of quotes
+# can split between the inner `''` alternative and the outer star, and two adjacent items with
+# no comma parse either as one escaped string or as two. Measured on
+# `" sample_values ('" + "'" * n`: 0.01 ms at n=14, 0.56 at n=26, 814 at n=46.
+#
+# The unrolled item `'[^']*(?:''[^']*)*'` has exactly one parse, and items are comma-SEPARATED.
+# The trailing group is `(?:\s*,)?\s*` and NOT `\s*,?\s*`: two unbounded `\s*` either side of
+# an optional separator is the same class of split point, quadratic rather than exponential,
+# and the first attempt at this fix had it.
+#
+# `tests/test_strip_sample_values.py` holds what this is verified against, including the two
+# growth curves and the widening below -- the previous version of this comment asserted a
+# verification that lived only in a scratch file.
+_SAMPLES = re.compile(
+    r" sample_values \((?:"
+    r"'[^']*(?:''[^']*)*'"
+    r"(?:\s*,\s*'[^']*(?:''[^']*)*')*"
+    r"(?:\s*,)?\s*"
+    r")?\)"
+)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--database", default="SPIDER2")
+    p.add_argument("--view", default="SPIDER2_SV")
+    p.add_argument("--schema", action="append", dest="schemas", required=True)
+    p.add_argument("--connection", default=os.environ.get("SNOWFLAKE_CONNECTION", "bench_key"))
+    p.add_argument("--warehouse", default=os.environ.get("SNOWFLAKE_WAREHOUSE", "BENCH_WH"))
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+
+    # Imported here, not at module scope: the driver is an optional extra, and the regex above
+    # is the part worth testing. `capture_rows`, `grade_spider2` and `grade_warehouse` defer it
+    # the same way.
+    import snowflake.connector
+
+    con = snowflake.connector.connect(connection_name=args.connection)
+    cur = con.cursor()
+    cur.execute(f"USE WAREHOUSE {args.warehouse}")
+    try:
+        for schema in args.schemas:
+            cur.execute(
+                f"SELECT GET_DDL('SEMANTIC_VIEW', '{args.database}.\"{schema}\".{args.view}')"
+            )
+            ddl = cur.fetchone()[0]
+            stripped, count = _SAMPLES.subn("", ddl)
+            print(f"{schema:30} {count:4} sample_values clauses removed")
+            if count and not args.dry_run:
+                cur.execute(f'USE SCHEMA {args.database}."{schema}"')
+                cur.execute(stripped)
+    finally:
+        cur.close()
+        con.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/uppercase_columns_snowflake.py
+++ b/scripts/uppercase_columns_snowflake.py
@@ -1,0 +1,76 @@
+"""Rename every lower/mixed-case column in BENCH to upper case.
+
+INFER_SCHEMA takes column names verbatim from the Parquet footer, so the loaded tables carry
+SQLite's original casing. Snowflake upper-cases unquoted identifiers, so BIRD's gold SQL
+(`SELECT ... FROM account WHERE account_id = ...`) resolves to ACCOUNT_ID and fails against a
+column actually named "account_id". Renaming to upper case is the Snowflake-native convention
+and makes both the gold and the generated SQL resolve without quoting games.
+
+Renames are metadata-only: no data is rewritten and existing constraints follow the column.
+
+  uv run python scripts/uppercase_columns_snowflake.py --connection bench_key
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import snowflake.connector
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--database", default="BENCH")
+    p.add_argument("--connection", default=os.environ.get("SNOWFLAKE_CONNECTION", "bench_key"))
+    p.add_argument("--warehouse", default=os.environ.get("SNOWFLAKE_WAREHOUSE", "BENCH_WH"))
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+
+    con = snowflake.connector.connect(connection_name=args.connection)
+    cur = con.cursor()
+    cur.execute(f"USE WAREHOUSE {args.warehouse}")
+
+    cur.execute(
+        f"""SELECT table_schema, table_name, column_name
+            FROM {args.database}.INFORMATION_SCHEMA.COLUMNS
+            WHERE table_schema NOT IN ('INFORMATION_SCHEMA', 'PUBLIC')
+              AND column_name <> UPPER(column_name)
+            ORDER BY table_schema, table_name, ordinal_position"""
+    )
+    targets = cur.fetchall()
+    print(f"{len(targets)} columns to rename")
+
+    renamed, clashes = 0, []
+    try:
+        for schema, table, column in targets:
+            sql = (
+                # Quote the schema too: Spider 2.0-lite has hyphenated db_ids.
+                f'ALTER TABLE {args.database}."{schema}"."{table}" '
+                f'RENAME COLUMN "{column}" TO "{column.upper()}"'
+            )
+            if args.dry_run:
+                print(f"  {sql}")
+                continue
+            try:
+                cur.execute(sql)
+                renamed += 1
+            except Exception as exc:
+                # Two columns differing only by case cannot both become the same upper-case
+                # name -- worth reporting rather than silently losing one.
+                clashes.append(f"{schema}.{table}.{column}: {str(exc).splitlines()[-1][:80]}")
+    finally:
+        cur.close()
+        con.close()
+
+    print(f"renamed {renamed} columns")
+    if clashes:
+        print(f"\n{len(clashes)} could not be renamed:")
+        for line in clashes:
+            print(f"  {line}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_snowflake.py
+++ b/scripts/verify_snowflake.py
@@ -1,0 +1,114 @@
+"""Compare row counts in Snowflake against the BIRD SQLite sources, table by table.
+
+A COPY INTO that silently drops or duplicates rows would show up later as unexplained
+accuracy loss, not as an error. This catches it before the benchmark run.
+
+  uv run python scripts/verify_snowflake.py --connection bench_key
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import duckdb
+import snowflake.connector
+
+from bird_to_parquet import _INTERNAL_PREFIXES, sqlite_dbs
+
+_DEFAULT_MINIDEV = os.environ.get(
+    "MNEMIQ_MINIDEV_DIR", os.path.expanduser("~/src/dataset/bird-minidev/minidev/MINIDEV")
+)
+
+
+def sqlite_counts(sqlite_path: str) -> dict[str, int]:
+    con = duckdb.connect()
+    con.execute("INSTALL sqlite; LOAD sqlite;")
+    con.execute(f"ATTACH '{sqlite_path}' AS s (TYPE sqlite, READ_ONLY);")
+    tables = [
+        row[0]
+        for row in con.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_catalog = 's'"
+        ).fetchall()
+        if not row[0].lower().startswith(_INTERNAL_PREFIXES)
+    ]
+    counts = {
+        t.upper(): con.execute(f'SELECT count(*) FROM s.main."{t}"').fetchone()[0] for t in tables
+    }
+    con.close()
+    return counts
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--minidev", default=_DEFAULT_MINIDEV)
+    p.add_argument("--databases-subdir", default="dev_databases")
+    p.add_argument("--database", default="BENCH")
+    p.add_argument("--connection", default=os.environ.get("SNOWFLAKE_CONNECTION", "bench_key"))
+    # The only Snowflake script here that had neither the flag nor a USE, though its own
+    # `SELECT count(*)` needs a warehouse: on a named connection without a default one, every
+    # count raises and the exception leaves this script uncaught.
+    p.add_argument("--warehouse", default=os.environ.get("SNOWFLAKE_WAREHOUSE", "BENCH_WH"))
+    p.add_argument("--db", action="append", dest="dbs")
+    args = p.parse_args()
+
+    root = os.path.join(os.path.expanduser(args.minidev), args.databases_subdir)
+    allowed = set(args.dbs) if args.dbs else None
+    databases = [(d, path) for d, path in sqlite_dbs(root) if allowed is None or d in allowed]
+    if not databases:
+        print(f"no SQLite databases under {root}", file=sys.stderr)
+        return 1
+
+    con = snowflake.connector.connect(connection_name=args.connection)
+    cur = con.cursor()
+    cur.execute(f"USE WAREHOUSE {args.warehouse}")
+
+    mismatches: list[str] = []
+    checked = 0
+    try:
+        for db_id, sqlite_path in databases:
+            schema = db_id.upper()
+            expected = sqlite_counts(sqlite_path)
+
+            actual = {
+                row[0].upper(): None
+                for row in cur.execute(
+                    f"SELECT table_name FROM {args.database}.INFORMATION_SCHEMA.TABLES "
+                    f"WHERE table_schema = '{schema}'"
+                ).fetchall()
+            }
+            for table in actual:
+                actual[table] = cur.execute(
+                    f'SELECT count(*) FROM {args.database}.{schema}."{table}"'
+                ).fetchone()[0]
+
+            for table, want in sorted(expected.items()):
+                checked += 1
+                got = actual.get(table)
+                if got is None:
+                    mismatches.append(f"{schema}.{table}: MISSING in Snowflake (expected {want})")
+                elif got != want:
+                    mismatches.append(f"{schema}.{table}: sqlite {want} != snowflake {got}")
+
+            extra = set(actual) - set(expected)
+            for table in sorted(extra):
+                mismatches.append(f"{schema}.{table}: extra table in Snowflake, not in SQLite")
+
+            print(f"  {db_id:24} {len(expected):3} tables checked", flush=True)
+    finally:
+        cur.close()
+        con.close()
+
+    if mismatches:
+        print(f"\n{len(mismatches)} MISMATCHES:")
+        for line in mismatches:
+            print(f"  {line}")
+        return 1
+
+    print(f"\nall {checked} tables match row-for-row")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_strip_sample_values.py
+++ b/tests/test_strip_sample_values.py
@@ -1,0 +1,85 @@
+"""`strip_sample_values`'s clause regex, which is the whole of what that script decides.
+
+Here rather than in a comment because the comment claiming this verification was the finding:
+it asserted "identical substitutions" for work done in a scratch file that no one could re-run.
+`tests/test_ddl_translate.py` is the convention -- a script's pure part gets a test.
+
+The script defers its `snowflake.connector` import into `main()` so this module imports in CI,
+where the warehouse extra is not installed.
+"""
+
+import time
+
+from scripts.strip_sample_values import _SAMPLES
+
+
+def strip(text: str) -> str:
+    return _SAMPLES.sub("", text)
+
+
+# The pattern's first character is the space before `sample_values`, so it is consumed with the
+# clause -- `"  sample_values (...)"` leaves one space, not two. Asserted rather than trimmed,
+# because that space is the join between the clause and whatever preceded it in the DDL.
+
+
+def test_the_clause_is_removed_and_its_surroundings_are_not():
+    assert strip("  a sample_values ('x', 'y') b") == "  a b"
+    assert strip("  sample_values ('plain')") == " "
+    assert strip("  sample_values ()") == " "
+    assert strip("  no clause here") == "  no clause here"
+
+
+def test_a_value_may_contain_the_characters_that_would_end_the_clause():
+    """The reason this is not `\\(.*?\\)`. A doubled quote is SQL's escape, and a comma or a
+    closing paren inside a value must not terminate anything."""
+    assert strip("  sample_values ('with '' an escaped quote')") == " "
+    assert strip("  sample_values ('has, comma', 'paren ) inside')") == " "
+    assert strip("  sample_values ('multi'', ''escape', 'two')") == " "
+
+
+def test_whitespace_around_the_separators_is_stripped_too():
+    """The WIDENING the unrolled form introduced, asserted so it is a decision and not a
+    surprise. Only the first two are new -- `('a' )` and `('a' , 'b')`, where whitespace sits
+    against the separator -- and both are valid clauses. The last two matched before as well
+    and are here so the widening cannot quietly become a narrowing."""
+    assert strip("  sample_values ('a' )") == " "
+    assert strip("  sample_values ('a' , 'b')") == " "
+    assert strip("  sample_values ('a',   'b')") == " "
+    assert strip("  sample_values ('trailing',)") == " "
+
+
+# Each probe is sized so the pattern it guards against blows PAST the 0.5s bound while the
+# current one finishes in under a millisecond -- measured, because a threshold sitting near
+# the failing case stops catching it on a faster machine. The first draft of the space test
+# used 6,400 spaces, where the quadratic form takes 148 ms and would have sailed through.
+
+
+def test_two_clauses_in_one_statement_are_removed_separately():
+    """Every other case here is one clause alone, which cannot catch the pattern running
+    greedily from the first `sample_values (` to the LAST `)` and eating the columns between
+    them. A real `GET_DDL` has one clause per column, so the two-clause case IS the normal
+    case and the isolated ones are the artificial ones."""
+    assert strip("a sample_values ('x') KEEP sample_values ('y') b") == "a KEEP b"
+    # The paren inside a value is what makes this more than a repetition of the above: a
+    # pattern that stopped at the first `)` would leave `paren') MID sample_values ('z'`.
+    assert strip("c1 sample_values ('has ) paren') MID sample_values ('z') c2") == "c1 MID c2"
+
+
+def test_the_pattern_is_linear_in_a_run_of_quotes():
+    """py/redos. The form this replaced quadrupled every four quotes -- 0.01 ms at 14, 0.56 at
+    26, 814 at 46 -- so 60 is minutes. The current form does 60 in 0.022 ms."""
+    probe = " sample_values ('" + "'" * 60
+    start = time.perf_counter()
+    _SAMPLES.search(probe)
+    assert (time.perf_counter() - start) < 0.5, "exponential backtracking is back"
+
+
+def test_the_pattern_is_linear_in_a_run_of_SPACES():
+    """The second split point, and the one the first fix introduced: `\\s*,?\\s*` is two
+    unbounded `\\s*` either side of an optional comma. Quadratic rather than exponential, so it
+    would never have blocked a merge: 3,068 ms here against 0.5 ms for `(?:\\s*,)?\\s*`, which
+    binds the whitespace to the comma and leaves nothing to split."""
+    probe = " sample_values ('a'" + " " * 25600 + "x"
+    start = time.perf_counter()
+    _SAMPLES.search(probe)
+    assert (time.perf_counter() - start) < 0.5, "the whitespace split point is back"

--- a/uv.lock
+++ b/uv.lock
@@ -787,11 +787,15 @@ server = [
     { name = "uvicorn" },
 ]
 snowflake = [
+    { name = "cryptography" },
+    { name = "requests" },
     { name = "snowflake-connector-python" },
 ]
 warehouse = [
+    { name = "cryptography" },
     { name = "databricks-sdk" },
     { name = "databricks-sql-connector" },
+    { name = "requests" },
     { name = "snowflake-connector-python" },
     { name = "sqlglot" },
 ]
@@ -799,6 +803,8 @@ warehouse = [
 [package.metadata]
 requires-dist = [
     { name = "cachetools", specifier = ">=5" },
+    { name = "cryptography", marker = "extra == 'snowflake'", specifier = ">=42" },
+    { name = "cryptography", marker = "extra == 'warehouse'", specifier = ">=42" },
     { name = "databricks-sdk", marker = "extra == 'databricks'", specifier = ">=0.30" },
     { name = "databricks-sdk", marker = "extra == 'warehouse'", specifier = ">=0.30" },
     { name = "databricks-sql-connector", marker = "extra == 'databricks'", specifier = ">=3" },
@@ -818,6 +824,8 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytz" },
     { name = "rdflib", marker = "extra == 'ontology'", specifier = ">=7" },
+    { name = "requests", marker = "extra == 'snowflake'", specifier = ">=2.31" },
+    { name = "requests", marker = "extra == 'warehouse'", specifier = ">=2.31" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3" },
     { name = "snowflake-connector-python", marker = "extra == 'warehouse'", specifier = ">=3" },


### PR DESCRIPTION
Makes the vendor-comparison methodology reproducible from main: loaders, key replay, semantic-layer builders, Cortex/Genie runners and warehouse graders — previously reachable only at dd9c5c1 on a branch with no common history (upstream rewrite). Restores the three warehouse connector deps the reset dropped. pyproject taken from current main + deps appended (no regression).

Not merged automatically — review + merge is Paulina's call. Until merged, the launch post's 'every script is published' claim points at a branch.