### PR TITLE
The control's docstring still described the guard's first version

### DIFF
--- a/tests/test_sql_authz_guard.py
+++ b/tests/test_sql_authz_guard.py
@@ -240,12 +240,20 @@ def test_an_opaque_call_cannot_be_decided(sql, dialect):
     "SELECT date_part('year', created_at) FROM claim",
 ])
 def test_a_modelled_call_is_untouched(sql, dialect):
-    """The degeneracy control, and it is the whole reason this is a whitelist rather than a
-    blocklist of names. sqlglot's typed function classes ARE the allowlist: sum, count, upper,
-    cast and date_trunc parse to Sum, Count, Upper, Cast and DateTrunc, so they never reach
-    this guard. `now()` is here because the lineage layer measured it as `Anonymous` on a bare
-    parse -- through the decider it is not, and a guard that refused `WHERE created_at < now()`
-    would be useless whatever it caught.
+    """The degeneracy control, and the reason this is a whitelist rather than a blocklist.
+
+    Two different things keep these approved, and conflating them is how the first version of
+    this guard shipped broken:
+
+      * sqlglot models the name IN THE DIALECT BEING PARSED, so it never becomes an
+        `exp.Anonymous` and the guard never sees it -- `sum`, `count`, `upper`, `cast`.
+      * it DOES become `Anonymous` and the cross-dialect allowlist lets it through by name --
+        `now()` and `date_part()` under duckdb, which sqlglot models only under postgres.
+
+    The second case is the one that matters here. The first version had no allowlist and tested
+    `isinstance(node, exp.Anonymous)`, so it refused `WHERE created_at < now()` on the
+    production dialect -- useless whatever else it caught -- while these tests, pinned to
+    postgres, said otherwise. Hence `_DIALECTS`, duckdb first.
     """
     assert not isinstance(_decide(sql, dialect), Refusal), f"{sql!r} refused under {dialect}"
 


### PR DESCRIPTION
Docstring-only. `test_a_modelled_call_is_untouched` still says "sqlglot's typed function classes ARE the allowlist" and that `now()` is not `Anonymous` through the decider.

Both were true of the version of this guard that shipped broken, and are false of the one that merged in #15: the allowlist is the cross-dialect **name** union, and `now()` under duckdb **is** `Anonymous` — it passes because the allowlist holds the name, which is precisely the case the allowlist was added for.

There are two distinct paths to approval and the docstring collapsed them:

| | mechanism |
|---|---|
| `sum`, `count`, `cast` | sqlglot models the name **in the parsed dialect** → never `Anonymous` → guard never sees it |
| `now()`, `date_part()` under duckdb | **is** `Anonymous` → allowed by name from the cross-dialect list |

Left as written, a maintainer concludes the cross-dialect allowlist is dead code — the whole content of #15's fix.

Third place I made this conflation; the register row and the decision record are corrected in `mnemiq-internal`.