### PR TITLE
Keep the source's error text off the caller-facing paths

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security policy
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security problem.** Use GitHub's private
+advisory form:
+
+**[Report a vulnerability](https://github.com/agenticfabriq/mnemiq/security/advisories/new)**
+
+That opens a channel visible only to you and the maintainers, and it is the route we
+watch. If you cannot use it, open a public issue saying only that you have a security
+report and giving no details — we will open a private channel and come to you.
+
+We aim to acknowledge a report within three working days and to tell you what we intend
+to do about it within ten. If a fix is warranted we will credit you in the release notes
+unless you ask us not to.
+
+## What is in scope
+
+mnemiq sits between a question and a database that has an access policy, so the bugs
+that matter most here are the ones that let a caller reach data the policy denies. In
+rough order of how seriously we take them:
+
+- **An identity reading what its grants exclude** — through retrieval, a generated
+  query, a view, a function, a federated source, or the write path's read side.
+- **Disclosure through a side channel** — an error message, a refusal reason, a trace or
+  audit record, a value-grounding refusal, or a lineage report that names an object the
+  caller was not entitled to know about. A refusal that reveals what it refused is a
+  disclosure.
+- **A statement executing that the decider should have refused** — DDL or DML reaching a
+  read-only deployment, a row filter or column mask not applied, a repair loop producing
+  an approved statement the original would have been refused for.
+- **Credential or configuration exposure** — a DSN, key or wallet path reaching a
+  response, a log, or a published artifact.
+
+Both halves of an access control count. The engine scoping what a model is *shown* and
+the decider re-checking what a query *names* are separate mechanisms, and a bypass of
+either is a finding even when the other happens to catch it.
+
+## What is out of scope
+
+- Findings that require the deployer to have configured something the documentation
+  tells them not to — a superuser or `BYPASSRLS` connection, `MNEMIQ_WRITE_ENABLED` on a
+  source with no policy, or an unset `MNEMIQ_AUTHZ_PATH`. These are deployment
+  preconditions, documented as such, and we would rather hear about places the docs fail
+  to say so.
+- The model generating incorrect SQL. That is an accuracy problem and belongs in a
+  public issue; the engine is designed to refuse rather than trust generated SQL, so a
+  wrong query is only a security finding if it *executed* when it should not have.
+- Denial of service through expensive queries against your own database.
+- Anything in `demo/`, `evals/` or the benchmark harnesses, which are not deployment
+  surface.
+
+## Supported versions
+
+mnemiq is pre-1.0 and moves quickly. Fixes land on `main`; there is no backport branch
+yet. If you depend on a released version and need that to change, say so in your report.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,11 @@ rough order of how seriously we take them:
   read-only deployment, a row filter or column mask not applied, a repair loop producing
   an approved statement the original would have been refused for.
 - **Credential or configuration exposure** — a DSN, key or wallet path reaching a
-  response, a log, or a published artifact.
+  response, a trace or audit record, or a published artifact. The deployment's own server
+  log is the exception, and deliberately so: it is where the engine puts what it withholds
+  from the caller, and it already sits inside the boundary that holds the connection
+  settings. A secret written somewhere it was not configured to go — a key in a trace that
+  ships off-host — is in scope wherever it lands.
 
 Both halves of an access control count. The engine scoping what a model is *shown* and
 the decider re-checking what a query *names* are separate mechanisms, and a bypass of

--- a/src/mnemiq/agent/loop.py
+++ b/src/mnemiq/agent/loop.py
@@ -353,7 +353,12 @@ class Agent:
             return from_ipc(hit)
         try:
             result = run(self.adapter, approved.target_sql, timeout_s=self.timeout_s)
-        except ExecutionError:
+        except ExecutionError as exc:
+            # This candidate drops out of the vote. Logged for the same reason the single-answer
+            # path logs: when three of five candidates are rejected by the source and two
+            # succeed, the answer reports `candidates_executed=2` and the three rejections are
+            # otherwise recorded nowhere -- a source half-refusing looks like a narrower vote.
+            logger.warning("a candidate's execution failed; the source said: %s", exc.repair_text)
             return None
         self.cache.put(key, to_ipc(result.table))
         return result.table

--- a/src/mnemiq/agent/loop.py
+++ b/src/mnemiq/agent/loop.py
@@ -25,7 +25,7 @@ from mnemiq.execute.select import (
     trust,
 )
 from mnemiq.generate.generator import Generator, StrategyGenerator
-from mnemiq.generate.plan_query import Deferred, plan_query
+from mnemiq.generate.plan_query import Deferred, Feedback, plan_query
 from mnemiq.semantic.retrieval import ContextPacket
 from mnemiq.sql.verdict import Approved
 
@@ -245,11 +245,10 @@ class Agent:
         deadline,
         emit: Emit | None = None,
     ) -> AgentAnswer:
-        feedback: str | None = None
-        # Travels with `feedback`: whether it holds the source's words or only ours. `plan_query`
-        # needs it because the model is shown the feedback and its stated reason is forwarded to
-        # the caller, so the two together form a path back out for whatever the source said.
-        feedback_from_source = False
+        # `Feedback` carries its own provenance: whether the SOURCE wrote any of it. `plan_query`
+        # needs that because the model is shown the feedback and its own words reach the caller,
+        # so the two together form a path back out for whatever the source said.
+        feedback: Feedback | None = None
         failure: ExecutionError | None = None
 
         for _attempt in range(self.budget.max_attempts):
@@ -267,7 +266,6 @@ class Agent:
                     dialect=self.dialect,
                     target=self.dialect,
                     feedback=feedback,
-                    feedback_carries_source_words=feedback_from_source,
                     corrector=self.corrector,
                     values=self.values,
                     guard_undefined_terms=self.guard_undefined_terms,
@@ -302,8 +300,7 @@ class Agent:
                 logger.warning("execution attempt %d failed; the source said: %s",
                                _attempt + 1, exc.repair_text)
                 failure = exc
-                feedback = exc.repair_text
-                feedback_from_source = exc.source_detail is not None
+                feedback = Feedback(exc.repair_text, from_source=exc.source_detail is not None)
                 continue
 
             self.cache.put(key, to_ipc(result.table))

--- a/src/mnemiq/agent/loop.py
+++ b/src/mnemiq/agent/loop.py
@@ -292,6 +292,10 @@ class Agent:
             except ExecutionError as exc:
                 # The database is the one authority that cannot be wrong about itself: its
                 # complaint is the cheapest accuracy lever we have. Feed it back and retry.
+                # Every attempt, not just the last: `failure` is overwritten each time round,
+                # so an error that a later attempt repaired would otherwise be recorded nowhere.
+                logger.warning("execution attempt %d failed; the source said: %s",
+                               _attempt + 1, exc.repair_text)
                 failure = exc
                 feedback = exc.repair_text
                 continue
@@ -326,8 +330,8 @@ class Agent:
         #
         # Not by dropping the text, though: `message` is the sentence this engine wrote, and
         # it is often the useful one -- a timeout says to ask something cheaper. Only
-        # `source_detail` is withheld, and it goes to the log, where the schema is already
-        # known and the whole retry can be read.
+        # `source_detail` is withheld, and each attempt logs its own as it happens, so the
+        # log holds the whole retry rather than just whichever error came last.
         logger.warning(
             "every execution attempt failed; last source error: %s",
             failure.repair_text if failure is not None else "(no attempt was made)",

--- a/src/mnemiq/agent/loop.py
+++ b/src/mnemiq/agent/loop.py
@@ -246,6 +246,10 @@ class Agent:
         emit: Emit | None = None,
     ) -> AgentAnswer:
         feedback: str | None = None
+        # Travels with `feedback`: whether it holds the source's words or only ours. `plan_query`
+        # needs it because the model is shown the feedback and its stated reason is forwarded to
+        # the caller, so the two together form a path back out for whatever the source said.
+        feedback_from_source = False
         failure: ExecutionError | None = None
 
         for _attempt in range(self.budget.max_attempts):
@@ -263,6 +267,7 @@ class Agent:
                     dialect=self.dialect,
                     target=self.dialect,
                     feedback=feedback,
+                    feedback_carries_source_words=feedback_from_source,
                     corrector=self.corrector,
                     values=self.values,
                     guard_undefined_terms=self.guard_undefined_terms,
@@ -298,6 +303,7 @@ class Agent:
                                _attempt + 1, exc.repair_text)
                 failure = exc
                 feedback = exc.repair_text
+                feedback_from_source = exc.source_detail is not None
                 continue
 
             self.cache.put(key, to_ipc(result.table))

--- a/src/mnemiq/agent/loop.py
+++ b/src/mnemiq/agent/loop.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 from mnemiq.agent.budget import Budget
@@ -27,6 +28,8 @@ from mnemiq.generate.generator import Generator, StrategyGenerator
 from mnemiq.generate.plan_query import Deferred, plan_query
 from mnemiq.semantic.retrieval import ContextPacket
 from mnemiq.sql.verdict import Approved
+
+logger = logging.getLogger(__name__)
 
 # Cycled across candidates in multi-candidate mode: engineered disagreement, so the
 # selector has something real to select over (uniform resampling measured 56% unanimous).
@@ -243,7 +246,7 @@ class Agent:
         emit: Emit | None = None,
     ) -> AgentAnswer:
         feedback: str | None = None
-        failure: str | None = None
+        failure: ExecutionError | None = None
 
         for _attempt in range(self.budget.max_attempts):
             # Two nested repair loops, answering two different judges. plan_query repairs what the
@@ -289,8 +292,8 @@ class Agent:
             except ExecutionError as exc:
                 # The database is the one authority that cannot be wrong about itself: its
                 # complaint is the cheapest accuracy lever we have. Feed it back and retry.
-                failure = str(exc)
-                feedback = failure
+                failure = exc
+                feedback = exc.repair_text
                 continue
 
             self.cache.put(key, to_ipc(result.table))
