### PR TITLE
Declare workflow token permissions, and halve the CI bill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,21 @@
 name: ci
-on: [push, pull_request]
+on:
+  # `pull_request` alone would leave `main` itself unbuilt; `push` alone would skip PRs from
+  # forks, which is where the checks matter most. Both, but `push` is narrowed to `main` --
+  # unnarrowed, a branch in this repo fired BOTH events and every job ran twice, which is
+  # what made a green PR cost double and read as two conflicting sets of checks.
+  push:
+    branches: [main]
+  pull_request:
+
+# This repo's default is already `read`, so today this changes nothing at runtime. It is here
+# because that default is a REPO SETTING -- one checkbox in a UI, changeable by anyone with
+# admin, invisible in review, and silently applied to every workflow at once. Declared here it
+# is version-controlled, diffed, and cannot be widened without a commit. Top level, so a job
+# added later inherits the floor instead of whatever the setting happens to be that week.
+permissions:
+  contents: read
+
 jobs:
   unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/eval-nightly.yml
+++ b/.github/workflows/eval-nightly.yml
@@ -71,6 +71,9 @@ env:
   ACME_DATASET_REPO: dbt-labs/semantic-layer-llm-benchmarking
   ACME_DATASET_REF: ac20c9292fa88ec44d30aeeae61ee41a51e31748
 
+permissions:
+  contents: read
+
 jobs:
   acme:
     runs-on: ubuntu-latest

--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -1,11 +1,18 @@
 name: repo-guard
 on:
-  # Deliberately NOT narrowed to `main`, unlike ci.yml. This repo is public, so a branch is
-  # world-readable the moment it is pushed, and this is the job whose whole premise is that
-  # such a push cannot be taken back. Narrowing it would leave the window between pushing a
-  # branch and opening a PR unscanned -- and the local hook does not cover that window either,
-  # being opt-in per clone and skippable with `--no-verify`. Running it twice on a PR costs
-  # about nine seconds; the double run on ci.yml was worth removing, this one is not.
+  # Deliberately NOT narrowed to `main`, unlike ci.yml. This repo is public, so a branch pushed
+  # HERE is world-readable at once (a fork's own branch fires nothing in this repo -- for those,
+  # the PR run is the first look), and this is the job whose premise is that such a push cannot
+  # be taken back. Narrowing would leave the window between pushing a branch and opening a PR
+  # scanned by nothing: the local hook is opt-in per clone and `--no-verify` skips it.
+  #
+  # The second run is close to free for a maintainer's branch, which is the case being defended
+  # here. It is NOT free for an outside contributor: secrets are withheld from fork PRs, so this
+  # currently fails closed on theirs for a reason they cannot act on. That is PR #6's subject,
+  # not this trigger's -- noting it so the two are not confused.
+  #
+  # Scope worth knowing: `--all` scans the checked-out tree, not the history behind it, so a
+  # secret added and then removed within a branch passes. See M97.
   push:
   pull_request:
 

--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -1,7 +1,12 @@
 name: repo-guard
 on:
   push:
+    branches: [main]
   pull_request:
+
+permissions:
+  contents: read
+
 jobs:
   guard:
     runs-on: ubuntu-latest

--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -7,9 +7,11 @@ on:
   # scanned by nothing: the local hook is opt-in per clone and `--no-verify` skips it.
   #
   # For a maintainer's branch the extra run is close to free, and that is the case defended
-  # here. An outside contributor gets no extra run at all -- the PR run is their only one, and
-  # it currently fails closed, because secrets are withheld from fork PRs. That is PR #6's
-  # subject, not this trigger's -- noting it so the two are not confused.
+  # here. An outside contributor gets no extra run at all -- a fork's own branch pushes fire
+  # nothing here, so the PR run is their only one. It used to fail closed for them, because
+  # repository secrets are withheld from fork PRs and the name check needed one; #6 moved that
+  # check to local-only, so the PR run now works for a fork. Recorded because this trigger and
+  # that fix look like the same subject and are not.
   #
   # Scope worth knowing: `--all` scans the checked-out tree, not the history behind it, so a
   # secret added and then removed within a branch passes. See M97.

