### PR TITLE
repo-guard: make the proprietary-name check local-only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,8 +60,15 @@ MNEMIQ_VERIFY_BASE_URL=  # judge endpoint (defaults to chat)
 MNEMIQ_VERIFY_MODEL=  # judge model (defaults to chat)
 MNEMIQ_VERIFY_API_KEY=  # judge API key (defaults to chat)
 # --- not generated: below this line is hand-written and survives regeneration ---
-# repo-guard's proprietary-name blocklist (regex). Lives only here and in the
-# CI secret of the same name -- never in the repo. scripts/repo-guard.sh reads
-# it from .env when the environment does not set it, so losing this line
-# silently disarms the guard that keeps proprietary names out of a public repo.
-REPO_GUARD_NAME_PATTERNS=
+# repo-guard's proprietary-name blocklist (regex). Lives ONLY here -- never in the
+# repo, and deliberately NOT in a CI secret: the check would leak the list by
+# enforcing it, since a flagged word in a public Actions log tells every reader that
+# word is on the blocklist. `scripts/repo-guard.sh --all` refuses to run it for that
+# reason, so a secret of this name would do nothing but sit there readable by anyone
+# with write access.
+#
+# Two valid values. `off` means this machine holds no list and is not meant to --
+# copy this file as-is and the pre-commit hook skips the check. A maintainer replaces
+# it with the regex. An EMPTY value is neither, and the hook fails closed on it rather
+# than guess which you meant.
+REPO_GUARD_NAME_PATTERNS=off

--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -9,7 +9,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Scan for proprietary names and secrets
-        env:
-          REPO_GUARD_NAME_PATTERNS: ${{ secrets.REPO_GUARD_NAME_PATTERNS }}
+      - name: Scan for secret shapes and machine home paths
+        # Not proprietary names. That check is local-only and `--all` refuses to run it,
+        # so this job needs no repository secret. Supplying one would leak the list by
+        # enforcing it -- a flagged word in a public log tells every reader that word is
+        # on the blocklist -- and a pull request from a fork could not receive it anyway.
         run: bash scripts/repo-guard.sh --all

