### PR TITLE
A function in projection position is not a table, so nothing checked it (M43)

### DIFF
--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from sqlglot import exp
+from sqlglot.dialects.dialect import Dialect
 
 from mnemiq.sql.qualify import object_key
 from mnemiq.sql.scope import base_tables, column_tables
@@ -82,4 +83,78 @@ def check_access(ast: exp.Expression, visible: dict[str, set[str]],
                 subject=column.name,
             )
 
+    return None
+
+
+def _known_function_names() -> frozenset[str]:
+    """Every function name sqlglot can model, in ANY dialect.
+
+    Not `exp.Func` subclasses alone: those carry `sql_names()` for 623 names and miss `now`
+    and `date_part`, which live in each dialect's PARSER table rather than on a class. Missing
+    them is not academic -- see the guard below for what it cost.
+    """
+    names: set[str] = set()
+
+    def walk(cls: type) -> None:
+        for sub in cls.__subclasses__():
+            try:
+                names.update(n.upper() for n in sub.sql_names())
+            except Exception:  # a class that does not declare names is simply not a source
+                pass
+            walk(sub)
+
+    walk(exp.Func)
+    for dialect in Dialect.classes.values():
+        try:
+            names.update(k.upper() for k in dialect.parser_class.FUNCTIONS)
+        except Exception:
+            continue
+    return frozenset(names)
+
+
+_KNOWN_FUNCTIONS = _known_function_names()
+
+
+def check_unmodelled_calls(ast: exp.Expression) -> Refusal | None:
+    """Refuse a call this engine cannot model, because it cannot say what such a call reads.
+
+    `check_access` re-checks every `exp.Table` against the identity's visible set, and the RLS
+    rewrite wraps each one. A function in PROJECTION position produces no `exp.Table` at all,
+    so both walk past it: measured, `SELECT customer_rows() AS x` and
+    `SELECT pg_read_file('/etc/passwd')` were APPROVED with `tables=[]` for a caller granted
+    only `claim`, while `SELECT id FROM customer` was correctly refused in the same run (M43).
+
+    A **whitelist**, the same inversion `unrecognised_source` took for source shapes, and for
+    the reason its docstring gives: enumerate dangerous functions and an unlisted one passes,
+    with every review round finding another nobody thought of.
+
+    The allowlist is sqlglot's whole function vocabulary, ACROSS DIALECTS, and that detail is
+    the guard. The first version tested `isinstance(node, exp.Anonymous)`, which asks whether
+    the ONE dialect being parsed happens to model the name. Production parses as `duckdb`
+    (`Agent.dialect` from the adapter), sqlglot models `now` and `date_part` only under
+    postgres, and so the first version refused `SELECT id FROM claim WHERE created_at < now()`
+    -- measured through `decide`, on the shipped default. Its control test asserted the
+    opposite while pinning `dialect="postgres"`, the one dialect where the claim held.
+
+    Not a claim that an unknown call reads data. It is a claim that the decider cannot tell,
+    and the decider's premise is that it sees every table a query reads. An opaque call makes
+    that premise false, so the honest verdict is that this query cannot be decided.
+
+    Names, not identities: a UDF named `median` is modelled by sqlglot and passes here. That is
+    the acknowledged limit of any name-based allowlist, and it is bounded by the same
+    per-identity execution that dissolves M43 and M65 in v2.
+    """
+    for call in ast.find_all(exp.Anonymous):
+        name = str(call.this)
+        if name.upper() in _KNOWN_FUNCTIONS:
+            continue
+        return Refusal(
+            code=RefusalCode.UNMODELLED_CALL,
+            message=(
+                f"{name}() is a function this engine cannot model, so it cannot confirm what "
+                "the query reads. Answer using only the listed tables and columns and "
+                "standard SQL functions."
+            ),
+            subject=name,
+        )
     return None

--- a/src/mnemiq/sql/decide.py
+++ b/src/mnemiq/sql/decide.py
@@ -4,7 +4,7 @@ import sqlglot
 from sqlglot import exp
 
 from mnemiq.contract import ViewDefinition
-from mnemiq.sql.authz_guard import check_access
+from mnemiq.sql.authz_guard import check_access, check_unmodelled_calls
 from mnemiq.sql.cls import check_cls
 from mnemiq.sql.guard import MAX_ROWS, check_shape
 from mnemiq.sql.lint import lint