--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -6,10 +6,10 @@ on:
   # be taken back. Narrowing would leave the window between pushing a branch and opening a PR
   # scanned by nothing: the local hook is opt-in per clone and `--no-verify` skips it.
   #
-  # The second run is close to free for a maintainer's branch, which is the case being defended
-  # here. It is NOT free for an outside contributor: secrets are withheld from fork PRs, so this
-  # currently fails closed on theirs for a reason they cannot act on. That is PR #6's subject,
-  # not this trigger's -- noting it so the two are not confused.
+  # For a maintainer's branch the extra run is close to free, and that is the case defended
+  # here. An outside contributor gets no extra run at all -- the PR run is their only one, and
+  # it currently fails closed, because secrets are withheld from fork PRs. That is PR #6's
+  # subject, not this trigger's -- noting it so the two are not confused.
   #
   # Scope worth knowing: `--all` scans the checked-out tree, not the history behind it, so a
   # secret added and then removed within a branch passes. See M97.
@@ -25,6 +25,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # Full history, though the scan reads only the tree (see the scope note above and
+          # M97). Kept because the fix for M97 needs the commits a push adds; today it fetches
+          # what nothing opens, which is precisely the mismatch that finding is about.
           fetch-depth: 0
       - name: Scan for proprietary names and secrets
         env:

--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -1,7 +1,12 @@
 name: repo-guard
 on:
+  # Deliberately NOT narrowed to `main`, unlike ci.yml. This repo is public, so a branch is
+  # world-readable the moment it is pushed, and this is the job whose whole premise is that
+  # such a push cannot be taken back. Narrowing it would leave the window between pushing a
+  # branch and opening a PR unscanned -- and the local hook does not cover that window either,
+  # being opt-in per clone and skippable with `--no-verify`. Running it twice on a PR costs
+  # about nine seconds; the double run on ci.yml was worth removing, this one is not.
   push:
-    branches: [main]
   pull_request:
 
 permissions:


### PR DESCRIPTION
Closes the four `actions/missing-workflow-permissions` alerts, and stops every
job running twice on every PR.

### Permissions

The blocks change nothing at runtime today — this repo's default is already
`read`, which I checked rather than assumed. The CodeQL rule fires on the
declaration being absent, not on the token being wide.

Declaring it anyway is worth it because that default is a **repo setting**: one
checkbox, changeable by anyone with admin, invisible in review, applied to every
workflow at once. In the file it is version-controlled, diffed, and cannot be
widened without a commit.

### Triggers — and why only one workflow is narrowed

`on: [push, pull_request]` fires **both** events for a branch in this repo, so
every job ran twice. I narrowed both workflows in the first pass. That was
wrong, and the two cases have opposite answers:

- **ci.yml** — narrowed. The double run costs a full test matrix twice per PR
  and buys nothing; `pull_request` covers the same commit.
- **repo-guard.yml** — reverted, left on every push. This repo is public, so a
  branch pushed here is world-readable at once, and this is the job whose stated
  premise is that such a push cannot be taken back. Narrowing left the window
  between pushing a branch and opening a PR scanned by nothing — the local hook
  is opt-in per clone and `--no-verify` skips it. I removed a nine-second control
  to save nine seconds.

The asymmetry is now written into both files, since the next person to notice
the double run will reach for the same fix I did.

### Noted, not fixed

- **M97** — `--all` resolves to `git ls-files`, so the guard scans the checked-out
  tree, not the history behind it. A secret added and removed within a branch
  scans clean while staying readable in the pushed public history, and
  `fetch-depth: 0` fetches history the script never opens. Not fixed here: a
  full-history sweep would light up this repo's pre-rewrite ancestry on every
  run, which is how a guard becomes the thing people route around. The bounded
  shape is the push event's own `before..after` range.
- Fork PRs still fail repo-guard closed, because secrets are withheld from them.
  That is **PR #6**, which is now green and should merge first.

### Validation

Parsed all three workflows rather than eyeballing them — job names are still
`unit`, `workbench`, `guard`, which are the contexts `main`'s new protection
requires. A workflow that fails to parse reports no checks at all, and required
checks that never report would block every PR permanently.