@@ -313,10 +316,26 @@ class Agent:
 
         # NOT a deferral. We did not decline to answer -- the source refused to serve us, and
         # counting that as abstention is what let an outage look like the engine working (M6).
+        #
+        # Our half of the failure goes to the caller; the source's half does not. A rejection
+        # in the database's own words is made of the caller's schema -- it names the table and
+        # the column and often quotes the statement -- so an identity denied a table would
+        # learn the table exists by being told why it could not read it -- the side-channel
+        # disclosure SECURITY.md names, and it arrives through the ANSWER, which means
+        # `/v1/ask` carried it as readily as the stream's error frame.
+        #
+        # Not by dropping the text, though: `message` is the sentence this engine wrote, and
+        # it is often the useful one -- a timeout says to ask something cheaper. Only
+        # `source_detail` is withheld, and it goes to the log, where the schema is already
+        # known and the whole retry can be read.
+        logger.warning(
+            "every execution attempt failed; last source error: %s",
+            failure.repair_text if failure is not None else "(no attempt was made)",
+        )
         return AgentAnswer(
             answer=(
                 "Could not answer this question: the database rejected every attempt. "
-                f"Last error: {failure}"
+                + (failure.message if failure is not None else "No attempt was made.")
             ),
             failed=True,
             reason_code=DeferralReason.EXECUTION_FAILED,

--- a/src/mnemiq/execute/runner.py
+++ b/src/mnemiq/execute/runner.py
@@ -9,7 +9,24 @@ DEFAULT_TIMEOUT_S = 30.0
 
 
 class ExecutionError(Exception):
-    """The source refused to run the query. The message is written for the model to repair."""
+    """The source refused to run the query.
+
+    `message` is written for a reader: the model repairs against it and the caller may be
+    shown it, so it holds only words this engine authored. When the source's own exception
+    is what explains the failure, it goes in `source_detail` instead -- that text names the
+    relation and column it refused and can carry a DSN, and the agent forwards the
+    caller-facing half into the answer. Same split as `Refusal`, for the same reason.
+    """
+
+    def __init__(self, message: str, source_detail: str | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.source_detail = source_detail
+
+    @property
+    def repair_text(self) -> str:
+        """What the model repairs against: our sentence, plus the source's own words."""
+        return f"{self.message} {self.source_detail}" if self.source_detail else self.message
 
 
 @dataclass
@@ -23,13 +40,19 @@ def run(adapter, sql: str, timeout_s: float = DEFAULT_TIMEOUT_S) -> ExecutionRes
     started = time.perf_counter()
     try:
         table = adapter.execute_arrow(sql, timeout_s=timeout_s)
+    except ExecutionError:
+        # Already in this form, with its two halves assigned. Re-wrapping would demote a
+        # sentence we wrote into `source_detail` and hide it from the caller -- which the old
+        # `f"...: {exc}"` concatenation obscured, because a nested message still came out
+        # somewhere in the string.
+        raise
     except Exception as exc:
         if "interrupt" in type(exc).__name__.lower() or "interrupt" in str(exc).lower():
             raise ExecutionError(
                 f"The query timed out after {timeout_s}s. Make it cheaper: fewer joins, "
                 "narrower filters, or an aggregate instead of raw rows."
             ) from exc
-        raise ExecutionError(f"The source rejected this query: {exc}") from exc
+        raise ExecutionError("The source rejected this query.", source_detail=str(exc)) from exc
 
     elapsed = (time.perf_counter() - started) * 1000
     return ExecutionResult(table=table, row_count=table.num_rows, elapsed_ms=elapsed)

--- a/src/mnemiq/generate/plan_query.py
+++ b/src/mnemiq/generate/plan_query.py
@@ -29,6 +29,20 @@ Outcome = Approved | Deferred
 CORRECTABLE = frozenset({RefusalCode.LOGIC_LINT, RefusalCode.VALUE_GROUNDING})
 
 
+@dataclass(frozen=True)
+class Feedback:
+    """Text fed back to the model, and whether the SOURCE wrote any of it.
+
+    One value rather than two parameters, and `from_source` has no default, because the unsafe
+    setting is the one a caller reaches by forgetting. A bare string plus an optional bool lets
+    a future caller seed the feedback, omit the flag, and silently reopen the exit this closes --
+    with every existing test still green, because they pin the caller that remembers.
+    """
+
+    text: str
+    from_source: bool
+
+
 def plan_query(
     packet: ContextPacket,
     snapshot: Snapshot,
@@ -38,8 +52,7 @@ def plan_query(
     max_attempts: int = 3,
     dialect: str = "duckdb",
     target: str = "postgres",
-    feedback: str | None = None,
-    feedback_carries_source_words: bool = False,
+    feedback: Feedback | None = None,
     corrector=None,
     values=None,
     guard_undefined_terms: bool = False,
@@ -95,10 +108,10 @@ def plan_query(
     # This tracks the PROVENANCE of the string, not a guess about its content. There is no
     # pattern to match and so no false-positive rate to measure, and it stays correct when a
     # source starts phrasing its errors differently or a DSN turns up in a shape nobody listed.
-    carries_source_words = feedback_carries_source_words
+    carries_source_words = feedback.from_source if feedback else False
 
     for _attempt in range(max_attempts):
-        proposal = generator.propose(packet, feedback)
+        proposal = generator.propose(packet, feedback.text if feedback else None)
 
         # M35, and OFF BY DEFAULT -- withdrawn on its own pre-registered criterion.
         #
@@ -140,11 +153,16 @@ def plan_query(
             else []
         )
         if missing:
+            # `missing` is model-authored too -- the terms come from `proposal.assumed_terms`,
+            # parsed straight out of the reply -- so this exit needs the same check as the
+            # stated-reason one below, and it runs FIRST. A model that echoes its feedback into
+            # the term list rather than into `reason` leaves through here.
+            named = ", ".join(repr(t) for t in missing)
             return Deferred(
                 reason=(
-                    "No certified definition for "
-                    + ", ".join(repr(t) for t in missing)
-                    + ". The data does not say how to compute it, so any answer would be a guess "
+                    (f"No certified definition for {named}. " if not carries_source_words
+                     else "A term in this question has no certified definition. ")
+                    + "The data does not say how to compute it, so any answer would be a guess "
                     "at your business rule rather than a reading of your data."
                 ),
                 code=DeferralReason.UNDEFINED_TERM,
@@ -204,8 +222,8 @@ def plan_query(
             )
 
         last = verdict
-        feedback = verdict.repair_text
         carries_source_words = verdict.source_detail is not None
+        feedback = Feedback(verdict.repair_text, from_source=carries_source_words)
 
     reason = last.message if last else "The query could not be made valid."
     return Deferred(

--- a/src/mnemiq/generate/plan_query.py
+++ b/src/mnemiq/generate/plan_query.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from dataclasses import dataclass, replace
 
 from mnemiq.authz.grants import GrantSet
@@ -12,6 +14,8 @@ from mnemiq.sql.views import inventory_for
 from mnemiq.sql.policy import build_access_policy
 from mnemiq.sql.schema import visible_schema
 from mnemiq.sql.verdict import Approved, Refusal, RefusalCode
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -158,6 +162,9 @@ def plan_query(
             # stated-reason one below, and it runs FIRST. A model that echoes its feedback into
             # the term list rather than into `reason` leaves through here.
             named = ", ".join(repr(t) for t in missing)
+            # Which term is the one fact this deferral exists to carry, so when it cannot be
+            # said to the caller it still has to be said somewhere.
+            logger.warning("undefined terms refused: %s", named)
             return Deferred(
                 reason=(
                     (f"No certified definition for {named}. " if not carries_source_words
@@ -213,10 +220,18 @@ def plan_query(
 
         if verdict.code == RefusalCode.UNAUTHORIZED_TABLE:
             # Do not retry. A guard that can be retried is a puzzle, not a guard.
+            #
+            # `subject` is model-authored: `authz_guard` reads it off the table name in the
+            # model's own SQL, so a model handed the source's words can name a "table" spelled
+            # out of them. Third exit of the same kind, and the naming is what makes this one
+            # worth keeping when it is safe -- a caller told WHICH table it lacks can ask for it.
+            logger.warning("unauthorized table refused: %r", verdict.subject)
             return Deferred(
                 reason=(
                     f"Answering this would require access to {verdict.subject!r}, "
                     "which you do not have."
+                    if not carries_source_words
+                    else "Answering this would require access you do not have."
                 ),
                 code=DeferralReason.AUTHORIZATION,
             )

--- a/src/mnemiq/generate/plan_query.py
+++ b/src/mnemiq/generate/plan_query.py
@@ -39,6 +39,7 @@ def plan_query(
     dialect: str = "duckdb",
     target: str = "postgres",
     feedback: str | None = None,
+    feedback_carries_source_words: bool = False,
     corrector=None,
     values=None,
     guard_undefined_terms: bool = False,
@@ -84,6 +85,17 @@ def plan_query(
                         code=DeferralReason.NO_TABLES)
 
     last: Refusal | None = None
+    # Whether the feedback in hand carries words the SOURCE wrote rather than words this engine
+    # wrote. The model is shown those words on purpose -- a rejection is the repair's whole input
+    # -- but `proposal.reason` is model-authored free text that this function forwards to the
+    # caller verbatim, so a model that quotes its feedback carries the source's words back out.
+    # Measured: a generator answering "the database said: <feedback>" returns a DSN through
+    # `AgentAnswer.answer`.
+    #
+    # This tracks the PROVENANCE of the string, not a guess about its content. There is no
+    # pattern to match and so no false-positive rate to measure, and it stays correct when a
+    # source starts phrasing its errors differently or a DSN turns up in a shape nobody listed.
+    carries_source_words = feedback_carries_source_words
 
     for _attempt in range(max_attempts):
         proposal = generator.propose(packet, feedback)
@@ -139,8 +151,14 @@ def plan_query(
             )
 
         if proposal.sql is None:
+            # The model's own words, EXCEPT when it was shown the source's. Then they are the
+            # one thing it might be repeating, and this is the path they would leave by.
             return Deferred(
-                reason=proposal.reason or "The model could not answer from these tables.",
+                reason=(
+                    "The model could not answer from these tables."
+                    if carries_source_words
+                    else (proposal.reason or "The model could not answer from these tables.")
+                ),
                 code=DeferralReason.UNANSWERABLE,
             )
 
@@ -187,6 +205,7 @@ def plan_query(
 
         last = verdict
         feedback = verdict.repair_text
+        carries_source_words = verdict.source_detail is not None
 
     reason = last.message if last else "The query could not be made valid."
     return Deferred(

--- a/src/mnemiq/generate/plan_query.py
+++ b/src/mnemiq/generate/plan_query.py
@@ -158,7 +158,7 @@ def plan_query(
             # one surgical pass: fix only the flagged problem, then re-decide (which re-runs
             # shape/access/lint/values/EXPLAIN, so a bad edit cannot slip through)
             verdict = decide(
-                corrector.correct(proposal.sql, verdict.message),
+                corrector.correct(proposal.sql, verdict.repair_text),
                 visible,
                 adapter=adapter,
                 dialect=dialect,
@@ -186,7 +186,7 @@ def plan_query(
             )
 
         last = verdict
-        feedback = verdict.message
+        feedback = verdict.repair_text
 
     reason = last.message if last else "The query could not be made valid."
     return Deferred(

--- a/src/mnemiq/runtime.py
+++ b/src/mnemiq/runtime.py
@@ -246,7 +246,13 @@ class Runtime:
         except Exception as exc:  # the read-only attach backstop rejects the write here
             # The decision was evaluated even though the source refused the statement, so the
             # narrowing is a fact about this attempt and travels with it.
-            return WriteResult(approved=False, refusal=f"the source rejected the write: {exc}",
+            #
+            # `refusal` is returned to the MCP caller by `db_write`, so the source's own words
+            # cannot ride in it -- the backstop this fires on is a permission or connection
+            # error, which is precisely the kind that names what it refused. Same split the
+            # read path makes: our sentence to the caller, the source's to the log.
+            logger.warning("the source refused a write; it said: %s", exc)
+            return WriteResult(approved=False, refusal="the source rejected the write",
                                target=verdict.target, plan_sql=verdict.plan_sql,
                                target_sql=verdict.target_sql,
                                narrowed=getattr(verdict, "narrowed", None))

--- a/src/mnemiq/server/app.py
+++ b/src/mnemiq/server/app.py
@@ -12,6 +12,7 @@ from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
+from mnemiq.agent.modes import MODES
 from mnemiq.agent.route import UnknownMode
 from mnemiq.contract import HistoryTurn
 from mnemiq.server.serialize import answer_payload
@@ -76,7 +77,16 @@ def build_app(
                 runtime.ask(body.question, identity, mode=body.mode, history=body.history)
             )
         except UnknownMode as exc:
-            raise HTTPException(status_code=422, detail=str(exc)) from exc
+            # Built from the mode registry, not from `str(exc)`. The text this particular
+            # exception carries happens to be safe -- the caller's own override and a fixed list
+            # -- but "safe because this exception is safe" is the reasoning that puts an error's
+            # words on the wire, and it stops holding the moment the message gains a field or
+            # another exception reaches this handler. Same rule as the stream's error frame:
+            # what the caller is told is composed here, from what this layer already knows.
+            raise HTTPException(
+                status_code=422,
+                detail=f"unknown mode; this deployment offers: {sorted(MODES)}",
+            ) from exc
 
     @app.post("/v1/chat")
     def chat(body: AskBody) -> StreamingResponse:

--- a/src/mnemiq/server/sse.py
+++ b/src/mnemiq/server/sse.py
@@ -15,8 +15,10 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from uuid import uuid4
 
+from mnemiq.agent.route import UnknownMode
 from mnemiq.server.serialize import answer_payload
 
 _DONE = object()
@@ -42,6 +44,28 @@ def step_frame(event: dict) -> dict:
         return {"type": "STEP_STARTED", **common}
     return {"type": "STEP_FINISHED", "durationMs": event.get("ms"), "ok": event.get("ok"),
             **common}
+
+
+logger = logging.getLogger(__name__)
+
+# What a caller may be told when the run fails, keyed by exception TYPE.
+#
+# Every value is a constant. Nothing is interpolated from the exception, because the
+# thing being kept off the wire is its text: `ExecutionError` wraps the source's own
+# error, which on a governed deployment names tables and columns this identity was
+# never shown, quotes the statement, and can carry a DSN fragment. Sending `str(exc)`
+# hands the caller a description of the schema they were refused -- the disclosure the
+# retrieval scoping and `check_access` exist to prevent, arriving through the error
+# path instead of the answer path.
+#
+# The default is deliberately uninformative TO THE CALLER and fully informative to the
+# operator: the traceback is logged against the run id, which the client already has
+# and can quote. An opaque message with a correlation handle costs a support round
+# trip; a leaked one cannot be taken back.
+_CALLER_FACING: dict[type[BaseException], str] = {
+    UnknownMode: "That mode is not one this deployment offers.",
+}
+_OPAQUE = "The engine could not complete this request."
 
 
 async def chat_stream(runtime, identity, question: str, mode: str | None,
@@ -74,7 +98,11 @@ async def chat_stream(runtime, identity, question: str, mode: str | None,
     try:
         ans = fut.result()
     except Exception as exc:  # engine failure -> in-band error, stream ends
-        yield frame({"type": "RUN_ERROR", "message": str(exc), "runId": run_id})
+        # Logged with the traceback and the run id BEFORE anything is yielded, so a
+        # failure is diagnosable even if the client hangs up on the next frame.
+        logger.exception("chat run %s failed", run_id)
+        message = _CALLER_FACING.get(type(exc), _OPAQUE)
+        yield frame({"type": "RUN_ERROR", "message": message, "runId": run_id})
         return
 
     yield frame({"type": "TEXT_MESSAGE_START", "messageId": msg_id, "role": "assistant"})

--- a/src/mnemiq/server/sse.py
+++ b/src/mnemiq/server/sse.py
@@ -60,7 +60,7 @@ logger = logging.getLogger(__name__)
 #
 # Note this is the narrower half. A source rejection never arrives here: `ExecutionError`
 # is caught in the agent loop and turned into a failed `AgentAnswer`, so it leaves through
-# the answer path, which `/v1/ask` shares -- see the fall-through in `Agent._answer`.
+# the answer path, which `/v1/ask` shares -- see the fall-through in `_answer_single`.
 #
 # The default is deliberately uninformative TO THE CALLER and fully informative to the
 # operator: the traceback is logged against the run id, which the client already has

--- a/src/mnemiq/server/sse.py
+++ b/src/mnemiq/server/sse.py
@@ -51,12 +51,16 @@ logger = logging.getLogger(__name__)
 # What a caller may be told when the run fails, keyed by exception TYPE.
 #
 # Every value is a constant. Nothing is interpolated from the exception, because the
-# thing being kept off the wire is its text: `ExecutionError` wraps the source's own
-# error, which on a governed deployment names tables and columns this identity was
-# never shown, quotes the statement, and can carry a DSN fragment. Sending `str(exc)`
-# hands the caller a description of the schema they were refused -- the disclosure the
-# retrieval scoping and `check_access` exist to prevent, arriving through the error
-# path instead of the answer path.
+# thing being kept off the wire is its text. What reaches this handler is whatever the
+# agent did NOT convert to an answer -- a store error from `retrieve` naming the DuckDB
+# path, an authz provider failing open on a file it can name, an embedder or provider
+# transport error carrying an endpoint and its request headers. Those strings are made
+# of deployment configuration, and `str(exc)` puts them in front of whoever asked a
+# question. The engine refusing to answer must not become a way to read the engine.
+#
+# Note this is the narrower half. A source rejection never arrives here: `ExecutionError`
+# is caught in the agent loop and turned into a failed `AgentAnswer`, so it leaves through
+# the answer path, which `/v1/ask` shares -- see the fall-through in `Agent._answer`.
 #
 # The default is deliberately uninformative TO THE CALLER and fully informative to the
 # operator: the traceback is logged against the run id, which the client already has

--- a/src/mnemiq/sql/prove.py
+++ b/src/mnemiq/sql/prove.py
@@ -42,6 +42,7 @@ def prove(adapter: Any, target_sql: str) -> Refusal | None:
     except Exception as exc:
         return Refusal(
             code=RefusalCode.EXPLAIN_FAILED,
-            message=f"The source rejected this query: {exc}",
+            message="The source rejected this query.",
+            source_detail=str(exc),
         )
     return None

--- a/src/mnemiq/sql/prove.py
+++ b/src/mnemiq/sql/prove.py
@@ -20,9 +20,13 @@ offers one; the rest keep the behaviour they already had, unchanged.
 
 from __future__ import annotations
 
+import logging
+
 from typing import Any
 
 from mnemiq.sql.verdict import Refusal, RefusalCode
+
+logger = logging.getLogger(__name__)
 
 
 def prove(adapter: Any, target_sql: str) -> Refusal | None:
@@ -40,6 +44,11 @@ def prove(adapter: Any, target_sql: str) -> Refusal | None:
             # `EXPLAIN` plans without executing on Postgres, DuckDB and SQLite.
             adapter.execute(f"EXPLAIN {target_sql}")
     except Exception as exc:
+        # Logged here rather than where the loop gives up, because a refusal on an attempt that
+        # a later one repairs is exactly the one an operator wants to read, and by then it has
+        # been overwritten. This is the only record of it: `source_detail` is withheld from the
+        # caller, so without this line an EXPLAIN failure would be visible nowhere at all.
+        logger.warning("EXPLAIN refused a plan; the source said: %s", exc)
         return Refusal(
             code=RefusalCode.EXPLAIN_FAILED,
             message="The source rejected this query.",

--- a/src/mnemiq/sql/verdict.py
+++ b/src/mnemiq/sql/verdict.py
@@ -69,10 +69,22 @@ class Refusal:
     code: RefusalCode
     message: str  # written for the model to repair against, not for a log
     subject: str | None = None
+    # The source's own words, when a refusal has any. Deliberately NOT in `message`:
+    # `plan_query` forwards `message` to the caller as a deferral reason, and a source's
+    # exception is made of the caller's schema -- it names the relation and the column it
+    # refused and can carry a DSN. Splitting it out is what lets the repair loop keep the
+    # database's complaint (the cheapest accuracy lever there is) without the wire keeping
+    # it too. The model already holds the schema, so the boundary is the wire, not the prompt.
+    source_detail: str | None = None
 
     @property
     def repairable(self) -> bool:
         return self.code in REPAIRABLE
+
+    @property
+    def repair_text(self) -> str:
+        """What the model repairs against: our refusal, plus the source's own words."""
+        return f"{self.message} {self.source_detail}" if self.source_detail else self.message
 
 
 @dataclass

--- a/src/mnemiq/sql/verdict.py
+++ b/src/mnemiq/sql/verdict.py
@@ -78,10 +78,16 @@ class Refusal:
     #
     # The prompt is NOT a safe destination, and this field does not pretend otherwise:
     # retrieval scoping means the model may never have been shown the object a rejection
-    # names, and a DSN is not schema at all. What makes the split hold is that `plan_query`
-    # treats every model-authored string as unforwardable on a turn it fed source words into
-    # -- see `Feedback`, which carries that provenance and has no default for it. Withholding
-    # here is one half; the other is refusing to let the model hand it back.
+    # names, and a DSN is not schema at all. So `plan_query` withholds its model-authored
+    # DEFERRAL text on a turn it fed source words into -- the stated reason, the declared
+    # terms, the unauthorized subject -- keyed off `Feedback`, which carries that provenance
+    # and has no default for it. Withholding here is one half; the other is refusing to let
+    # the model hand it back.
+    #
+    # Bounded claim, deliberately. The approved SQL is model-authored too and ships to the
+    # caller as `trace.target_sql`, so a model can still launder text through a string
+    # literal. Suppressing that would cost the transparency the SQL surface exists for, and
+    # a partial-containment check is a guard with a false-positive rate nobody has measured.
     source_detail: str | None = None
 
     @property

--- a/src/mnemiq/sql/verdict.py
+++ b/src/mnemiq/sql/verdict.py
@@ -76,14 +76,12 @@ class Refusal:
     # database's complaint (the cheapest accuracy lever there is) without the wire keeping
     # it too.
     #
-    # This narrows the channel rather than closing it. The prompt is not a safe destination
-    # either: retrieval scoping means the model may never have been shown the object a
-    # rejection names, and a DSN is not schema at all -- and because a model's stated reason
-    # for producing no SQL is forwarded to the caller verbatim, a model that quotes its
-    # feedback puts the text back on the wire. Measured, not assumed: a generator that
-    # answers "the database said: <feedback>" returns the DSN through `Deferred.reason`.
-    # Withholding it from the caller's direct path is worth doing on its own; treating the
-    # prompt as private is the part that does not hold.
+    # The prompt is NOT a safe destination, and this field does not pretend otherwise:
+    # retrieval scoping means the model may never have been shown the object a rejection
+    # names, and a DSN is not schema at all. What makes the split hold is that `plan_query`
+    # treats every model-authored string as unforwardable on a turn it fed source words into
+    # -- see `Feedback`, which carries that provenance and has no default for it. Withholding
+    # here is one half; the other is refusing to let the model hand it back.
     source_detail: str | None = None
 
     @property

--- a/src/mnemiq/sql/verdict.py
+++ b/src/mnemiq/sql/verdict.py
@@ -74,7 +74,16 @@ class Refusal:
     # exception is made of the caller's schema -- it names the relation and the column it
     # refused and can carry a DSN. Splitting it out is what lets the repair loop keep the
     # database's complaint (the cheapest accuracy lever there is) without the wire keeping
-    # it too. The model already holds the schema, so the boundary is the wire, not the prompt.
+    # it too.
+    #
+    # This narrows the channel rather than closing it. The prompt is not a safe destination
+    # either: retrieval scoping means the model may never have been shown the object a
+    # rejection names, and a DSN is not schema at all -- and because a model's stated reason
+    # for producing no SQL is forwarded to the caller verbatim, a model that quotes its
+    # feedback puts the text back on the wire. Measured, not assumed: a generator that
+    # answers "the database said: <feedback>" returns the DSN through `Deferred.reason`.
+    # Withholding it from the caller's direct path is worth doing on its own; treating the
+    # prompt as private is the part that does not hold.
     source_detail: str | None = None
 
     @property

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,3 +1,5 @@
+import logging
+
 import pyarrow as pa
 
 from mnemiq.agent.budget import Budget
@@ -239,6 +241,38 @@ def test_plurality_result_wins_and_agreement_is_reported():
     assert ans.agreement == 0.6  # 3 of 5
     assert "3/5" in ans.answer
     assert "There are 7." in ans.answer
+
+
+def test_a_candidate_the_source_refuses_is_dropped_loudly_not_silently(caplog):
+    """`_execute` drops a rejected candidate with `return None`, and the vote just gets smaller.
+
+    With 3 of 5 refused and 2 surviving, the answer reports `candidates_executed=2` and reads
+    exactly like a narrower vote the engine chose. Self-consistency then decides on a sample
+    the SOURCE truncated. The log is the only thing that tells those apart, so it is the log
+    this pins -- and it must carry the source's words, since our half is the same sentence for
+    every refusal (M95).
+    """
+    leaky = 'permission denied for table hr_prod.payroll_salary'
+
+    class _RefusesSum(_VotingAdapter):
+        def execute_arrow(self, sql, timeout_s=None):
+            if "SUM" in sql.upper():
+                raise ExecutionError("The source rejected this query.", source_detail=leaky)
+            return super().execute_arrow(sql, timeout_s=timeout_s)
+
+    agent = Agent(
+        generator=FakeGenerator([_sql("count(*)"), _sql("count(*)"), _sql("sum(n)")]),
+        synthesizer=FakeSynthesizer("There are 7."),
+        adapter=_RefusesSum(), cache=TwoTierCache(L1Cache()), candidates=3,
+    )
+    with caplog.at_level(logging.WARNING, logger="mnemiq.agent.loop"):
+        ans = _answer(agent)
+
+    assert not ans.deferred
+    dropped = [r.getMessage() for r in caplog.records
+               if r.getMessage().startswith("a candidate's execution failed")]
+    assert len(dropped) == 1, dropped
+    assert leaky in dropped[0], "our sentence alone cannot tell one refusal from another"
 
 
 def test_a_tie_breaks_to_the_earliest_cluster():

--- a/tests/test_deferral_reasons.py
+++ b/tests/test_deferral_reasons.py
@@ -171,8 +171,12 @@ def test_the_source_error_is_still_fed_back_to_the_planner():
     """Withholding it from the caller must not withhold it from the repair loop.
 
     The database's complaint is the retry's whole input -- it is what a second attempt is
-    corrected *by*. The model already holds the schema this text is made of, so the boundary
-    that matters is the wire, not the prompt.
+    corrected *by*, so withholding it from the caller must not withhold it from the planner.
+
+    That is the whole claim here. The prompt is NOT a safe destination -- the model may never
+    have been shown the object a rejection names, and it can quote its feedback back into an
+    answer -- which is why this asserts the repair loop still works rather than that feeding
+    the model is harmless. See the residual recorded at `Refusal.source_detail`.
     """
     # Both plans are ones the decider ACCEPTS, so the only feedback that can appear is the
     # source's. A plan the decider rejects would be repaired inside `plan_query` against its

--- a/tests/test_deferral_reasons.py
+++ b/tests/test_deferral_reasons.py
@@ -27,15 +27,16 @@ _RESULT = pa.table({"n": [7]})
 
 
 class _FakeAdapter:
-    def __init__(self, errors: int = 0):
+    def __init__(self, errors: int = 0, message: str = 'column "typo" does not exist'):
         self.errors = errors
+        self.message = message
         self.queries: list[str] = []
 
     def execute_arrow(self, sql, timeout_s=None):
         self.queries.append(sql)
         if self.errors > 0:
             self.errors -= 1
-            raise Exception('column "typo" does not exist')
+            raise Exception(self.message)
         return _RESULT
 
     def execute(self, sql):
@@ -137,6 +138,52 @@ def test_a_database_that_rejects_every_attempt_is_a_failure_not_a_deferral():
         "counting a source outage as a deferral is what let an outage look like abstention"
     )
     assert result.reason_code == DeferralReason.EXECUTION_FAILED
+
+
+def test_the_sources_own_error_text_does_not_reach_the_caller():
+    """The answer used to carry `Last error: {failure}` -- the database's verbatim complaint.
+
+    A source rejection is made of the caller's schema. Postgres names the relation and the
+    column it refused, and a connection failure names the host and the user. An identity
+    denied a table would therefore learn the table exists by being told why it could not
+    read it, which is the first disclosure class SECURITY.md claims is in scope. It reaches
+    `AgentAnswer.answer`, so `/v1/ask` carried it too, not only the stream's error frame.
+    """
+    leaky = (
+        'permission denied for table hr_prod.payroll_salary; '
+        'connection postgresql://svc_mnemiq@10.2.0.7:5432/hr_prod'
+    )
+    adapter = _FakeAdapter(errors=99, message=leaky)
+    agent = _agent(['{"sql": "SELECT n FROM claim"}'] * 9, adapter=adapter,
+                   budget=Budget(max_attempts=2))
+
+    result = agent.answer(_packet(), _snapshot(), _GRANTS, _IDENTITY)
+
+    for secret in ("payroll_salary", "hr_prod", "svc_mnemiq", "10.2.0.7", "postgresql://",
+                   "permission denied"):
+        assert secret not in result.answer, f"the answer disclosed {secret!r}"
+    # The state still has to be legible, or hiding the cause would have cost the caller M6.
+    assert result.failed is True
+    assert result.reason_code == DeferralReason.EXECUTION_FAILED
+
+
+def test_the_source_error_is_still_fed_back_to_the_planner():
+    """Withholding it from the caller must not withhold it from the repair loop.
+
+    The database's complaint is the retry's whole input -- it is what a second attempt is
+    corrected *by*. The model already holds the schema this text is made of, so the boundary
+    that matters is the wire, not the prompt.
+    """
+    adapter = _FakeAdapter(errors=1, message='column "typo" does not exist')
+    agent = _agent(['{"sql": "SELECT typo FROM claim"}', '{"sql": "SELECT n FROM claim"}'],
+                   adapter=adapter, budget=Budget(max_attempts=2))
+
+    result = agent.answer(_packet(), _snapshot(), _GRANTS, _IDENTITY)
+
+    assert result.failed is False
+    assert any("typo" in (feedback or "") for feedback in agent.generator.calls[1:]), (
+        "the second attempt was planned without being told what the first one got wrong"
+    )
 
 
 def test_an_outage_cannot_raise_the_deferral_rate():

--- a/tests/test_deferral_reasons.py
+++ b/tests/test_deferral_reasons.py
@@ -176,6 +176,11 @@ def test_the_sources_own_error_text_does_not_reach_the_caller(caplog):
                    if r.getMessage().startswith("execution attempt")]
     assert len(per_attempt) == 2, per_attempt  # the closing summary opens with "every"
     assert all(leaky in m for m in per_attempt)
+    # And the summary itself, which the filter above excludes by construction. It is a separate
+    # line carrying the same words, so it needs its own assertion or it is pinned by nothing.
+    summary = [r.getMessage() for r in caplog.records if r.getMessage().startswith("every")]
+    assert len(summary) == 1, summary
+    assert leaky in summary[0]
 
 
 def test_the_source_error_is_still_fed_back_to_the_planner():

--- a/tests/test_deferral_reasons.py
+++ b/tests/test_deferral_reasons.py
@@ -18,7 +18,7 @@ from mnemiq.agent.synthesize import FakeSynthesizer
 from mnemiq.authz.grants import EMPTY, FileAuthzProvider, GrantSet
 from mnemiq.cache.store import L1Cache, TwoTierCache
 from mnemiq.contract import Column, IdentityContext, Snapshot
-from mnemiq.generate.generator import FakeGenerator
+from mnemiq.generate.generator import FakeGenerator, SqlProposal
 from mnemiq.observability.metrics import AnswerRecord, aggregate
 from mnemiq.semantic.retrieval import ContextPacket, RetrievedCard
 
@@ -243,3 +243,69 @@ def test_deferral_rate_is_computed_over_answers_that_were_actually_decided():
     assert metrics.errors == 1
     assert metrics.deferrals == 1
     assert metrics.deferral_rate == 0.5, "1 deferral out of the 2 requests we actually decided"
+
+
+# --------------------------------------------------------------------------------------------
+# M94 -- the model is shown the source's words, and its own words reach the caller
+# --------------------------------------------------------------------------------------------
+
+
+class _QuotesItsFeedback:
+    """A model that explains itself by repeating what it was told. Not a strawman: 'say why you
+    could not' is ordinary prompting, and the feedback is the most relevant thing in context."""
+
+    def __init__(self):
+        self.calls: list[str | None] = []
+
+    def propose(self, packet, feedback=None, strategy=None):
+        self.calls.append(feedback)
+        if feedback is None:
+            return SqlProposal(sql="SELECT n FROM claim")
+        return SqlProposal(sql=None, reason=f"I could not: the database said: {feedback}")
+
+
+def _quoting_agent(adapter, budget=None):
+    return Agent(generator=_QuotesItsFeedback(), synthesizer=FakeSynthesizer("There are 7."),
+                 adapter=adapter, cache=TwoTierCache(L1Cache()), budget=budget or Budget())
+
+
+def test_a_model_that_quotes_its_feedback_cannot_carry_the_source_out():
+    """The withheld half reaches the model on purpose; the model's own words reach the caller.
+
+    Those two facts compose into a path back out, and no amount of care at the direct sites
+    closes it. Withholding from the prompt is not the answer either -- a rejection is the whole
+    input a retry is corrected by. What breaks the chain is knowing we put source words in this
+    prompt, which is a fact about provenance and not a guess about the text.
+    """
+    leaky = ('permission denied for table hr_prod.payroll_salary; '
+             'connection postgresql://svc_mnemiq@10.2.0.7:5432/hr_prod')
+    agent = _quoting_agent(_FakeAdapter(errors=99, message=leaky), Budget(max_attempts=2))
+
+    result = agent.answer(_packet(), _snapshot(), _GRANTS, _IDENTITY)
+
+    for secret in ("payroll_salary", "hr_prod", "svc_mnemiq", "10.2.0.7", "postgresql://"):
+        assert secret not in result.answer, f"the model carried {secret!r} back to the caller"
+    # The repair loop must not have been paid for with the fix.
+    assert any(leaky in (c or "") for c in agent.generator.calls), (
+        "closing the exit by starving the model is the wrong fix -- the words are the repair's input"
+    )
+
+
+def test_a_model_that_was_told_nothing_by_the_source_still_speaks_for_itself():
+    """The narrowing must be exactly as wide as the risk.
+
+    A model's stated reason is genuinely useful -- "there is no date column on these tables" is
+    the difference between a caller rephrasing and a caller giving up. It is suppressed only on
+    the turn where the source's words were in the prompt, so a first-attempt refusal, which no
+    source has spoken into, still reaches the caller whole.
+    """
+    generator = FakeGenerator(['{"reason": "no date column on these tables"}'])
+    agent = Agent(generator=generator, synthesizer=FakeSynthesizer("x"),
+                  adapter=_FakeAdapter(), cache=TwoTierCache(L1Cache()), budget=Budget())
+
+    result = agent.answer(_packet(), _snapshot(), _GRANTS, _IDENTITY)
+
+    assert result.deferred is True
+    assert "no date column" in result.answer, (
+        "suppressing every model reason would cost the caller the one thing it can act on"
+    )

--- a/tests/test_deferral_reasons.py
+++ b/tests/test_deferral_reasons.py
@@ -8,6 +8,7 @@ request deferred, and `aggregate` hardcoded `errors=0` -- a total authorization 
 """
 
 import json
+import logging
 
 import pyarrow as pa
 
@@ -140,7 +141,7 @@ def test_a_database_that_rejects_every_attempt_is_a_failure_not_a_deferral():
     assert result.reason_code == DeferralReason.EXECUTION_FAILED
 
 
-def test_the_sources_own_error_text_does_not_reach_the_caller():
+def test_the_sources_own_error_text_does_not_reach_the_caller(caplog):
     """The answer used to carry `Last error: {failure}` -- the database's verbatim complaint.
 
     A source rejection is made of the caller's schema. Postgres names the relation and the
@@ -157,7 +158,8 @@ def test_the_sources_own_error_text_does_not_reach_the_caller():
     agent = _agent(['{"sql": "SELECT n FROM claim"}'] * 9, adapter=adapter,
                    budget=Budget(max_attempts=2))
 
-    result = agent.answer(_packet(), _snapshot(), _GRANTS, _IDENTITY)
+    with caplog.at_level(logging.WARNING, logger="mnemiq.agent.loop"):
+        result = agent.answer(_packet(), _snapshot(), _GRANTS, _IDENTITY)
 
     for secret in ("payroll_salary", "hr_prod", "svc_mnemiq", "10.2.0.7", "postgresql://",
                    "permission denied"):
@@ -165,6 +167,15 @@ def test_the_sources_own_error_text_does_not_reach_the_caller():
     # The state still has to be legible, or hiding the cause would have cost the caller M6.
     assert result.failed is True
     assert result.reason_code == DeferralReason.EXECUTION_FAILED
+    # The other half of the trade. Withheld from the caller is defensible only because the
+    # operator has it; withheld from both is the outage-looks-like-working shape M6 is about.
+    #
+    # Per ATTEMPT, not just the closing summary: `failure` is overwritten each time round, so
+    # asserting on `caplog.text` alone would stay green with the per-attempt line gutted.
+    per_attempt = [r.getMessage() for r in caplog.records
+                   if r.getMessage().startswith("execution attempt")]
+    assert len(per_attempt) == 2, per_attempt  # the closing summary opens with "every"
+    assert all(leaky in m for m in per_attempt)
 
 
 def test_the_source_error_is_still_fed_back_to_the_planner():

--- a/tests/test_deferral_reasons.py
+++ b/tests/test_deferral_reasons.py
@@ -174,15 +174,20 @@ def test_the_source_error_is_still_fed_back_to_the_planner():
     corrected *by*. The model already holds the schema this text is made of, so the boundary
     that matters is the wire, not the prompt.
     """
-    adapter = _FakeAdapter(errors=1, message='column "typo" does not exist')
-    agent = _agent(['{"sql": "SELECT typo FROM claim"}', '{"sql": "SELECT n FROM claim"}'],
+    # Both plans are ones the decider ACCEPTS, so the only feedback that can appear is the
+    # source's. A plan the decider rejects would be repaired inside `plan_query` against its
+    # own refusal text, and asserting on that would pass without `run` ever being called.
+    # The message is one no guard could produce, for the same reason.
+    adapter = _FakeAdapter(errors=1, message='relation "claim" is being vacuumed, retry later')
+    agent = _agent(['{"sql": "SELECT n FROM claim"}'] * 2,
                    adapter=adapter, budget=Budget(max_attempts=2))
 
     result = agent.answer(_packet(), _snapshot(), _GRANTS, _IDENTITY)
 
-    assert result.failed is False
-    assert any("typo" in (feedback or "") for feedback in agent.generator.calls[1:]), (
-        "the second attempt was planned without being told what the first one got wrong"
+    assert result.failed is False, result.answer
+    assert any("is being vacuumed" in (feedback or "") for feedback in agent.generator.calls), (
+        "the retry was planned without being told what the source said -- only `repair_text` "
+        "carries those words, so `message` alone would leave the repair loop blind"
     )
 
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -33,7 +33,11 @@ def test_an_aggregate_comes_back_typed():
 def test_a_bad_query_raises_an_error_the_model_can_repair():
     with pytest.raises(ExecutionError) as excinfo:
         run(_adapter(), "SELECT no_such_column FROM claim")
-    assert "no_such_column" in str(excinfo.value)
+    # `repair_text`, not `str(exc)`: the source's words are the repairable part and they are
+    # deliberately not in the default string, because that is the one a caller-facing message
+    # gets written from by accident.
+    assert "no_such_column" in excinfo.value.repair_text
+    assert "no_such_column" not in str(excinfo.value)
 
 
 def test_a_runaway_query_is_interrupted():

--- a/tests/test_plan_query.py
+++ b/tests/test_plan_query.py
@@ -278,3 +278,44 @@ def test_an_explain_refusal_also_marks_the_feedback_as_the_sources(caplog):
     # Still fed to the model, and still recorded for the operator.
     assert any(leaky in (c or "") for c in generator.calls)
     assert leaky in caplog.text
+
+
+def test_the_undefined_term_exit_does_not_carry_the_source_out_either():
+    """`assumed_terms` is model-authored, and its exit runs BEFORE the stated-reason one.
+
+    A model that echoes its feedback into the term list rather than into `reason` leaves
+    through here, twelve lines earlier. Same rule, same provenance check (M94).
+    """
+    from mnemiq.generate.generator import SqlProposal
+    from mnemiq.generate.plan_query import Feedback
+
+    leaky = 'permission denied for table hr_prod.payroll_salary; postgresql://svc:pw@10.2.0.7/x'
+
+    class _EchoesIntoTerms:
+        def propose(self, packet, feedback=None, strategy=None):
+            return SqlProposal(sql=None, reason="n/a", assumed_terms=[feedback or "x"])
+
+    outcome = plan_query(_packet(), _snapshot(), _GRANTS, _EchoesIntoTerms(), target="duckdb",
+                         feedback=Feedback(leaky, from_source=True), max_attempts=1,
+                         guard_undefined_terms=True)
+
+    assert isinstance(outcome, Deferred)
+    for secret in ("payroll_salary", "hr_prod", "10.2.0.7", "postgresql://"):
+        assert secret not in outcome.reason, f"the term list carried {secret!r} out"
+
+
+def test_a_term_the_source_never_spoke_into_is_still_named():
+    """The narrowing stays as narrow as the risk: naming the term is the point of this deferral."""
+    from mnemiq.generate.generator import SqlProposal
+    from mnemiq.generate.plan_query import Feedback
+
+    class _Declares:
+        def propose(self, packet, feedback=None, strategy=None):
+            return SqlProposal(sql=None, reason="n/a", assumed_terms=["lifetime value"])
+
+    outcome = plan_query(_packet(), _snapshot(), _GRANTS, _Declares(), target="duckdb",
+                         feedback=Feedback("SELECT * is not allowed.", from_source=False),
+                         max_attempts=1, guard_undefined_terms=True)
+
+    assert isinstance(outcome, Deferred)
+    assert "lifetime value" in outcome.reason

--- a/tests/test_plan_query.py
+++ b/tests/test_plan_query.py
@@ -1,3 +1,5 @@
+import logging
+
 from mnemiq.authz.grants import GrantSet
 from mnemiq.contract import Column, Snapshot
 from mnemiq.generate.generator import FakeGenerator
@@ -237,3 +239,42 @@ def test_decide_never_sets_corrected_because_the_decider_does_not_repair():
     verdict = decide("SELECT claim_identifier FROM claim", {"claim": {"claim_identifier"}},
                      dialect="duckdb", target="duckdb")
     assert isinstance(verdict, Approved) and verdict.corrected is False
+
+
+def test_an_explain_refusal_also_marks_the_feedback_as_the_sources(caplog):
+    """The other way source words enter a prompt: `prove` refuses, and its detail is fed back.
+
+    `plan_query`'s own repair loop is the shorter path -- no execution needed, so an EXPLAIN
+    refusal reaches the model on attempt two of a single ask. The suppression has to key off
+    the refusal that carried the words, not only off the agent's outer loop (M94).
+    """
+    leaky = 'permission denied for table hr_prod.payroll_salary; postgresql://svc:pw@10.2.0.7/x'
+
+    class _RefusingExplain:
+        dialect = "duckdb"
+
+        def execute(self, sql):
+            raise RuntimeError(leaky)
+
+    class _Quoting:
+        def __init__(self):
+            self.calls = []
+
+        def propose(self, packet, feedback=None, strategy=None):
+            from mnemiq.generate.generator import SqlProposal
+            self.calls.append(feedback)
+            if feedback is None:
+                return SqlProposal(sql="SELECT claim_identifier FROM claim")
+            return SqlProposal(sql=None, reason=f"the database said: {feedback}")
+
+    generator = _Quoting()
+    with caplog.at_level(logging.WARNING, logger="mnemiq.sql.prove"):
+        outcome = plan_query(_packet(), _snapshot(), _GRANTS, generator,
+                             adapter=_RefusingExplain(), target="duckdb", max_attempts=2)
+
+    assert isinstance(outcome, Deferred)
+    for secret in ("payroll_salary", "hr_prod", "10.2.0.7", "postgresql://"):
+        assert secret not in outcome.reason, f"the model carried {secret!r} out through prove"
+    # Still fed to the model, and still recorded for the operator.
+    assert any(leaky in (c or "") for c in generator.calls)
+    assert leaky in caplog.text

--- a/tests/test_plan_query.py
+++ b/tests/test_plan_query.py
@@ -319,3 +319,46 @@ def test_a_term_the_source_never_spoke_into_is_still_named():
 
     assert isinstance(outcome, Deferred)
     assert "lifetime value" in outcome.reason
+
+
+def test_the_unauthorized_table_exit_does_not_carry_the_source_out_either(caplog):
+    """`subject` is read off the model's own SQL, so it is model-authored like the rest.
+
+    Third exit of the same kind. The caller normally SHOULD be told which table it lacks --
+    that is what makes the refusal actionable -- so this is suppressed only on a turn fed the
+    source's words, and the name still reaches the operator (M94).
+    """
+    from mnemiq.generate.generator import SqlProposal
+    from mnemiq.generate.plan_query import Feedback
+
+    leaky = 'permission denied for table hr_prod.payroll_salary; postgresql://svc:pw@10.2.0.7/x'
+
+    class _NamesItAsATable:
+        def propose(self, packet, feedback=None, strategy=None):
+            return SqlProposal(sql=f'SELECT claim_identifier FROM "{feedback}"')
+
+    with caplog.at_level(logging.WARNING, logger="mnemiq.generate.plan_query"):
+        outcome = plan_query(_packet(), _snapshot(), _GRANTS, _NamesItAsATable(), target="duckdb",
+                             feedback=Feedback(leaky, from_source=True), max_attempts=1)
+
+    assert isinstance(outcome, Deferred)
+    for secret in ("payroll_salary", "hr_prod", "10.2.0.7", "postgresql://"):
+        assert secret not in outcome.reason, f"the refused subject carried {secret!r} out"
+    assert leaky in caplog.text, "the operator still has to be able to see what was refused"
+
+
+def test_a_table_the_source_never_named_is_still_named_to_the_caller():
+    """A caller told which table it lacks can ask for it; one told nothing cannot."""
+    from mnemiq.generate.generator import SqlProposal
+    from mnemiq.generate.plan_query import Feedback
+
+    class _AsksForPerson:
+        def propose(self, packet, feedback=None, strategy=None):
+            return SqlProposal(sql="SELECT last_name FROM person")
+
+    outcome = plan_query(_packet(), _snapshot(), _GRANTS, _AsksForPerson(), target="duckdb",
+                         feedback=Feedback("SELECT * is not allowed.", from_source=False),
+                         max_attempts=1)
+
+    assert isinstance(outcome, Deferred)
+    assert "person" in outcome.reason

--- a/tests/test_prove.py
+++ b/tests/test_prove.py
@@ -99,7 +99,8 @@ def test_the_sources_words_are_kept_out_of_the_callers_half_of_a_refusal():
     assert verdict.code == RefusalCode.EXPLAIN_FAILED
     for secret in ("payroll_salary", "hr_prod", "svc_mnemiq", "10.2.0.7", "postgresql://"):
         assert secret not in verdict.message, f"the caller-facing message disclosed {secret!r}"
-    # The model is the one consumer that should see it -- it already holds the schema.
+    # The model is the consumer this half is FOR -- the repair loop is corrected by it. That is
+    # not the same as the prompt being a safe place: see the residual at `Refusal.source_detail`.
     assert leaky in verdict.source_detail
     assert leaky in verdict.repair_text
 

--- a/tests/test_prove.py
+++ b/tests/test_prove.py
@@ -55,16 +55,20 @@ def test_an_adapter_with_validate_is_never_sent_explain():
 
 
 def test_a_rejection_becomes_explain_failed_carrying_the_sources_own_message():
-    """The message is not decoration: the correction loop reads it to repair the SQL."""
+    """The message is not decoration: the correction loop reads it to repair the SQL.
+
+    It reaches the loop through `repair_text` rather than `message`, because `message` is
+    also what the caller is told and the source's words are made of the caller's schema.
+    """
     r = prove(_Explains(fail='relation "ghost" does not exist'), "SELECT 1 FROM ghost")
     assert isinstance(r, Refusal) and r.code is RefusalCode.EXPLAIN_FAILED
-    assert 'relation "ghost" does not exist' in r.message
+    assert 'relation "ghost" does not exist' in r.repair_text
 
 
 def test_a_validate_rejection_takes_the_same_path():
     r = prove(_Validates(fail="ORA-00942: table or view does not exist"), "SELECT 1 FROM ghost")
     assert isinstance(r, Refusal) and r.code is RefusalCode.EXPLAIN_FAILED
-    assert "ORA-00942" in r.message
+    assert "ORA-00942" in r.repair_text
 
 
 def test_the_seam_is_optional_rather_than_required():
@@ -76,3 +80,38 @@ def test_the_seam_is_optional_rather_than_required():
             return []
 
     assert prove(_Bare(), "SELECT 1") is None
+
+
+def test_the_sources_words_are_kept_out_of_the_callers_half_of_a_refusal():
+    """`message` is forwarded to the caller; the source's exception must not ride in it.
+
+    `plan_query` ends an exhausted repair loop with `reason = last.message`, and that reason
+    becomes `AgentAnswer.answer`. So anything `prove` interpolates into `message` is shipped
+    to whoever asked -- and a source rejection names the relation and column it refused and
+    can carry a DSN. The repair loop still needs those words, which is why they move to
+    `source_detail` rather than being dropped.
+    """
+    leaky = ('permission denied for table hr_prod.payroll_salary; '
+             'connection postgresql://svc_mnemiq@10.2.0.7:5432/hr_prod')
+    verdict = prove(_Explains(fail=leaky), "SELECT n FROM claim")
+
+    assert isinstance(verdict, Refusal)
+    assert verdict.code == RefusalCode.EXPLAIN_FAILED
+    for secret in ("payroll_salary", "hr_prod", "svc_mnemiq", "10.2.0.7", "postgresql://"):
+        assert secret not in verdict.message, f"the caller-facing message disclosed {secret!r}"
+    # The model is the one consumer that should see it -- it already holds the schema.
+    assert leaky in verdict.source_detail
+    assert leaky in verdict.repair_text
+
+
+def test_a_refusal_we_authored_still_reaches_the_caller_whole():
+    """The split must not silence the refusals that are useful to read.
+
+    Only `prove` interpolates a source exception. Every other refusal is text this engine
+    wrote for a person, so `repair_text` and `message` stay the same string and the caller
+    keeps the explanation.
+    """
+    ours = Refusal(code=RefusalCode.SELECT_STAR, message="SELECT * is not allowed.")
+
+    assert ours.source_detail is None
+    assert ours.repair_text == ours.message == "SELECT * is not allowed."

--- a/tests/test_prove.py
+++ b/tests/test_prove.py
@@ -8,6 +8,8 @@ adapters that speak EXPLAIN. The failure lived in the gap between two well-teste
 
 from __future__ import annotations
 
+import logging
+
 from mnemiq.sql.prove import prove
 from mnemiq.sql.verdict import Refusal, RefusalCode
 
@@ -82,7 +84,7 @@ def test_the_seam_is_optional_rather_than_required():
     assert prove(_Bare(), "SELECT 1") is None
 
 
-def test_the_sources_words_are_kept_out_of_the_callers_half_of_a_refusal():
+def test_the_sources_words_are_kept_out_of_the_callers_half_of_a_refusal(caplog):
     """`message` is forwarded to the caller; the source's exception must not ride in it.
 
     `plan_query` ends an exhausted repair loop with `reason = last.message`, and that reason
@@ -93,7 +95,8 @@ def test_the_sources_words_are_kept_out_of_the_callers_half_of_a_refusal():
     """
     leaky = ('permission denied for table hr_prod.payroll_salary; '
              'connection postgresql://svc_mnemiq@10.2.0.7:5432/hr_prod')
-    verdict = prove(_Explains(fail=leaky), "SELECT n FROM claim")
+    with caplog.at_level(logging.WARNING, logger="mnemiq.sql.prove"):
+        verdict = prove(_Explains(fail=leaky), "SELECT n FROM claim")
 
     assert isinstance(verdict, Refusal)
     assert verdict.code == RefusalCode.EXPLAIN_FAILED
@@ -103,6 +106,9 @@ def test_the_sources_words_are_kept_out_of_the_callers_half_of_a_refusal():
     # not the same as the prompt being a safe place: see the residual at `Refusal.source_detail`.
     assert leaky in verdict.source_detail
     assert leaky in verdict.repair_text
+    # And the operator's half: an EXPLAIN refusal a later attempt repairs is logged here or
+    # nowhere, since `plan_query` keeps only the last one.
+    assert leaky in caplog.text
 
 
 def test_a_refusal_we_authored_still_reaches_the_caller_whole():

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -244,6 +244,44 @@ def test_write_executes_on_approval():
     assert any(not s.startswith("EXPLAIN") for s in adapter.ran)  # the write actually ran
 
 
+def test_a_source_that_refuses_a_write_does_not_say_why_to_the_caller():
+    """`WriteResult.refusal` is handed to an MCP agent verbatim by `db_write`.
+
+    The backstop this fires on is the read-only attach rejecting the statement, so the
+    exception is a permission or connection error -- exactly the kind that names the table it
+    refused and carries the DSN it refused it on. The read path withholds those words; this
+    surface is the one an external agent actually reads.
+    """
+    from mnemiq.contract import Column, Snapshot
+    from mnemiq.runtime import Runtime
+
+    snap = Snapshot(version="v1", source_id="acme", created_at="t",
+                    columns=[Column(id="claim.id", object_id="claim", name="id")])
+    leaky = ('permission denied for table hr_prod.payroll_salary; '
+             'connection postgresql://svc_mnemiq@10.2.0.7:5432/hr_prod')
+
+    class _RefusingAdapter:
+        dialect = "duckdb"
+
+        def execute(self, sql):
+            if sql.startswith("EXPLAIN"):
+                return []
+            raise RuntimeError(leaky)
+
+    class _WritesEnabled:
+        write_enabled = True
+        source_id = "acme"
+
+    rt = Runtime(con=None, snapshot=snap, adapter=_RefusingAdapter(), agent=None, embedder=None,
+                 authz=_WriteAuthz("claim"), settings=_WritesEnabled())
+    res = rt.write("INSERT INTO claim (id) VALUES (1)", _identity())
+
+    assert res.approved is False
+    assert res.refusal, "the caller must still be told it was refused"
+    for secret in ("payroll_salary", "hr_prod", "svc_mnemiq", "10.2.0.7", "postgresql://"):
+        assert secret not in res.refusal, f"the write refusal disclosed {secret!r}"
+
+
 def test_ask_threads_ontology_index_columns_and_definitions(monkeypatch):
     """Regression: question-time code resolution and the glossary reached eval's build_engine
     but NOT the product path, so `mnemiq ask` and the MCP server saw neither. The absence of a

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -244,13 +244,17 @@ def test_write_executes_on_approval():
     assert any(not s.startswith("EXPLAIN") for s in adapter.ran)  # the write actually ran
 
 
-def test_a_source_that_refuses_a_write_does_not_say_why_to_the_caller():
+def test_a_source_that_refuses_a_write_does_not_say_why_to_the_caller(caplog):
     """`WriteResult.refusal` is handed to an MCP agent verbatim by `db_write`.
 
-    The backstop this fires on is the read-only attach rejecting the statement, so the
-    exception is a permission or connection error -- exactly the kind that names the table it
-    refused and carries the DSN it refused it on. The read path withholds those words; this
-    surface is the one an external agent actually reads.
+    Any refusal from the source reaches here -- a permission error, a failed connection, a
+    read-only deployment rejecting the statement -- and those name the table they refused and
+    carry the DSN they refused it on. The read path withholds those words; this surface is the
+    one an external agent actually reads.
+
+    Both halves are asserted. Withholding from the caller is only defensible because the
+    operator still gets it, so a test that checks the caller alone would go green on a change
+    that disclosed the words to nobody at all.
     """
     from mnemiq.contract import Column, Snapshot
     from mnemiq.runtime import Runtime
@@ -274,12 +278,14 @@ def test_a_source_that_refuses_a_write_does_not_say_why_to_the_caller():
 
     rt = Runtime(con=None, snapshot=snap, adapter=_RefusingAdapter(), agent=None, embedder=None,
                  authz=_WriteAuthz("claim"), settings=_WritesEnabled())
-    res = rt.write("INSERT INTO claim (id) VALUES (1)", _identity())
+    with caplog.at_level(logging.WARNING, logger="mnemiq.runtime"):
+        res = rt.write("INSERT INTO claim (id) VALUES (1)", _identity())
 
     assert res.approved is False
     assert res.refusal, "the caller must still be told it was refused"
     for secret in ("payroll_salary", "hr_prod", "svc_mnemiq", "10.2.0.7", "postgresql://"):
         assert secret not in res.refusal, f"the write refusal disclosed {secret!r}"
+    assert leaky in caplog.text, "withheld from the caller AND from the operator is not the trade"
 
 
 def test_ask_threads_ontology_index_columns_and_definitions(monkeypatch):

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 
 from mnemiq.agent.loop import AgentAnswer
+from mnemiq.agent.modes import MODES
 from mnemiq.agent.route import UnknownMode
 from mnemiq.contract import IdentityContext
 from mnemiq.server.app import build_app
@@ -49,6 +50,25 @@ def test_unknown_mode_is_422():
     rt = _RT(raises=UnknownMode("no such mode"))
     r = _client(rt).post("/v1/ask", json={"question": "q", "mode": "warp"})
     assert r.status_code == 422
+
+
+def test_the_422_is_composed_here_not_taken_from_the_exception():
+    """The `detail` used to be `str(exc)`, which is what CodeQL flagged as reaching a caller.
+
+    `UnknownMode`'s own text is harmless today. The point is that the handler must not depend
+    on that staying true -- an exception gaining a field, or another type reaching this
+    `except`, would put words on the wire that nobody chose to send. So the response is built
+    from the mode registry, and this pins that by raising one whose message must not appear.
+    """
+    rt = _RT(raises=UnknownMode("MNEMIQ_MODE='deep' invalid; store=/srv/mnemiq/acme.duckdb"))
+    r = _client(rt).post("/v1/ask", json={"question": "q", "mode": "warp"})
+
+    assert r.status_code == 422
+    detail = r.json()["detail"]
+    for leaked in ("/srv/mnemiq", "acme.duckdb", "MNEMIQ_MODE"):
+        assert leaked not in detail, f"the 422 disclosed {leaked!r}"
+    # From the registry, so this cannot drift from the modes the deployment actually offers.
+    assert all(m in detail for m in MODES), "the caller must still learn what it may ask for"
 
 
 def test_schema_and_healthz():

--- a/tests/test_server_chat.py
+++ b/tests/test_server_chat.py
@@ -46,7 +46,48 @@ def test_chat_engine_failure_ends_in_run_error():
     r = TestClient(build_app(rt, _identity())).post("/v1/chat", json={"question": "q"})
     types = [e["type"] for e in _events(r.text)]
     assert types == ["RUN_STARTED", "RUN_ERROR"]
-    assert "boom" in _events(r.text)[-1]["message"]
+    err = _events(r.text)[-1]
+    # The frame carries the run id, which is the handle a caller quotes and an operator
+    # greps for. It does NOT carry the exception -- see the test below.
+    assert err["runId"]
+    assert err["message"] == "The engine could not complete this request."
+
+
+def test_chat_failure_does_not_put_the_sources_error_on_the_wire():
+    """An engine failure used to yield `str(exc)`, and on a governed deployment that is
+    a description of the schema the caller was refused.
+
+    The exception here is shaped like what actually reaches this handler: the source's
+    own message, naming a table this identity was never shown, quoting the statement,
+    and carrying a DSN. Retrieval scoping and `check_access` keep all three out of the
+    ANSWER path; the error path must not be the way around them."""
+    leaky = RuntimeError(
+        'relation "payroll_salary" does not exist\n'
+        'LINE 1: SELECT employee_id, base_salary FROM payroll_salary\n'
+        "connection: postgresql://svc_mnemiq@10.2.0.7:5432/hr_prod"
+    )
+    r = TestClient(build_app(_RT(raises=leaky), _identity())).post(
+        "/v1/chat", json={"question": "q"}
+    )
+    err = _events(r.text)[-1]
+    assert err["type"] == "RUN_ERROR"
+    for secret in ("payroll_salary", "base_salary", "SELECT", "postgresql://",
+                   "10.2.0.7", "hr_prod", "svc_mnemiq"):
+        assert secret not in r.text, f"{secret!r} reached the client"
+
+
+def test_a_mode_the_deployment_does_not_offer_is_still_told_to_the_caller():
+    """Opaque by default, not opaque always. `UnknownMode` is a message the PRODUCT
+    wrote about the caller's own input, so withholding it would turn a fixable request
+    into a mystery -- and it is a constant here, not the exception's text."""
+    from mnemiq.agent.route import UnknownMode
+
+    r = TestClient(build_app(_RT(raises=UnknownMode("nope")), _identity())).post(
+        "/v1/chat", json={"question": "q"}
+    )
+    err = _events(r.text)[-1]
+    assert err["message"] == "That mode is not one this deployment offers."
+    assert "nope" not in r.text
 
 
 def test_chat_emits_keepalive_comments_while_the_engine_works():

--- a/tests/test_server_progress.py
+++ b/tests/test_server_progress.py
@@ -77,9 +77,15 @@ def test_a_step_that_raised_says_so():
     rt = _RT(raises=RuntimeError("boom"), stages=[Stage.RETRIEVE])
     events = _events(_post(rt).text)
 
-    # The stage itself succeeded; the run failed after it.
+    # The stage itself succeeded; the run failed after it. Both halves are the point,
+    # so the completed step must still be reported rather than swallowed by the error.
     assert [e["type"] for e in events][-1] == "RUN_ERROR"
-    assert "boom" in events[-1]["message"]
+    assert [e for e in events if e["type"] == "STEP_FINISHED"][-1]["ok"] is True
+    # The failure is signalled by the frame, not by its prose: the exception's text is
+    # kept off the wire (see tests/test_server_chat.py), so asserting on it here would
+    # pin the disclosure rather than the behaviour.
+    assert events[-1]["runId"]
+    assert "boom" not in _post(rt).text
 
 
 def test_extra_step_fields_survive_to_the_client():

--- a/tests/test_sql_authz_guard.py
+++ b/tests/test_sql_authz_guard.py
@@ -167,7 +167,7 @@ def test_a_stale_snapshot_is_refused_before_execution_not_leaked():
     assert isinstance(verdict, Refusal)
     assert verdict.code == RefusalCode.EXPLAIN_FAILED, verdict.code
     # The refusal must be the BINDER refusing the qualified name, not the double falling over.
-    assert "does not have a column named" in verdict.message, verdict.message
+    assert "does not have a column named" in verdict.repair_text, verdict.repair_text
 
     # And a plainly valid query through the same adapter is approved, so the double is not simply
     # refusing everything -- which is exactly what the broken one did.


### PR DESCRIPTION
A CodeQL `py/stack-trace-exposure` alert (#5) points at `app.py`'s
`HTTPException(detail=str(exc))`. Chasing it turned up the same pattern on four
other caller-facing paths, all of which put a **source's** error text — which is
made of the caller's schema — in front of whoever asked the question.

### What was leaking

| site | text | reaches |
|---|---|---|
| `prove()`'s EXPLAIN refusal | `f"The source rejected this query: {exc}"` | the answer, on **every** refused query |
| `Agent._answer_single` fall-through | `f"Last error: {failure}"` | the answer |
| `run()`'s wrapper | `f"The source rejected this query: {exc}"` | the answer |
| `runtime.write`'s refusal | `f"the source rejected the write: {exc}"` | MCP agents, via `db_write` |
| `chat_stream`'s `RUN_ERROR` | `str(exc)` | the stream |
| `app.py`'s 422 | `str(exc)` | `/v1/ask` — **the alert's own sink** |

The widest is `prove`. `plan_query` ends an exhausted repair loop with
`reason = last.message`, so every refused query shipped whatever the source
said, not only one whose execution attempts all failed. A Postgres rejection
names the relation and the column it refused, so an identity denied a table
learns the table exists by being told why it could not read it.

### The shape

Both types already documented the split they lacked — `Refusal.message` and
`ExecutionError` each carry the comment *"written for the model to repair"*.
One field, two audiences. Each gains `source_detail` and `repair_text`:

```
caller  <- message        our sentence, and often the useful one
model   <- repair_text    the database's complaint is the repair's whole input
log     <- repair_text    where the schema is already known
```

Dropping the text outright would have been wrong, and a test said so: a timeout
message is ours, is not schema, and tells the caller to ask something cheaper.
It still reaches them. The 422 is composed from the mode registry for the same
reason — `UnknownMode`'s text is harmless *today*, and that is the reasoning
this branch exists to stop relying on.

### The hard half: the model as carrier

Withholding at those sites is only half of it. The model is *shown* the source's
words on purpose — a rejection is the repair's whole input — and the model's own
words reach the caller. Those two facts compose, and it is not theoretical: a
generator answering *"the database said: &lt;feedback&gt;"* put
`postgresql://svc:pw@10.2.0.7/hr_prod` straight back into `AgentAnswer.answer`.

There were **three** such exits in one function, and I found them one at a time
because I kept fixing the one I had demonstrated instead of counting them:
`proposal.reason`, then `proposal.assumed_terms` (twelve lines *earlier*), then
`verdict.subject` (read off the model's own SQL by `authz_guard`).

Neither obvious fix works. Starving the prompt costs the repair loop the input a
retry is corrected by; suppressing every model-authored string costs the caller
"there is no date column on these tables" and "you lack access to `person`",
which are the facts those deferrals exist to carry. So the chain breaks in the
middle, on **provenance**: `Feedback` carries whether the source wrote any of the
text, and `from_source` has **no default** — a caller cannot seed feedback and
forget to say where it came from. Suppression fires only on a turn that was fed
source words, and each suppressed exit logs what it withheld.

That is provenance, not content: no pattern to match, nothing to tune, no false
positives, and it stays correct when a source rephrases its errors.

### What is still open (M96)

The approved SQL is model-authored too and ships as `trace.target_sql`. No guard
reads string literals, so `SELECT n, '<the error>' AS note FROM claim` is
approved and the text ships — verified in-process. Narrower than the prose exits
(quoting feedback in an explanation is ordinary model behaviour; embedding it in
a literal is not), but the same laundering.

Not fixed here, deliberately: a containment check is a guard whose false-positive
rate nobody has measured, and suppressing `target_sql` would cost the
transparency that surface exists for. The real question it raises is whether
**credentials** should reach the prompt at all — a DSN has zero repair value,
unlike a schema name. That is a product call, so it is recorded rather than
guessed at.

Also open: the warnings carry no run id, so an operator cannot correlate one with
a caller's run.

### Notes for review

- **Three existing tests pinned the leak**, asserting the source's words were in
  `message`. Each moves to `repair_text` — what their own docstrings said they
  were checking.
- Every assertion here was **checked by mutation**, which is how four defects in
  this branch's own work were caught: a test that could not fail (it matched our
  guard's text, not the source's), the write-path fix shipping with no guard at
  all, and two log lines that nothing pinned.
- The log is the compensating control, so each site asserts the operator half
  too. Five lines carry those words; each was found by counting call sites, and
  the last two had been claimed complete before they were.
- `SECURITY.md` is added, and its scope corrected: it claimed a DSN reaching "a
  log" was in scope while this deliberately logs one.

`1841 passed`, 58 integration/live-LLM deselected. M94 and M95.
