### PR TITLE
Add glama.json for MCP server directory listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "paulinazhx"
+  ]
+}

--- a/glama.json
+++ b/glama.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "maintainers": [
-    "paulinazhx"
+    "paulinazhx",
+    "hiddendim"
   ]
 }


### PR DESCRIPTION
Adds `glama.json` at the repository root so mnemiq can be listed in
[Glama's](https://glama.ai/mcp) MCP server directory.

```json
{
  "$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": ["paulinazhx"]
}
```

mnemiq exposes an MCP server today — `mnemiq serve` over stdio, with two read-only,
access-scoped tools (`db_read(question)` and `get_schema()`) — so the listing is accurate rather
than aspirational. The `maintainers` array is how Glama establishes who may claim and edit the
listing; it does not grant anything in this repository.

No code change, no dependency change.