### PR TITLE
Fix the five lint errors keeping main's CI red

### DIFF
--- a/scripts/capture_rows.py
+++ b/scripts/capture_rows.py
@@ -7,7 +7,10 @@ case_id, db_id, question, sql, columns (ordered, from cursor.description), rows
 No model calls; execution only.
 """
 from __future__ import annotations
-import argparse, json, os, time
+import argparse
+import json
+import os
+import time
 from pathlib import Path
 
 from mnemiq.eval.warehouse import databricks_sql_connection, databricks_workspace, schema_for
@@ -39,7 +42,7 @@ def main() -> None:
     done = set()
     out = Path(args.out)
     if out.exists():  # resume
-        done = {json.loads(l)["case_id"] for l in out.open() if l.strip()}
+        done = {json.loads(line)["case_id"] for line in out.open() if line.strip()}
     n = 0
     with out.open("a") as fh:
         for line in open(args.results):
@@ -69,7 +72,8 @@ def main() -> None:
                     rec["exec_ms"] = int((time.time() - t0) * 1000)
                 except Exception as e:  # capture, don't die
                     rec["error"] = f"capture: {type(e).__name__}: {e}"[:400]
-            fh.write(json.dumps(rec, default=str) + "\n"); fh.flush()
+            fh.write(json.dumps(rec, default=str) + "\n")
+            fh.flush()
             n += 1
             if n % 25 == 0:
                 print(f"captured {n}", flush=True)

--- a/scripts/regrade_engine_runs.py
+++ b/scripts/regrade_engine_runs.py
@@ -18,11 +18,9 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import sys
 
 import pyarrow as pa
 
-from mnemiq.adapters.sqlite import SQLiteAdapter
 from mnemiq.eval.bird import bird_db_path
 from mnemiq.eval.grade import results_match
 from mnemiq.eval.spider import spider_db_path
@@ -107,7 +105,6 @@ def main() -> int:
 
     for path in args.results:
         rows = [json.loads(line) for line in open(path) if line.strip()]
-        adapters: dict[str, SQLiteAdapter] = {}
         counts = {"correct": 0, "correct_facts": 0, "wrong": 0, "other": 0, "ungradable": 0}
         changed = 0
         out = []
@@ -122,10 +119,6 @@ def main() -> int:
                 counts["other"] += 1
                 out.append({**rec, "regraded": was})
                 continue
-
-            if db_id not in adapters:
-                adapters[db_id] = SQLiteAdapter(db_path(root, db_id))
-            adapter = adapters[db_id]
 
             try:
                 gold_rows, gold_names = _run(


### PR DESCRIPTION
`ruff check .` fails on `main` and has since 2026-09-08 — three consecutive red `unit`
jobs. Every PR opened against it inherits that failure for reasons unrelated to the
change under review, which is the state a first outside contributor arrives in.

Four of the five are mechanical:

| file | error |
|---|---|
| `capture_rows.py` | `E401` four imports on one line |
| `capture_rows.py` | `E741` `l` as a comprehension variable — unreadable beside `1` |
| `capture_rows.py` | `E702` a semicolon joining two statements |
| `regrade_engine_runs.py` | `F401` `import sys`, used nowhere |

**The fifth needed more than the fix ruff suggested.** `F841` flagged
`adapter = adapters[db_id]` as an unused binding, and deleting just that line would
have been worse than leaving it alone: the dict it reads is only ever *written*.
`_run()` takes a path and opens its own connection, so nothing anywhere consumes an
adapter. Removing the name alone would have left a block whose whole effect is
constructing one `SQLiteAdapter` per database and holding it — connections opened for
nothing and closed nowhere — while still reading as load-bearing. The dict, the
construction and the now-unused import go together.

`ruff check .` clean, 1832 tests passing.

Split from #6 on purpose: main being red blocks every PR, and a lint fix in files that
branch never touches belongs on its own.