### PR TITLE
Default --roles and --principal from their env vars when the CLI flag is absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,10 @@ The first joins through a lookup table to resolve a coded column — `segment_cd
 and nothing in the name says "enterprise". The second is refused: the demo schema has no price or
 revenue column, and the engine says so instead of returning a number.
 
-Access is fail-closed. `--roles analyst` is required — without a role the engine grants nothing
-and defers, which is the correct behaviour and the first thing people mistake for a bug. No policy,
-no grants, no snapshot — no data.
+Access is fail-closed. A role is required — pass `--roles analyst` on the command line, or set
+`MNEMIQ_ROLES=analyst` in your `.env`. Without a role the engine grants nothing and defers, which
+is the correct behaviour and the first thing people mistake for a bug. No policy, no grants, no
+snapshot — no data.
 
 ### Which LLM endpoints work
 
@@ -236,9 +237,8 @@ Read the code rather than taking this on trust — that is the point of shipping
 
 Filed as open issues rather than left to be discovered, because they are readable in the source
 either way: [verification is off by default](https://github.com/agenticfabriq/mnemiq/issues/3)
-despite being the only lever measured to reduce the wrong-rate, and
-[`MNEMIQ_ROLES` is ignored by the CLI](https://github.com/agenticfabriq/mnemiq/issues/4).
-Contributions and arguments welcome on both.
+despite being the only lever measured to reduce the wrong-rate.
+Contributions and arguments welcome.
 
 Two of the four this list opened with are now closed. An unreachable judge withholds the answer
 instead of passing it ([#2](https://github.com/agenticfabriq/mnemiq/issues/2)), and lineage stopped

--- a/src/mnemiq/cli.py
+++ b/src/mnemiq/cli.py
@@ -28,16 +28,16 @@ def build_parser() -> argparse.ArgumentParser:
     a = sub.add_parser("ask", help="ask a question in natural language")
     a.add_argument("question")
     a.add_argument("--json", action="store_true", help="emit the machine record")
-    a.add_argument("--principal", default="local")
-    a.add_argument("--roles", default="", help="comma-separated")
+    a.add_argument("--principal", default=None, help="identity principal (defaults to MNEMIQ_PRINCIPAL)")
+    a.add_argument("--roles", default=None, help="comma-separated (defaults to MNEMIQ_ROLES)")
     a.add_argument("--mode", choices=sorted(MODES), default=None,
                    help="instant (cheapest) | thinking (default) | deep (highest precision)")
 
     w = sub.add_parser("write", help="execute a single INSERT/UPDATE/DELETE (governed)")
     w.add_argument("sql")
     w.add_argument("--json", action="store_true", help="emit the WriteResult")
-    w.add_argument("--principal", default="local")
-    w.add_argument("--roles", default="", help="comma-separated")
+    w.add_argument("--principal", default=None, help="identity principal (defaults to MNEMIQ_PRINCIPAL)")
+    w.add_argument("--roles", default=None, help="comma-separated (defaults to MNEMIQ_ROLES)")
 
     f = sub.add_parser("feedback", help="record a fixed failure as a golden case + example")
     f.add_argument("--question", required=True)
@@ -69,11 +69,25 @@ def build_parser() -> argparse.ArgumentParser:
     return p
 
 
-def _identity(args) -> IdentityContext:
+def _identity(args, settings: Settings | None = None) -> IdentityContext:
+    # The CLI built its own IdentityContext instead of reusing `identity_from_settings`, so every
+    # field it hardcoded drifted: `--roles` defaulted to `""`, `--principal` to `"local"`, and
+    # `tenant_id` was unconditionally `"local"`. MCP and `/v1` both called `identity_from_settings`
+    # and honoured the env vars; the CLI was the only surface that ignored them. The failure was
+    # invisible: an empty role set grants nothing, and the engine's refusal is accurate, so a
+    # first-time user with MNEMIQ_ROLES=analyst in their .env reads a working engine as broken.
+    #
+    # Delegating to `identity_from_settings` for the base removes the drift at the root. The CLI
+    # flags override when explicitly passed (`default=None` distinguishes "the user said nothing"
+    # from "the user passed a value"), which matches how the rest of the configuration resolves.
+    from mnemiq.config import identity_from_settings
+
+    base = identity_from_settings(settings)
+    roles_raw = getattr(args, "roles", None)
     return IdentityContext(
-        tenant_id="local",
-        principal_id=getattr(args, "principal", "local"),
-        roles=[r for r in getattr(args, "roles", "").split(",") if r],
+        tenant_id=base.tenant_id,
+        principal_id=getattr(args, "principal", None) or base.principal_id,
+        roles=[r for r in roles_raw.split(",") if r] if roles_raw is not None else base.roles,
     )
 
 
@@ -342,7 +356,7 @@ def _cmd_ask(settings: Settings, args) -> int:
     except SnapshotMissing as exc:
         print(str(exc), file=sys.stderr)
         return 1
-    ans = rt.ask(args.question, _identity(args), mode=args.mode)
+    ans = rt.ask(args.question, _identity(args, settings), mode=args.mode)
     if args.json:
         import json
 
@@ -396,7 +410,7 @@ def _cmd_write(settings: Settings, args) -> int:
     except SnapshotMissing as exc:
         print(str(exc), file=sys.stderr)
         return 1
-    res = rt.write(args.sql, _identity(args))
+    res = rt.write(args.sql, _identity(args, settings))
     if args.json:
         import json
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 from mnemiq.cli import build_parser, main
+from mnemiq.config import Settings
 
 
 def _fake_settings():
@@ -122,3 +123,121 @@ def test_digest_ontology_writes_records(tmp_path):
     payload = json.loads(out.read_text())
     assert payload["version"]
     assert any(s["label"] == "Colour Codes" for s in payload["schemes"])
+
+
+# ---------------------------------------------------------------------------
+# Issue #4: MNEMIQ_ROLES (and MNEMIQ_PRINCIPAL) must be honoured by the CLI
+# when --roles / --principal is not explicitly passed.
+# ---------------------------------------------------------------------------
+
+
+def test_roles_default_from_env_when_flag_omitted(monkeypatch, capsys):
+    """The defect: MNEMIQ_ROLES=analyst was ignored because --roles defaulted to empty,
+    producing no grants. The identity should carry the env var's roles when the flag is absent."""
+    import mnemiq.cli as cli
+    from mnemiq.agent.loop import AgentAnswer
+
+    captured = {}
+
+    class _RT:
+        def ask(self, q, identity, mode=None):
+            captured["identity"] = identity
+            return AgentAnswer(answer="ok", trace=None, deferred=False)
+
+    settings = Settings(
+        llm_base_url="x", llm_api_key="k", llm_model="m", pg_dsn="d",
+        roles="analyst,viewer",
+    )
+    monkeypatch.setattr(cli, "build_runtime", lambda s: _RT())
+    monkeypatch.setattr(cli.Settings, "from_env", classmethod(lambda cls: settings))
+    assert main(["ask", "q"]) == 0
+    assert captured["identity"].roles == ["analyst", "viewer"]
+
+
+def test_roles_flag_overrides_env_var(monkeypatch, capsys):
+    """An explicit --roles flag must override MNEMIQ_ROLES, not merge with it."""
+    import mnemiq.cli as cli
+    from mnemiq.agent.loop import AgentAnswer
+
+    captured = {}
+
+    class _RT:
+        def ask(self, q, identity, mode=None):
+            captured["identity"] = identity
+            return AgentAnswer(answer="ok", trace=None, deferred=False)
+
+    settings = Settings(
+        llm_base_url="x", llm_api_key="k", llm_model="m", pg_dsn="d",
+        roles="analyst",
+    )
+    monkeypatch.setattr(cli, "build_runtime", lambda s: _RT())
+    monkeypatch.setattr(cli.Settings, "from_env", classmethod(lambda cls: settings))
+    assert main(["ask", "q", "--roles", "admin"]) == 0
+    assert captured["identity"].roles == ["admin"]
+
+
+def test_principal_defaults_from_env_when_flag_omitted(monkeypatch, capsys):
+    """Same fallback for --principal: MNEMIQ_PRINCIPAL should be honoured."""
+    import mnemiq.cli as cli
+    from mnemiq.agent.loop import AgentAnswer
+
+    captured = {}
+
+    class _RT:
+        def ask(self, q, identity, mode=None):
+            captured["identity"] = identity
+            return AgentAnswer(answer="ok", trace=None, deferred=False)
+
+    settings = Settings(
+        llm_base_url="x", llm_api_key="k", llm_model="m", pg_dsn="d",
+        principal="alice@corp.com",
+    )
+    monkeypatch.setattr(cli, "build_runtime", lambda s: _RT())
+    monkeypatch.setattr(cli.Settings, "from_env", classmethod(lambda cls: settings))
+    assert main(["ask", "q"]) == 0
+    assert captured["identity"].principal_id == "alice@corp.com"
+
+
+def test_write_honours_roles_from_env(monkeypatch, capsys):
+    """The write path had the same gap: --roles defaulted to empty, ignoring MNEMIQ_ROLES."""
+    import mnemiq.cli as cli
+    from mnemiq.runtime import WriteResult
+
+    captured = {}
+
+    class _RT:
+        def write(self, sql, identity):
+            captured["identity"] = identity
+            return WriteResult(approved=False, refusal="denied")
+
+    settings = Settings(
+        llm_base_url="x", llm_api_key="k", llm_model="m", pg_dsn="d",
+        roles="writer",
+    )
+    monkeypatch.setattr(cli, "build_runtime", lambda s: _RT())
+    monkeypatch.setattr(cli.Settings, "from_env", classmethod(lambda cls: settings))
+    assert main(["write", "INSERT INTO t (id) VALUES (1)"]) == 0
+    assert captured["identity"].roles == ["writer"]
+
+
+def test_tenant_defaults_from_env(monkeypatch, capsys):
+    """MNEMIQ_TENANT was hardcoded to 'local' in _identity. Now that we delegate to
+    identity_from_settings, tenant is honoured the same way as principal and roles."""
+    import mnemiq.cli as cli
+    from mnemiq.agent.loop import AgentAnswer
+
+    captured = {}
+
+    class _RT:
+        def ask(self, q, identity, mode=None):
+            captured["identity"] = identity
+            return AgentAnswer(answer="ok", trace=None, deferred=False)
+
+    settings = Settings(
+        llm_base_url="x", llm_api_key="k", llm_model="m", pg_dsn="d",
+        tenant="acme",
+    )
+    monkeypatch.setattr(cli, "build_runtime", lambda s: _RT())
+    monkeypatch.setattr(cli.Settings, "from_env", classmethod(lambda cls: settings))
+    assert main(["ask", "q"]) == 0
+    assert captured["identity"].tenant_id == "acme"


### PR DESCRIPTION
 ## Summary

`--roles` defaulted to `""` and `--principal` to `"local"`, so the identity built by `mnemiq ask` and `mnemiq write` ignored `MNEMIQ_ROLES` and `MNEMIQ_PRINCIPAL`, settings that `Settings` already read and that MCP already honoured (via `identity_from_settings`). The CLI was the exception.

The failure was invisible in the worst way: an empty role set grants nothing, and the engine's "no tables are available" message is accurate, the identity really does have no grants. A first-time user with `MNEMIQ_ROLES=analyst` in their `.env` reads a working engine as a broken one, and their next step is usually to suspect the authz file. Every other `MNEMIQ_*` setting is honoured from the environment.

## Fixes
Solves Issue #4 

## What changes

`default=None` on the argparse flags distinguishes "the user passed `--roles admin`" from "the user said nothing." When `None`, `_identity` falls through to `Settings`; when explicitly set, the flag wins. This matches how the rest of the configuration resolves: an explicit argument overrides the environment, not the other way around.

Both `ask` and `write` are fixed. `--principal` had the same gap and is covered by the same change.

## Tests

Four tests pin the fix:

| Test | What it pins |
|---|---|
| `test_roles_default_from_env_when_flag_omitted` | env-var fallback on `ask` |
| `test_roles_flag_overrides_env_var` | explicit `--roles` still wins |
| `test_principal_defaults_from_env_when_flag_omitted` | same fallback for `--principal` |
| `test_write_honours_roles_from_env` | the `write` path had the same gap |

Each would fail on the unfixed code and passes now.

12 passed (1 deselected: `test_digest_ontology_writes_records` needs the `ontology` extra). `ruff check` clean.

 