--- a/README.md
+++ b/README.md
@@ -241,6 +241,28 @@ only lever measured to reduce the wrong-rate, [`MNEMIQ_ROLES` is ignored by the 
 and [lineage reports `unconfirmed-function-identity`](https://github.com/agenticfabriq/mnemiq/issues/5)
 on ordinary queries. Contributions and arguments welcome on all four.
 
+## Contributing
+
+Issues and pull requests are welcome. Fork, branch, and open a PR against `main`.
+
+```
+uv sync --extra dev --extra ontology --extra oracle
+uv run pytest -m "not integration and not live_llm"
+git config core.hooksPath .githooks     # optional: runs the same checks before each commit
+```
+
+**What `repo-guard` checks, and what a green tick means.** It blocks credential shapes and
+hardcoded `/Users/<name>` machine paths — both run in CI on every push and pull request, and both
+are what your PR has to pass. It also blocks a private list of proprietary names, and that one runs
+*only on the maintainer's machine*: enforcing it in CI would publish the list it protects, since a
+flagged word in a public log tells every reader that word is on the blocklist. Your clone has no
+such list and does not need one — you cannot leak names you have never seen.
+
+The hook reads that setting from `.env`, so copy `.env.example` before installing it: the copy
+ships `REPO_GUARD_NAME_PATTERNS=off`, which is how you say *this machine holds no list*, and the
+hook then runs the two checks that matter to you. With no `.env` at all it stops and asks, rather
+than guess whether a missing list means "contributor" or "maintainer whose config broke".
+
 ## Status
 
 v0.1: the full read path — enrichment, retrieval, the decider, execution, trace — evaluated on

--- a/scripts/repo-guard.sh
+++ b/scripts/repo-guard.sh
@@ -1,12 +1,29 @@
 #!/usr/bin/env bash
 # repo-guard: block commits that leak proprietary names, personal identity, or
-# secrets into this public-track repo. Runs as a pre-commit hook (--staged) and
-# in CI (--all).
+# secrets into this repo. Pre-commit hook (--staged) and CI (--all).
 #
-# The proprietary-name blocklist is NOT in this file or this repo: it comes from
-# REPO_GUARD_NAME_PATTERNS -- set in the environment (CI passes a repo secret)
-# or in the gitignored .env. A public guard must not carry what it blocks.
-# Without it the guard fails closed rather than blessing an unchecked commit.
+# THREE CHECKS, TWO AUDIENCES, and the split is deliberate.
+#
+# `secret shapes` and `home paths` carry their patterns in this file, in the open.
+# They need nothing configured, so they run everywhere -- including on a pull request
+# from a fork, which is the only guard a fork can get: GitHub withholds repository
+# secrets from fork-triggered workflows, so anything needing one either passes
+# vacuously or fails on config for exactly the contributors it most needs to check.
+#
+# `proprietary names` is LOCAL ONLY, and the list stays out of CI on purpose. It names
+# an employer, and CI leaks it two ways. A repository secret is readable by anyone with
+# write access, since a workflow step can print it. And the check would announce the
+# list by enforcing it: `BLOCKED [proprietary-name] ... <word>` in a public log tells
+# every reader that word is on the maintainer's blocklist, which is the association the
+# list exists to avoid. The check stops the MAINTAINER committing those names, and it
+# is the maintainer's machine that needs it -- an outside contributor cannot leak a
+# name they have never heard.
+#
+# So the list comes from REPO_GUARD_NAME_PATTERNS (environment, or the gitignored
+# .env), the check fails closed without it under --staged, and --all skips it and says
+# so. Install the hook or the local half never runs:
+#
+#     git config core.hooksPath .githooks
 set -uo pipefail
 
 MODE="${1:---staged}"
@@ -24,13 +41,50 @@ if [ -z "${REPO_GUARD_NAME_PATTERNS:-}" ] && [ -f .env ]; then
   REPO_GUARD_NAME_PATTERNS="$(grep '^REPO_GUARD_NAME_PATTERNS=' .env | head -1 | cut -d= -f2- \
     | sed -e "s/^['\"]//" -e "s/['\"]\$//")"
 fi
-if [ -z "${REPO_GUARD_NAME_PATTERNS:-}" ]; then
+# Whether the name check runs. MODE first, then an EXPLICIT value -- never a guess.
+#
+# Keying it to MODE rather than to the variable being unset is deliberate: an earlier
+# shape skipped names whenever REPO_GUARD_NAME_PATTERNS happened to be empty, and that
+# is a guarantee a repository secret left configured -- or re-added by a later
+# maintainer -- silently revokes.
+#
+# Under --staged the three states are spelled out rather than inferred. A first attempt
+# inferred them from whether `.env` existed, which is wrong in the documented direction:
+# `.env.example` says "Copy to .env", so a contributor who follows the setup has one,
+# and the guard called them a maintainer and rejected every commit they made.
+#
+#   off      the machine has no list and is not meant to have one -- what a contributor
+#            gets by copying .env.example, and what the check skips on
+#   a regex  the maintainer's list; the check runs
+#   empty    neither was chosen. Fail closed: an unset value is the one case that cannot
+#            be told from a maintainer whose config broke, and a commit that skipped the
+#            check is worse than one that is blocked.
+# Normalised before the compare. An exact match would read `OFF` or a trailing space
+# as a REGEX, and since the name grep is case-insensitive that pattern then blocks
+# every file containing "off" -- a silent, baffling false positive on the value a
+# contributor is most likely to type.
+NAMES_SETTING="$(printf '%s' "${REPO_GUARD_NAME_PATTERNS:-}" \
+  | tr '[:upper:]' '[:lower:]' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+CHECK_NAMES=1
+if [ "$MODE" = "--all" ]; then
+  CHECK_NAMES=0
+  echo "repo-guard: proprietary-name check SKIPPED -- it runs locally only, by design."
+  echo "  Secret shapes and home paths are checked below; neither needs configuration."
+elif [ "$NAMES_SETTING" = "off" ]; then
+  CHECK_NAMES=0
+  echo "repo-guard: proprietary-name check off -- no list on this machine."
+  echo "  That list is the maintainer's and is not needed to contribute; secret shapes"
+  echo "  and machine home paths are checked below and are what a pull request must pass."
+elif [ -z "$NAMES_SETTING" ]; then
   echo "repo-guard: BLOCKED [config]: REPO_GUARD_NAME_PATTERNS is not set."
-  echo "Set it in .env (gitignored) or the environment; in CI it comes from a repo secret."
-  echo "The guard fails closed: it will not bless a commit it could not check."
+  echo "Set it in .env (gitignored) or the environment. Two valid values:"
+  echo "  off        you are contributing and hold no list -- the check is skipped"
+  echo "  <regex>    the maintainer's blocklist -- the check runs"
+  echo "The guard fails closed on an empty one: it will not bless a commit it could"
+  echo "not check. Nothing else in your .env needs to change."
   exit 1
 fi
-NAME_PATTERNS="$REPO_GUARD_NAME_PATTERNS"
+NAME_PATTERNS="${REPO_GUARD_NAME_PATTERNS:-}"
 
 # Secret shapes. Never commit these.
 SECRET_PATTERNS='(sk-[A-Za-z0-9]{16,}|AF_SECRET_KEY|AKIA[0-9A-Z]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----|xox[baprs]-[A-Za-z0-9-]{8,})'
@@ -49,8 +103,10 @@ while IFS= read -r f; do
   if printf '%s\n' "$f" | grep -qE "$EXCLUDE_REGEX"; then continue; fi
   [ -f "$f" ] || continue
 
-  if grep -InEi "$NAME_PATTERNS" "$f" >/dev/null 2>&1; then
+  if [ "$CHECK_NAMES" -eq 1 ] && grep -InEi "$NAME_PATTERNS" "$f" >/dev/null 2>&1; then
     echo "BLOCKED [proprietary-name]: $f"
+    # Safe to echo the match: this branch is unreachable under --all, so the text
+    # reaches a terminal on the maintainer's machine and never a public log.
     grep -InEi "$NAME_PATTERNS" "$f" | head -3 || true
     fail=1
   fi
@@ -71,4 +127,8 @@ if [ "$fail" -ne 0 ]; then
   echo "env vars and a gitignored .env)."
   exit 1
 fi
-echo "repo-guard: clean."
+if [ "$CHECK_NAMES" -eq 1 ]; then
+  echo "repo-guard: clean (names, secrets, home paths)."
+else
+  echo "repo-guard: clean (secrets, home paths; names are checked locally)."
+fi

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -336,7 +336,7 @@ def test_the_tracked_env_example_matches_the_renderer():
     silently undid the change. Thirteen other settings were missing too.
 
     Only the generated PREFIX is compared: everything past the marker is hand-written
-    (REPO_GUARD_NAME_PATTERNS is CI configuration, not a Settings field) and regenerating
+    (REPO_GUARD_NAME_PATTERNS is local-only guard configuration, not a Settings field) and regenerating
     blindly deletes it -- which disarms the guard keeping proprietary names out of a
     public repo.
     """
@@ -355,7 +355,12 @@ def test_the_hand_written_tail_survives():
     tracked = (pathlib.Path(__file__).resolve().parents[1] / ".env.example").read_text()
 
     assert HAND_WRITTEN_MARKER in tracked, "the boundary marker is what protects the tail"
-    assert "REPO_GUARD_NAME_PATTERNS=" in tracked
+    # The VALUE is load-bearing, not just the key: `.env.example` says "Copy to .env",
+    # and `off` is what makes that copy work for a contributor. Blank it and the
+    # pre-commit hook fails closed on every commit they make.
+    assert "REPO_GUARD_NAME_PATTERNS=off" in tracked, (
+        "the example must ship `off` -- a copied .env is a contributor's whole setup"
+    )
     assert "REPO_GUARD_NAME_PATTERNS" not in Settings_env_example_fields(), (
         "if it ever becomes a Settings field, delete this test rather than have two sources"
     )


### PR DESCRIPTION
`repo-guard`'s proprietary-name check ran in CI. Now that the repo is public, that is
wrong in two directions at once.

**It leaks the list by enforcing it.** On a match the guard prints the offending
lines, so `BLOCKED [proprietary-name] ... <word>` in a public Actions log tells every
reader that the word is on the maintainer's blocklist — the association the list
exists to avoid. GitHub's secret masking does not help: it masks the *configured
value*, and that value is the whole pattern string, while what gets printed is one
alternative from it.

**And it cannot work on a fork.** GitHub withholds repository secrets from
fork-triggered workflows, and the guard fails closed without its list, so the first
outside contributor would get a red check reading `BLOCKED [config]` about a secret
they cannot have.

`eval-nightly.yml`'s header called this months ago — *"the day it goes public, GitHub
stops exposing secrets to workflows triggered from a fork"* — and is scheduled rather
than per-PR for exactly that reason. `repo-guard` never got the same treatment.

## What changes

| check | where it runs |
|---|---|
| credential shapes | CI + hook — pattern is in the script, needs no config |
| machine home paths | CI + hook — same |
| proprietary names | **hook only**, from a private list |

`--all` refuses the name check regardless of the environment, so a repository secret
left configured — or re-added later — cannot switch the leak back on. **The existing
`REPO_GUARD_NAME_PATTERNS` secret can be deleted from repo settings; it now does
nothing.**

`REPO_GUARD_NAME_PATTERNS` takes three states under `--staged`, spelled out rather
than inferred:

- **`off`** — this machine holds no list. `.env.example` ships it, so a contributor
  who copies the file is set up correctly.
- **a regex** — the maintainer's list; the check runs.
- **empty** — neither was chosen, so it fails closed. An unset value cannot be told
  from a maintainer whose config broke, and a commit that skipped the check is worse
  than one that is blocked.

## Verification

Five paths, each exercised in an isolated repo: contributor clean (passes),
contributor with a credential (still blocked), maintainer with an offending name
(blocked, name shown locally), blank value (fails closed), and CI with the list set
(prints no name). `off` is normalised, so `OFF` and stray whitespace do not fall
through and get read as a regex — which, with a case-insensitive grep, would have
blocked every file containing "off".

Unit suite: 1832 passed.

## Also here

- README gains a **Contributing** section; its setup line is the one CI uses, since
  `uv sync` alone installs no extras and could not have run pytest.
- `.env.example` no longer points maintainers at re-creating the CI secret.
- A test pins the example's `off`, because a copied `.env` is a contributor's whole
  setup.