@@ -51,6 +51,15 @@ def decide(
     refusal = check_access(shaped, visible, target)
     if refusal is not None:
         return refusal
+
+    # Beside `check_access` because it defends the same premise: that the decider sees every
+    # table the query reads. `check_access` walks `exp.Table` nodes, and a function in
+    # projection position is not one -- so an opaque call slipped past both it and the RLS
+    # rewrite (M43). This does not decide whether such a call is dangerous; it says the query
+    # cannot be decided, which is the true thing.
+    opaque = check_unmodelled_calls(shaped)
+    if opaque is not None:
+        return opaque
 
     cls = check_cls(shaped, policy, target)  # column deny / mask-in-predicate
     if cls is not None:

--- a/src/mnemiq/sql/decide_write.py
+++ b/src/mnemiq/sql/decide_write.py
@@ -5,7 +5,7 @@ from sqlglot import exp
 
 from mnemiq.authz.grants import GrantSet
 from mnemiq.contract import ViewDefinition
-from mnemiq.sql.authz_guard import check_access
+from mnemiq.sql.authz_guard import check_access, check_unmodelled_calls
 from mnemiq.sql.cls import check_cls
 from mnemiq.sql.policy import AccessPolicy
 from mnemiq.sql.prove import prove
@@ -211,6 +211,15 @@ def decide_write(
     refusal = check_access(shaped, visible, target)  # every referenced table readable, cols exist
     if refusal is not None:
         return refusal
+
+    # The read path's M43 fix, on the write path, because the premise is identical and a write
+    # is the worse place to lose it: measured before this line existed, `UPDATE claim SET
+    # amount = pg_read_file('/etc/passwd') WHERE id = 1` and `INSERT INTO claim (id, amount)
+    # SELECT customer_rows(), 1` were both APPROVED with tables=['claim'] -- the same audit lie,
+    # and here it persists what it read into a table.
+    opaque = check_unmodelled_calls(shaped)
+    if opaque is not None:
+        return opaque
 
     # A write needs RAW access: a masked column is treated as denied for writes.
     write_cls = check_cls(shaped, AccessPolicy(denied=policy.denied | policy.masked), target)

--- a/src/mnemiq/sql/verdict.py
+++ b/src/mnemiq/sql/verdict.py
@@ -13,6 +13,9 @@ class RefusalCode(StrEnum):
     UNKNOWN_TABLE = "unknown_table"
     UNKNOWN_COLUMN = "unknown_column"
     EXPLAIN_FAILED = "explain_failed"
+    # A call this engine cannot model, so it cannot say what the query reads. Not
+    # "a forbidden function" -- there is no list of those, and that is the point (M43).
+    UNMODELLED_CALL = "unmodelled_call"
     LOGIC_LINT = "logic_lint"
     VALUE_GROUNDING = "value_grounding"
     NOT_A_WRITE = "not_a_write"
@@ -58,6 +61,11 @@ REPAIRABLE = frozenset(
         RefusalCode.UNKNOWN_TABLE,
         RefusalCode.UNKNOWN_COLUMN,
         RefusalCode.EXPLAIN_FAILED,
+        # Repairable on purpose. The measured cost of this guard is a legitimate scalar
+        # function sqlglot does not model -- Postgres `age()` was the one case in 459 --
+        # and the repair loop can rewrite that into arithmetic the engine does model.
+        # Without this the guard's false positives become deferrals instead of retries.
+        RefusalCode.UNMODELLED_CALL,
         RefusalCode.LOGIC_LINT,
         RefusalCode.VALUE_GROUNDING,
     }

--- a/tests/test_sql_authz_guard.py
+++ b/tests/test_sql_authz_guard.py
@@ -1,7 +1,8 @@
+import pytest
 import sqlglot
 
 from mnemiq.sql.authz_guard import check_access
-from mnemiq.sql.verdict import RefusalCode
+from mnemiq.sql.verdict import Refusal, RefusalCode
 
 VISIBLE = {
     "claim": {"claim_identifier", "status", "party_identifier"},
@@ -182,3 +183,129 @@ def test_a_stale_snapshot_is_refused_before_execution_not_leaked():
                      adapter=_Adapter(con), target="duckdb")
     assert isinstance(unstale, Refusal)
     assert unstale.code == RefusalCode.SELECT_STAR, unstale.code
+
+
+# --------------------------------------------------------------------------------------------
+# M43 -- a function in projection position produces no exp.Table, so both the access check
+# and the RLS rewrite walk past it
+# --------------------------------------------------------------------------------------------
+
+
+_M43_VISIBLE = {"claim": {"id", "amount", "created_at", "ssn"}}
+
+
+# Both, always. The first version of this guard tested `isinstance(node, exp.Anonymous)`,
+# which asks whether the ONE dialect being parsed models the name -- and these tests pinned
+# `postgres`, the dialect where the control held. Production parses as `duckdb`, where sqlglot
+# leaves `now` and `date_part` Anonymous, so the shipped guard refused
+# `WHERE created_at < now()` while its own control test said it did not.
+_DIALECTS = ("duckdb", "postgres")   # duckdb FIRST: it is the production default
+
+
+def _decide(sql, dialect):
+    from mnemiq.sql.decide import decide
+
+    return decide(sql, _M43_VISIBLE, dialect=dialect, target=dialect)
+
+
+@pytest.mark.parametrize("dialect", _DIALECTS)
+@pytest.mark.parametrize("sql", [
+    "SELECT customer_rows() AS x",                                  # a UDF that reads
+    "SELECT pg_read_file('/etc/passwd')",                           # not even a table read
+    "SELECT public.customer_rows() AS x",                           # schema-qualified
+    "SELECT id FROM claim WHERE amount > (SELECT max_amount())",    # buried in a predicate
+])
+def test_an_opaque_call_cannot_be_decided(sql, dialect):
+    """Measured before the fix: every one of these was APPROVED with `tables=[]` for a caller
+    granted only `claim`. `check_access` re-checks each `exp.Table`; a call in projection
+    position is not one, so nothing looked at it and the RLS rewrite had nothing to wrap.
+
+    The refusal does not claim the function is dangerous -- there is no list of dangerous
+    functions here, deliberately. It claims the decider cannot tell what the query reads, which
+    makes its own premise false.
+    """
+    v = _decide(sql, dialect)
+    assert isinstance(v, Refusal), f"{sql!r} was approved under {dialect}"
+    assert v.code == RefusalCode.UNMODELLED_CALL
+
+
+@pytest.mark.parametrize("dialect", _DIALECTS)
+@pytest.mark.parametrize("sql", [
+    "SELECT id FROM claim",
+    "SELECT sum(amount), count(*), upper(ssn) FROM claim",
+    "SELECT date_trunc('month', created_at) FROM claim",
+    "SELECT CAST(id AS TEXT) FROM claim",
+    "SELECT id FROM claim WHERE created_at < now()",
+    "SELECT current_timestamp FROM claim",
+    "SELECT date_part('year', created_at) FROM claim",
+])
+def test_a_modelled_call_is_untouched(sql, dialect):
+    """The degeneracy control, and it is the whole reason this is a whitelist rather than a
+    blocklist of names. sqlglot's typed function classes ARE the allowlist: sum, count, upper,
+    cast and date_trunc parse to Sum, Count, Upper, Cast and DateTrunc, so they never reach
+    this guard. `now()` is here because the lineage layer measured it as `Anonymous` on a bare
+    parse -- through the decider it is not, and a guard that refused `WHERE created_at < now()`
+    would be useless whatever it caught.
+    """
+    assert not isinstance(_decide(sql, dialect), Refusal), f"{sql!r} refused under {dialect}"
+
+
+def test_the_refusal_is_repairable_so_a_false_positive_costs_a_retry():
+    """The measured cost of this guard, over 459 SELECTs in this suite, under both dialects, was Postgres `age()`:
+    a pure scalar function sqlglot does not model. Every other refusal was an attack fixture,
+    a case another guard already refused, or SQL that never reaches the decider.
+
+    That one case is why UNMODELLED_CALL is repairable. The loop can rewrite `age(x)` into
+    arithmetic the engine does model, so a false positive costs an attempt rather than an
+    answer -- which is what keeps a fail-closed guard from being the thing people route around.
+    """
+    v = _decide("SELECT age(created_at) FROM claim", "duckdb")
+    assert isinstance(v, Refusal) and v.code == RefusalCode.UNMODELLED_CALL
+    assert v.repairable is True
+    assert "age" in v.message, "the model cannot repair what the refusal does not name"
+
+
+# --------------------------------------------------------------------------------------------
+# M43 on the WRITE path. Same premise, worse consequence: the write persists what it read.
+# --------------------------------------------------------------------------------------------
+
+
+def _decide_write(sql, dialect):
+    from mnemiq.authz.grants import GrantSet
+    from mnemiq.sql.decide import AccessPolicy
+    from mnemiq.sql.decide_write import decide_write
+
+    return decide_write(
+        sql, {"claim": {"id", "amount"}},
+        GrantSet(frozenset({"claim"}), writable=frozenset({"claim"})),
+        policy=AccessPolicy(), dialect=dialect, target=dialect, writes_enabled=True,
+    )
+
+
+@pytest.mark.parametrize("dialect", _DIALECTS)
+@pytest.mark.parametrize("sql", [
+    "UPDATE claim SET amount = 1 WHERE id = 1",
+    "UPDATE claim SET amount = amount + 1 WHERE id = 1",
+    "INSERT INTO claim (id, amount) VALUES (1, 2)",
+])
+def test_an_ordinary_write_is_still_approved(sql, dialect):
+    """The passing control. Without it the refusals below prove only that everything refuses --
+    the first run of that probe used a read-only grant and every case came back
+    `unauthorized_write`, which looks exactly like the guard working."""
+    assert not isinstance(_decide_write(sql, dialect), Refusal), f"{sql!r} refused under {dialect}"
+
+
+@pytest.mark.parametrize("dialect", _DIALECTS)
+@pytest.mark.parametrize("sql", [
+    "UPDATE claim SET amount = pg_read_file('/etc/passwd') WHERE id = 1",
+    "UPDATE claim SET amount = 1 WHERE id = (SELECT secret_max_id())",
+    "INSERT INTO claim (id, amount) SELECT customer_rows(), 1",
+])
+def test_an_opaque_call_cannot_be_decided_on_the_write_path_either(sql, dialect):
+    """`decide_write` called `check_access` and not this guard, so the read path's fix left the
+    write path open. Measured before it was wired: all three returned ApprovedWrite with
+    `tables=['claim']` -- the same audit lie, except a write persists what it read into a table
+    that a later plain SELECT returns forever (the M30 shape)."""
+    v = _decide_write(sql, dialect)
+    assert isinstance(v, Refusal), f"{sql!r} was approved under {dialect}"
+    assert v.code == RefusalCode.UNMODELLED_CALL


### PR DESCRIPTION
The decider's premise is that it sees every table a query reads: `check_access`
re-checks each `exp.Table` against the identity's visible set, and the RLS
rewrite wraps each one. **A call in projection position produces no `exp.Table`**,
so both walk past it.

Measured on `main` with passing controls in the same run — `SELECT id FROM
customer` correctly refused, `SELECT id FROM claim` approved:

```
SELECT customer_rows() AS x                                APPROVED tables=[]
SELECT pg_read_file('/etc/passwd')                         APPROVED tables=[]
SELECT public.customer_rows() AS x                         APPROVED tables=[]
SELECT id FROM claim WHERE amount > (SELECT max_amount())  APPROVED
```

### The design

A whitelist — the inversion `unrecognised_source` already took for source shapes,
for the reason its docstring gives: enumerate dangerous functions and an unlisted
one passes, with every review round finding another nobody thought of.

It does **not** claim an unknown call is dangerous. It claims the decider cannot
tell, which makes its own premise false — so the honest verdict is that the query
cannot be decided.

### What I got wrong first, because it matters

The first version tested `isinstance(node, exp.Anonymous)` — which asks whether
the *one dialect being parsed* models the name. **Production parses as `duckdb`**;
sqlglot models `now` and `date_part` only under postgres. So it refused
`SELECT id FROM claim WHERE created_at < now()` on the shipped default: the
useless guard its own docstring said it must not be.

Its control test asserted the opposite while pinning `dialect="postgres"`, the
single dialect where the claim held — so nothing caught it. Every test is now
parametrised over both dialects, **duckdb first**, and restoring the old version
fails exactly those two controls.

The allowlist is now sqlglot's whole vocabulary across all 33 dialects (1004
names), from the parser tables and not just `Func.sql_names()` — the class names
alone are 623 and omit `now` and `date_part`, which is how it went wrong.

### Write path too

`decide_write` called `check_access` and not this guard, so the read fix left the
write path open. `UPDATE claim SET amount = pg_read_file(...)` and
`INSERT INTO claim SELECT customer_rows(), 1` were both `ApprovedWrite` with
`tables=['claim']` — and a write persists what it read into a table a later plain
`SELECT` returns forever (the M30 shape).

### Cost, measured under both dialects

26 of 459 SELECTs in this suite refuse, identical either way. 25 are attack
fixtures, cases another guard already refused, or SQL that never reaches the
decider. The single genuine casualty is Postgres `age()` — which is why
`UNMODELLED_CALL` is **repairable**: the loop rewrites it into arithmetic the
engine models, so a false positive costs an attempt rather than an answer.

### Known limit

Names are not identities: a UDF called `median` is modelled by sqlglot and passes.
715 of the 1004 allowlisted names are not DuckDB builtins, so the boundary is
sqlglot's vocabulary rather than the engine's. Disclosed in the docstring and
recorded; bounded by the same per-identity execution that dissolves M43 and M65
in v2. Tightening it would mean intersecting with the live source's catalogue
(`duckdb_functions()` and equivalents), which needs an adapter round-trip the
guard deliberately does not make today.

`1883 passed`. Verified by mutation: unwiring fails 5, degrading to a name
blocklist fails 4.