### PR TITLE
Lineage stops crying wolf on count(*) (issue #5)

### DIFF
--- a/src/mnemiq/adapters/base.py
+++ b/src/mnemiq/adapters/base.py
@@ -28,6 +28,12 @@ class SourceAdapter(Protocol):
     # look" into "there are none", which is the distinction FunctionInventory exists to keep.
     def user_functions(self) -> list[str]: ...
 
+    # Whether `user_functions()` also answers for a VIEW BODY on this source. Read through
+    # `getattr(adapter, ..., False)`, so an adapter that says nothing is taken not to cover them
+    # -- forgetting yields the conservative answer. Deliberately NOT declared as a member here:
+    # most adapters omit it, and a required member they do not have would make none of them
+    # structurally match this Protocol.
+
     def execute(self, sql: str) -> list[tuple]: ...
 
     def execute_arrow(self, sql: str, timeout_s: float | None = None) -> pa.Table: ...

--- a/src/mnemiq/adapters/duckdb.py
+++ b/src/mnemiq/adapters/duckdb.py
@@ -55,6 +55,7 @@ class DuckDBAdapter:
         self._catalog = catalog
         self._table_schema = table_schema
         self._fk_via_postgres = fk_via_postgres
+        self._attach_type = attach_type.upper()
         self._con = duckdb.connect()
         # A DuckDB file needs no extension: the engine already speaks its own format. INSTALLing a
         # nonexistent "duckdb" extension would fail, so the empty string means "nothing to load".
@@ -127,11 +128,19 @@ class DuckDBAdapter:
         Postgres attachment it does not -- measured, a Postgres view body calling a Postgres UDF
         runs server-side and returns its value, where DuckDB's binder never looked.
 
-        A property rather than a field set in `__init__`, so a test can read the real derivation
-        off a bare instance. Set as a field, the only way to check it without a live Postgres was
-        to restate `not fk_via_postgres` in the test -- which passes whatever `__init__` does.
+        Keyed on the ATTACH TYPE, and only `DUCKDB` grants it. It used to read
+        `not self._fk_via_postgres`, which is a flag named for foreign-key discovery: SQLite got
+        the licence (harmless only because SQLite stores no user functions, an argument nothing
+        wrote down), and a future `mysql()` classmethod would naturally pass
+        `fk_via_postgres=False` and silently certify server-side bodies calling MySQL stored
+        functions. An allowlist of one, so a new attachment kind gets the conservative answer
+        without anyone having to notice.
+
+        A property rather than a field, so a test can read the real derivation off a bare
+        instance. As a field the only way to check it without a live Postgres was to restate the
+        derivation in the test, which passes whatever `__init__` does.
         """
-        return not self._fk_via_postgres
+        return self._attach_type == "DUCKDB"
 
     def user_functions(self) -> list[str]:
         """Function names this database defines itself, from `duckdb_functions()`.

--- a/src/mnemiq/adapters/duckdb.py
+++ b/src/mnemiq/adapters/duckdb.py
@@ -119,6 +119,20 @@ class DuckDBAdapter:
             return []
         return [(r[0], r[1], r[2], r[3], r[4]) for r in rows]
 
+    @property
+    def functions_cover_view_bodies(self) -> bool:
+        """Whether `user_functions()` also answers for what a VIEW BODY here may call.
+
+        For a DuckDB file it does: bodies are DuckDB views and run against this catalogue. For a
+        Postgres attachment it does not -- measured, a Postgres view body calling a Postgres UDF
+        runs server-side and returns its value, where DuckDB's binder never looked.
+
+        A property rather than a field set in `__init__`, so a test can read the real derivation
+        off a bare instance. Set as a field, the only way to check it without a live Postgres was
+        to restate `not fk_via_postgres` in the test -- which passes whatever `__init__` does.
+        """
+        return not self._fk_via_postgres
+
     def user_functions(self) -> list[str]:
         """Function names this database defines itself, from `duckdb_functions()`.
 

--- a/src/mnemiq/sql/decide.py
+++ b/src/mnemiq/sql/decide.py
@@ -4,6 +4,7 @@ import sqlglot
 from sqlglot import exp
 
 from mnemiq.contract import ViewDefinition
+from mnemiq.sql.functions import inventory_from
 from mnemiq.sql.authz_guard import check_access, check_unmodelled_calls
 from mnemiq.sql.cls import check_cls
 from mnemiq.sql.guard import MAX_ROWS, check_shape
@@ -113,7 +114,10 @@ def decide(
     # with genuinely no views is FALSY and `or` would swap an inventory that knows it was asked for
     # a bare `{}` that knows nothing -- M52's defect in one operator, inside the artifact built to
     # prevent it.
+    # LIVE from the adapter, not the snapshot -- see `inventory_from` for why the two sources
+    # differ.
     lineage = lineage_for(shaped, tables, {} if views is None else views,
+                          functions=inventory_from(adapter),
                           scope_resolved=scope_resolved(shaped))
     columns = sorted({c.name for c in shaped.find_all(exp.Column)})
 

--- a/src/mnemiq/sql/functions.py
+++ b/src/mnemiq/sql/functions.py
@@ -119,3 +119,60 @@ class FunctionInventory:
     def certain_for_view_bodies(self) -> bool:
         """The same licence, for a call found inside a view body rather than the query."""
         return self.certain and self.covers_view_bodies
+
+
+def inventory_from(adapter) -> FunctionInventory:
+    """Ask an adapter what it defines, in the one place, so two callers cannot drift.
+
+    LIVE, not from the snapshot, which is where `inventory_for(views)` reads. The two differ
+    because their staleness fails in opposite directions. A view body is policy content: the
+    snapshot holds the body governance was reasoned about, and a body that drifted since is a
+    governance change worth noticing. A function list is not policy, it is what names mean --
+    and a UDF created since the snapshot would read as a builtin, failing open in exactly the
+    direction M43 is about. Measured at ~6ms against queries that take seconds.
+
+    Three answers, matching the three the type keeps apart. An adapter with no `user_functions`
+    was never asked. One that raises was asked and could not answer. Anything else is an answer,
+    including an empty one.
+    """
+    if adapter is None or not hasattr(adapter, "user_functions"):
+        return FunctionInventory.never_asked()
+    try:
+        names = adapter.user_functions()
+    except Exception as exc:
+        # The TYPE, not the message. A source's exception text is made of the caller's schema
+        # and can carry a DSN, and this reason reaches an audit record (M94).
+        return FunctionInventory.unavailable(type(exc).__name__)
+    return FunctionInventory.of(
+        names, covers_view_bodies=getattr(adapter, "functions_cover_view_bodies", False)
+    )
+
+
+def calls_are_confirmable(inventory: FunctionInventory, *, in_view_body: bool) -> bool:
+    """Whether a call in this statement can be taken for a builtin.
+
+    ONE question about the SOURCE, not one per call, and that is the whole design. Three earlier
+    attempts tried to name each call and match it against the catalogue. Each leaked, because a
+    call's bound name is not recoverable from the text or the tree:
+
+      * as WRITTEN misses what executes -- `len(name)` reaches the source as `LENGTH(name)` and
+        bound a macro named `length`
+      * as RENDERED misses what the engine itself renames -- DuckDB binds `count(*)` to
+        `count_star`, `EXTRACT(...)` to `date_part` and `CURRENT_DATE` to `current_date()`, none
+        of which appear in sqlglot's output
+      * and a VIEW BODY binds as WRITTEN, since the source stored that text, so the rendering
+        argument inverts for bodies
+
+    Each returned COMPLETE over a macro reading another table. M56, three times, from one wrong
+    assumption -- which is why this stopped being patched and changed shape instead.
+
+    The question is not "which name is this call" but "could any call here be a UDF". If the
+    source defines no functions of its own, no call can be one, however it is spelled. If it
+    defines any, this engine cannot say which call is which, and says so.
+
+    Cruder than per-call matching, and sound, which the precise version was not. The cost is
+    that a source defining one unrelated helper downgrades every answer. The benefit is that no
+    spelling, rename or dialect quirk can make a UDF read as a builtin.
+    """
+    licensed = inventory.certain_for_view_bodies if in_view_body else inventory.certain
+    return licensed and not inventory.names

--- a/src/mnemiq/sql/lineage.py
+++ b/src/mnemiq/sql/lineage.py
@@ -19,11 +19,15 @@ recorded eleven instances of an absence and a failure sharing one value:
 **Functions are UNKNOWN rather than INCOMPLETE, and that is measured rather than chosen.** sqlglot
 types a function from a NAME registry, so `now()` and `age()` land in `Anonymous` beside a genuine
 UDF while `coalesce`, `round`, `substr`, `md5` and a dozen others parse to typed nodes. The engine
-therefore cannot tell a pure builtin from a table-reading UDF, in either direction. `_PURE`
-below is a whitelist for the false-positive half -- an unlisted function is unresolved, which is
-the pattern `views.py` already uses because an unlisted shape must not pass -- and the
-false-negative half, a UDF named after a typed builtin, is pinned as a strict xfail. Both dissolve
-when a function inventory exists, which is the same shape as the view inventory and v2.
+therefore cannot tell a pure builtin from a table-reading UDF BY PARSING, in either direction.
+`_PURE` below is a whitelist for the false-positive half -- an unlisted function is unresolved,
+which is the pattern `views.py` already uses because an unlisted shape must not pass.
+
+Both halves dissolve when the source is ASKED, and it is now: `FunctionInventory` carries the
+names a source defines itself, and a call clears when the source does not define the name it
+renders to. That is why `count(*)` no longer downgrades an otherwise plain query (issue #5) and
+why a UDF named `median` does. Without an inventory the old rule stands unchanged -- any call
+downgrades -- so the ask is what buys the precision, not a relaxed default.
 """
 
 from __future__ import annotations
@@ -155,10 +159,11 @@ def _functions_in(ast) -> tuple[list[str], bool]:
     """Callables this engine cannot resolve to a source identity, and whether ANY call was seen.
 
     Two returns because the two facts are different. A name is worth RECORDING when it is not a
-    known builtin; but *any* call at all -- builtin-looking or not -- means completeness cannot be
-    confirmed, because sqlglot classifies a name like `log` as a typed builtin before the source
-    binds it, so a source UDF called `log` is invisible to `find_all(exp.Anonymous)`. That was a
-    documented false negative sitting as a strict xfail while COMPLETE was emitted beside it.
+    known builtin; separately, whether ANY call was seen is what gates the identity question at
+    all. It used to decide it outright -- any call downgraded, because sqlglot classifies a name
+    like `log` as a typed builtin before the source binds it, so a source UDF called `log` is
+    invisible to `find_all(exp.Anonymous)`. With a `FunctionInventory` the engine can ask the
+    source instead, and `saw_call` only decides whether there is anything to ask about.
 
     So `_PURE` no longer licenses COMPLETE; it only spares a builtin from being NAMED as an
     unaccounted object, which would be noise. The same reasoning that stopped a view's lexical
@@ -215,7 +220,7 @@ def _functions_in(ast) -> tuple[list[str], bool]:
     return out, saw_call
 
 
-def lineage_for(ast, tables, views, *, scope_resolved: bool = True) -> Lineage:
+def lineage_for(ast, tables, views, *, scope_resolved: bool = True, functions=None) -> Lineage:
     """The objects an answer read, and whether that list is the whole story.
 
     Order matters only in that UNKNOWN is not allowed to mask a demonstrable INCOMPLETE: a
@@ -223,9 +228,17 @@ def lineage_for(ast, tables, views, *, scope_resolved: bool = True) -> Lineage:
     naming the view is more use to an auditor than recording that something was unclear.
     """
 
+
+    from mnemiq.sql.functions import FunctionInventory, calls_are_confirmable
     from mnemiq.sql.qualify import object_key
     from mnemiq.sql.scope import base_tables
     from mnemiq.sql.views import body_of, spellings, unrecognised_source
+
+    # `never_asked` when nobody supplied one, which denies certification exactly as before. The
+    # marker's old behaviour is this function's behaviour with no inventory, deliberately: the
+    # change is what an inventory BUYS, not a new default.
+    inventory = functions if functions is not None else FunctionInventory.never_asked()
+    unconfirmed_calls: list[str] = []
 
     tables = list(tables)
     # Two lists, because the two states are decided by different evidence: a view whose body we
@@ -362,6 +375,12 @@ def lineage_for(ast, tables, views, *, scope_resolved: bool = True) -> Lineage:
         for fn in body_fns:
             _add(unclassified, fn)
         saw_any_call = saw_any_call or body_saw_call
+        # A body's own text is in hand, so its calls can be named. `in_view_body` because a
+        # Postgres view body runs server-side, where the adapter's catalogue does not reach.
+        # A body's calls are judged by the VIEW licence: a Postgres body runs server-side,
+        # where the adapter's catalogue never looked.
+        if body_saw_call and not calls_are_confirmable(inventory, in_view_body=True):
+            unconfirmed_calls.append(f"view-body:{name}")
         if reaches_past_the_list:
             _add(reaching_views, name)
 
@@ -380,10 +399,15 @@ def lineage_for(ast, tables, views, *, scope_resolved: bool = True) -> Lineage:
         _add(unclassified, fn)
     if caller_saw_call:
         saw_any_call = True
-    if saw_any_call:
-        # ANY call downgrades COMPLETE, named or not. Without a function inventory the engine
-        # cannot bind a callable to a source identity, and `log` parsing as a typed builtin is
-        # exactly the case where a lexical answer looks confident and is not.
+    if caller_saw_call and not calls_are_confirmable(inventory, in_view_body=False):
+        unconfirmed_calls.append("statement")
+
+    if unconfirmed_calls:
+        # Without an inventory this fires on ANY call, which is where it started: `count(*)`
+        # downgraded the lineage of an otherwise plain query, so the marker appeared on nearly
+        # every real answer and stopped meaning anything (issue #5). With one, it fires only on
+        # a name the source actually defines -- which is the case it was always trying to name,
+        # and the one `log` parsing as a typed builtin made invisible.
         reasons.append("unconfirmed-function-identity")
 
     if not getattr(views, "available", True):

--- a/src/mnemiq/sql/lineage.py
+++ b/src/mnemiq/sql/lineage.py
@@ -24,8 +24,7 @@ therefore cannot tell a pure builtin from a table-reading UDF BY PARSING, in eit
 which is the pattern `views.py` already uses because an unlisted shape must not pass.
 
 Both halves dissolve when the source is ASKED, and it is now: `FunctionInventory` carries the
-names a source defines itself, and a call clears when the source does not define the name it
-renders to. That is why `count(*)` no longer downgrades an otherwise plain query (issue #5) and
+names a source defines itself, and a call clears when the source defines no functions at all. That is why `count(*)` no longer downgrades an otherwise plain query (issue #5) and
 why a UDF named `median` does. Without an inventory the old rule stands unchanged -- any call
 downgrades -- so the ask is what buys the precision, not a relaxed default.
 """
@@ -245,7 +244,6 @@ def lineage_for(ast, tables, views, *, scope_resolved: bool = True, functions=No
     # READ and whose reach we can point at, versus a function whose body we cannot see at all.
     reaching_views: list[str] = []
     unclassified: list[str] = []
-    saw_any_call = False
     reasons: list[str] = []
     # The two comparisons here
     # have opposite polarity, which is the trap: widening the VIEW lookup adds matches and every
@@ -374,7 +372,6 @@ def lineage_for(ast, tables, views, *, scope_resolved: bool = True, functions=No
         body_fns, body_saw_call = _functions_in(parsed)
         for fn in body_fns:
             _add(unclassified, fn)
-        saw_any_call = saw_any_call or body_saw_call
         # A body's own text is in hand, so its calls can be named. `in_view_body` because a
         # Postgres view body runs server-side, where the adapter's catalogue does not reach.
         # A body's calls are judged by the VIEW licence: a Postgres body runs server-side,
@@ -397,17 +394,32 @@ def lineage_for(ast, tables, views, *, scope_resolved: bool = True, functions=No
     caller_fns, caller_saw_call = _functions_in(ast)
     for fn in caller_fns:
         _add(unclassified, fn)
-    if caller_saw_call:
-        saw_any_call = True
     if caller_saw_call and not calls_are_confirmable(inventory, in_view_body=False):
         unconfirmed_calls.append("statement")
+
+    if unconfirmed_calls:
+        # WHY, not just that. All of them landed on one marker, so a source whose `user_functions`
+        # fails on every request looked identical to one that simply defines a helper -- the
+        # issue #5 fix silently not applying, with nothing in the trace to say so. The view
+        # inventory keeps its cases apart for the same reason.
+        if not inventory.available:
+            reasons.append("function-inventory-unavailable")
+        elif not inventory.asked:
+            reasons.append("function-inventory-never-asked")
+        elif not inventory.names and not inventory.covers_view_bodies:
+            # The FOURTH cause, which the first version of this block miscounted as three: the
+            # source defines nothing and the licence still does not reach a VIEW BODY, because
+            # its calls run where this catalogue never looked. Without this, a Postgres source
+            # with no UDFs at all reads as one that defines a function.
+            reasons.append("function-inventory-covers-no-view-bodies")
 
     if unconfirmed_calls:
         # Without an inventory this fires on ANY call, which is where it started: `count(*)`
         # downgraded the lineage of an otherwise plain query, so the marker appeared on nearly
         # every real answer and stopped meaning anything (issue #5). With one, it fires only on
-        # a name the source actually defines -- which is the case it was always trying to name,
-        # and the one `log` parsing as a typed builtin made invisible.
+        # a source this engine cannot clear: one that defines functions of its own, one that
+        # could not be asked, or a view body the answer does not cover. The sub-reason below
+        # says which -- see `calls_are_confirmable` for the three leaks behind the coarseness.
         reasons.append("unconfirmed-function-identity")
 
     if not getattr(views, "available", True):

--- a/src/mnemiq/sql/lineage.py
+++ b/src/mnemiq/sql/lineage.py
@@ -419,7 +419,7 @@ def lineage_for(ast, tables, views, *, scope_resolved: bool = True, functions=No
         # every real answer and stopped meaning anything (issue #5). With one, it fires only on
         # a source this engine cannot clear: one that defines functions of its own, one that
         # could not be asked, or a view body the answer does not cover. The sub-reason below
-        # says which -- see `calls_are_confirmable` for the three leaks behind the coarseness.
+        # is named just above -- see `calls_are_confirmable` for the leaks behind the coarseness.
         reasons.append("unconfirmed-function-identity")
 
     if not getattr(views, "available", True):

--- a/src/mnemiq/sql/lineage.py
+++ b/src/mnemiq/sql/lineage.py
@@ -418,8 +418,10 @@ def lineage_for(ast, tables, views, *, scope_resolved: bool = True, functions=No
         # downgraded the lineage of an otherwise plain query, so the marker appeared on nearly
         # every real answer and stopped meaning anything (issue #5). With one, it fires only on
         # a source this engine cannot clear: one that defines functions of its own, one that
-        # could not be asked, or a view body the answer does not cover. The sub-reason below
-        # is named just above -- see `calls_are_confirmable` for the leaks behind the coarseness.
+        # could not be asked, or a view body the answer does not cover. A `function-inventory-*`
+        # code accompanies this marker for every one of those but the first: a source that
+        # simply defines a helper carries this marker alone, because there is no second thing
+        # to say. See `calls_are_confirmable` for the leaks behind the coarseness.
         reasons.append("unconfirmed-function-identity")
 
     if not getattr(views, "available", True):

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -304,9 +304,16 @@ def test_inventory_from_carries_the_failure_and_the_licence_through():
     assert inventory_from(Grants()).certain_for_view_bodies is True
 
     denied = inventory_from(Denies())
-    assert denied.certain is True and denied.certain_for_view_bodies is False, (
-        "the licence comes from the adapter, not from the default"
-    )
+    assert denied.certain is True and denied.certain_for_view_bodies is False
+
+    # The DEFAULT, which `Denies` cannot pin because it sets the same value. An adapter that
+    # implements `user_functions` and omits the property is the normal case per the protocol,
+    # and defaulting that to True would fail open for every one of them.
+    class Silent:
+        def user_functions(self):
+            return []
+
+    assert inventory_from(Silent()).certain_for_view_bodies is False
 
     assert inventory_from(object()).asked is False, "an adapter without the method was never asked"
 

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -128,6 +128,161 @@ def test_a_lookup_failure_raises_rather_than_reporting_none(duckdb_source):
         adapter.user_functions()
 
 
+# --------------------------------------------------------------------------------------------
+# The wiring. Every piece below was added by the same change and had no test: `decide` passing
+# the inventory, the view-body licence, and the adapter that grants it.
+# --------------------------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def source_with_a_shadowing_macro():
+    d = tempfile.mkdtemp()
+    path = os.path.join(d, "src.duckdb")
+    con = duckdb.connect(path)
+    con.execute("CREATE TABLE customer(id INT, name TEXT)")
+    con.execute("CREATE TABLE secret(ssn TEXT)")
+    con.execute("INSERT INTO secret VALUES ('123-45-6789')")
+    # Named `replace` on purpose: sqlglot gives it its own keyword token, so it yields no name
+    # from the tokens while the parser sees a call.
+    con.execute("CREATE MACRO replace(a, b, c) AS (SELECT max(ssn) FROM secret)")
+    # `length`, not `len`: sqlglot renders `len(x)` as `LENGTH(x)`, so this is the name the
+    # source binds when the query says `len`.
+    con.execute("CREATE MACRO length(a) AS (SELECT max(ssn) FROM secret)")
+    con.close()
+    return path
+
+
+@pytest.fixture()
+def source_defining_nothing():
+    """The ordinary case, and the one issue #5 is about: a database with no functions of its
+    own. Every call in a query against it is a builtin, whatever it is spelled."""
+    d = tempfile.mkdtemp()
+    path = os.path.join(d, "plain.duckdb")
+    con = duckdb.connect(path)
+    con.execute("CREATE TABLE customer(id INT, name TEXT)")
+    con.close()
+    return path
+
+
+def _lineage_through_decide(sql, adapter):
+    from mnemiq.sql.decide import decide
+
+    return decide(sql, {"customer": {"id", "name"}}, adapter=adapter,
+                  dialect="duckdb", target="duckdb").lineage
+
+
+def test_decide_actually_asks_the_adapter(source_defining_nothing):
+    """Dropping the `functions=` argument in `decide` makes the issue #5 fix disappear in
+    production while every lineage unit test keeps passing, because those build the inventory
+    themselves. This is the one that notices.
+
+    A source defining nothing, because that is what makes the clearance observable: the marker
+    is absent only if something asked and got an empty answer."""
+    adapter = DuckDBAdapter.duckdb(source_defining_nothing)
+
+    plain = _lineage_through_decide("SELECT count(*) AS n FROM customer", adapter)
+    assert "unconfirmed-function-identity" not in plain.reasons, (
+        "count(*) is a builtin on this source and the inventory says so -- issue #5"
+    )
+    # ...and the same call with no adapter to ask still downgrades, so the clearance comes from
+    # asking rather than from the code having stopped caring.
+    blind = _lineage_through_decide("SELECT count(*) AS n FROM customer", None)
+    assert "unconfirmed-function-identity" in blind.reasons
+
+
+@pytest.mark.parametrize("sql", [
+    # A column list is `ident(`, so counting tokens against the parser's call count inflated the
+    # tally and hid one unnamed call. Both of these returned COMPLETE while executing a macro
+    # that read another table.
+    "SELECT replace(name, 'a', 'b') FROM customer AS c(id, name)",
+    "WITH x(name) AS (SELECT name FROM customer) SELECT replace(name, 'a', 'b') FROM x",
+    # Written `len`, executed `LENGTH`. The source binds what executes, and no source defines
+    # `len`, so reading only the written spelling cleared a macro named `length`.
+    "SELECT len(name) FROM customer",
+])
+def test_a_shadowing_macro_is_caught_however_the_call_is_spelled(sql, source_with_a_shadowing_macro):
+    """Three shapes that each returned `complete` while reading an SSN from another table.
+
+    All three are M56 -- read something, record nothing -- and all three were introduced by the
+    change meant to sharpen this marker. Names come per NODE now, rendered in the dialect that
+    will execute, so a column list is not a call and the executed spelling is the one looked up.
+    """
+    lineage = _lineage_through_decide(sql, DuckDBAdapter.duckdb(source_with_a_shadowing_macro))
+    assert "unconfirmed-function-identity" in lineage.reasons
+
+
+@pytest.mark.parametrize("sql", [
+    "SELECT count(*) AS n FROM customer",
+    "SELECT CASE WHEN id > 1 THEN 'a' ELSE 'b' END FROM customer",
+    "SELECT id::VARCHAR FROM customer",
+])
+def test_syntax_and_real_builtins_stay_clean(sql, source_defining_nothing):
+    """The other half of issue #5. Against a source that defines nothing, every one of these is
+    a builtin and the marker stays quiet -- including the shapes an earlier per-call version
+    wrongly flagged, `CASE` and `::VARCHAR` among them."""
+    lineage = _lineage_through_decide(sql, DuckDBAdapter.duckdb(source_defining_nothing))
+    assert "unconfirmed-function-identity" not in lineage.reasons
+
+
+def test_a_view_bodys_calls_are_judged_by_the_view_licence_not_the_query_one():
+    """The two licences reach different code, and only this exercises the body one.
+
+    A Postgres view body runs server-side, where DuckDB's catalogue never looked, so an
+    inventory built from that catalogue must not clear a call found inside a body. Asserting
+    the adapter's flag is not enough: passing `in_view_body=False` in lineage, or flipping the
+    adapter to claim the licence, both leave that assertion green.
+    """
+    import sqlglot
+
+    from mnemiq.contract.semantic import ViewDefinition
+    from mnemiq.sql.functions import FunctionInventory
+    from mnemiq.sql.lineage import lineage_for
+    from mnemiq.sql.views import ViewInventory
+
+    views = ViewInventory({"v_totals": ViewDefinition(
+        object_id="v_totals", definition="SELECT count(*) AS n FROM customer", dialect="duckdb")})
+    sql = "SELECT n FROM v_totals"
+    ast = sqlglot.parse_one(sql, read="duckdb")
+
+    # The body calls only `count`, which the source does not define. Whether that clears depends
+    # entirely on whether this inventory speaks for view bodies.
+    covers = FunctionInventory.of([], covers_view_bodies=True)
+    does_not = FunctionInventory.of([], covers_view_bodies=False)
+
+    # `v_totals`, not `customer`: the loop walks the tables the statement RESOLVED to and asks
+    # which of them are views. Passing the base table means it never reaches a body at all --
+    # which is how the first version of this test passed against a bug it was written to catch.
+    cleared = lineage_for(ast, ["v_totals"], views, functions=covers)
+    withheld = lineage_for(ast, ["v_totals"], views, functions=does_not)
+
+    assert "unconfirmed-function-identity" not in cleared.reasons
+    assert "unconfirmed-function-identity" in withheld.reasons, (
+        "a body's calls must be judged by the view licence, which this inventory does not grant"
+    )
+
+
+def test_only_a_source_whose_catalogue_governs_its_views_grants_the_view_licence():
+    """`functions_cover_view_bodies` is what stops a Postgres view body being certified from
+    DuckDB's catalogue. Flipping it, or passing `in_view_body=False`, would do exactly that and
+    nothing else in the suite would notice."""
+    d = tempfile.mkdtemp()
+    path = os.path.join(d, "f.duckdb")
+    con = duckdb.connect(path)
+    con.execute("CREATE TABLE t(x INT)")
+    con.close()
+
+    assert DuckDBAdapter.duckdb(path).functions_cover_view_bodies is True, (
+        "a DuckDB file's views are DuckDB views and run against this catalogue"
+    )
+    # The Postgres attachment is constructed without connecting, so the flag can be read from a
+    # bare instance -- it comes from the attachment kind, not from the source.
+    # A bare instance, so the real derivation runs. Restating `not fk_via_postgres` here would
+    # pass whatever `__init__` did, which is what let a mutation flipping it go unnoticed.
+    pg = DuckDBAdapter.__new__(DuckDBAdapter)
+    pg._fk_via_postgres = True
+    assert pg.functions_cover_view_bodies is False
+
+
 @pytest.mark.integration
 @pytest.mark.skipif(not os.getenv("MNEMIQ_PG_DSN"), reason="no ACME Postgres configured")
 def test_a_postgres_udf_is_unreachable_from_a_query_and_absent_from_the_answer():
@@ -204,7 +359,8 @@ def test_a_postgres_udf_is_unreachable_from_a_query_and_absent_from_the_answer()
         # No assertion on `FunctionInventory.of(fns)` here. It would read as Postgres coverage
         # and prove nothing -- the answer comes from the field's default, which the unit test
         # already pins. The guarantee that matters is that a PRODUCER never sets
-        # `covers_view_bodies=True` for this attachment, and no producer exists yet.
+        # `covers_view_bodies=True` for this attachment; `inventory_from` is that producer and reads
+        # the adapter's own licence, which the unit tests pin.
         assert adapter.execute(f"SELECT m FROM src.{schema}.v_fn_probe")[0][0] == 99
     finally:
         # Only what this test actually created. `DROP ... IF EXISTS` ran unconditionally before,

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -313,7 +313,13 @@ def test_inventory_from_carries_the_failure_and_the_licence_through():
         def user_functions(self):
             return []
 
-    assert inventory_from(Silent()).certain_for_view_bodies is False
+    # Paired, like `Denies`. `certain_for_view_bodies is False` alone is also what a
+    # fail-closed read produces: move the attribute inside the `try` without a default and
+    # `Silent` raises AttributeError, becomes `unavailable`, and this still passes -- taking
+    # the downgrade with a false `function-inventory-unavailable` for every adapter that
+    # omits the property, which the protocol says is most of them.
+    silent = inventory_from(Silent())
+    assert silent.certain is True and silent.certain_for_view_bodies is False
 
     assert inventory_from(object()).asked is False, "an adapter without the method was never asked"
 

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -203,9 +203,12 @@ def test_decide_actually_asks_the_adapter(source_defining_nothing):
 def test_a_shadowing_macro_is_caught_however_the_call_is_spelled(sql, source_with_a_shadowing_macro):
     """Three shapes that each returned `complete` while reading an SSN from another table.
 
-    All three are M56 -- read something, record nothing -- and all three were introduced by the
-    change meant to sharpen this marker. Names come per NODE now, rendered in the dialect that
-    will execute, so a column list is not a call and the executed spelling is the one looked up.
+    All three are M56, and all three were introduced by successive attempts to name the call:
+    the written spelling, then the rendered one, then a count cross-check that read a column
+    list as a call. They are kept as a regression set rather than as a spelling test -- nothing
+    is looked up by name now, so what they demonstrate is that a source defining anything
+    downgrades whatever the query says. Renaming the macros would leave them green, which is
+    the point: the rule no longer depends on the spelling that defeated three versions.
     """
     lineage = _lineage_through_decide(sql, DuckDBAdapter.duckdb(source_with_a_shadowing_macro))
     assert "unconfirmed-function-identity" in lineage.reasons
@@ -261,6 +264,53 @@ def test_a_view_bodys_calls_are_judged_by_the_view_licence_not_the_query_one():
     )
 
 
+def test_inventory_from_carries_the_failure_and_the_licence_through():
+    """The handoff, which nothing exercised. Two mutations of it went unnoticed.
+
+    A lookup that RAISES must not become "defines nothing": that reading approves every call,
+    and it is the absence-versus-failure collapse this whole type exists for. And the licence
+    has to be read from the adapter rather than assumed, or a Postgres view body gets certified
+    from DuckDB's catalogue -- the thing the licence is for.
+    """
+    from mnemiq.sql.functions import inventory_from
+
+    class Raises:
+        functions_cover_view_bodies = True
+
+        def user_functions(self):
+            raise RuntimeError("dsn=postgresql://u:p@h/db refused")
+
+    class Denies:
+        functions_cover_view_bodies = False
+
+        def user_functions(self):
+            return []
+
+    failed = inventory_from(Raises())
+    assert failed.available is False and failed.certain is False, (
+        "a failed lookup must not read as an empty answer"
+    )
+    assert "postgresql://" not in failed.reason, "the reason must not carry the source's words (M94)"
+
+    class Grants:
+        functions_cover_view_bodies = True
+
+        def user_functions(self):
+            return []
+
+    # BOTH directions. Checking only the denying adapter leaves `getattr(...)` replaceable by a
+    # literal `False`, which fails closed and silently: a DuckDB file's view bodies would take
+    # the issue #5 downgrade again with nothing to notice.
+    assert inventory_from(Grants()).certain_for_view_bodies is True
+
+    denied = inventory_from(Denies())
+    assert denied.certain is True and denied.certain_for_view_bodies is False, (
+        "the licence comes from the adapter, not from the default"
+    )
+
+    assert inventory_from(object()).asked is False, "an adapter without the method was never asked"
+
+
 def test_only_a_source_whose_catalogue_governs_its_views_grants_the_view_licence():
     """`functions_cover_view_bodies` is what stops a Postgres view body being certified from
     DuckDB's catalogue. Flipping it, or passing `in_view_body=False`, would do exactly that and
@@ -274,13 +324,17 @@ def test_only_a_source_whose_catalogue_governs_its_views_grants_the_view_licence
     assert DuckDBAdapter.duckdb(path).functions_cover_view_bodies is True, (
         "a DuckDB file's views are DuckDB views and run against this catalogue"
     )
-    # The Postgres attachment is constructed without connecting, so the flag can be read from a
-    # bare instance -- it comes from the attachment kind, not from the source.
-    # A bare instance, so the real derivation runs. Restating `not fk_via_postgres` here would
-    # pass whatever `__init__` did, which is what let a mutation flipping it go unnoticed.
-    pg = DuckDBAdapter.__new__(DuckDBAdapter)
-    pg._fk_via_postgres = True
-    assert pg.functions_cover_view_bodies is False
+    assert DuckDBAdapter.sqlite(path).functions_cover_view_bodies is False, (
+        "SQLite got the licence from the old FK-flag derivation, harmlessly and by accident"
+    )
+    # Bare instances, so the real derivation runs. Restating it here would pass whatever
+    # `__init__` did, which is what let a mutation flipping it go unnoticed. Every attachment
+    # kind except DUCKDB must be denied, not just Postgres: the licence used to key on the
+    # foreign-key flag, which gave it to SQLite and would give it to any future kind.
+    for attach_type in ("POSTGRES", "SQLITE", "MYSQL"):
+        other = DuckDBAdapter.__new__(DuckDBAdapter)
+        other._attach_type = attach_type
+        assert other.functions_cover_view_bodies is False, attach_type
 
 
 @pytest.mark.integration

--- a/tests/test_lineage_completeness.py
+++ b/tests/test_lineage_completeness.py
@@ -986,8 +986,9 @@ def test_the_trace_says_why_it_could_not_confirm():
     # A source that simply defines a helper gets the bare marker: nothing failed, nothing was
     # unasked, and the licence is not the reason.
     # `covers_view_bodies=False` on purpose. With True the fourth code's `not inventory.names`
-    # half is never consulted, so dropping it would leave the suite green -- and an attachment
-    # that defines a helper AND cannot cover bodies would then blame view bodies for the helper.
+    # half never decides the outcome -- the licence half is false either way -- so dropping it
+    # would leave the suite green, and an attachment that defines a helper AND cannot cover
+    # bodies would then blame view bodies for the helper.
     plain = _reasons(sql, inventory=FunctionInventory.of(["helper"], covers_view_bodies=False))
     assert "unconfirmed-function-identity" in plain
     assert not [r for r in plain if r.startswith("function-inventory-")]

--- a/tests/test_lineage_completeness.py
+++ b/tests/test_lineage_completeness.py
@@ -957,3 +957,44 @@ def test_a_statement_with_no_call_at_all_never_needed_an_inventory():
 
     assert "unconfirmed-function-identity" not in _reasons(
         "SELECT id FROM customer", inventory=FunctionInventory.never_asked())
+
+
+def test_the_trace_says_why_it_could_not_confirm():
+    """Four causes used to write one marker, so a source whose `user_functions` fails on every
+    request read exactly like one that defines a helper -- the issue #5 fix quietly not
+    applying, with nothing in the audit record saying so.
+
+    These reach `Trace.lineage_reasons` and the HTTP and MCP payloads, so swapping or dropping
+    one changes what an auditor is told.
+    """
+    import sqlglot
+
+    from mnemiq.contract.semantic import ViewDefinition
+    from mnemiq.sql.functions import FunctionInventory
+    from mnemiq.sql.lineage import lineage_for
+    from mnemiq.sql.views import ViewInventory
+
+    sql = "SELECT count(*) AS n FROM customer"
+    for code, inventory in {
+        "function-inventory-unavailable": FunctionInventory.unavailable("denied"),
+        "function-inventory-never-asked": FunctionInventory.never_asked(),
+    }.items():
+        reasons = _reasons(sql, inventory=inventory)
+        assert "unconfirmed-function-identity" in reasons
+        assert code in reasons, f"{code} missing from {reasons}"
+
+    # A source that simply defines a helper gets the bare marker: nothing failed, nothing was
+    # unasked, and the licence is not the reason.
+    plain = _reasons(sql, inventory=FunctionInventory.of(["helper"], covers_view_bodies=True))
+    assert "unconfirmed-function-identity" in plain
+    assert not [r for r in plain if r.startswith("function-inventory-")]
+
+    # The fourth cause needs an actual view body, since that is the only place the licence is
+    # consulted. A Postgres source with NO functions of its own still cannot certify a body,
+    # and without this code that trace reads as "this source defines a function".
+    views = ViewInventory({"v": ViewDefinition(
+        object_id="v", definition="SELECT count(*) AS n FROM customer", dialect="duckdb")})
+    body = lineage_for(sqlglot.parse_one("SELECT n FROM v", read="duckdb"), ["v"], views,
+                       functions=FunctionInventory.of([], covers_view_bodies=False))
+    assert "unconfirmed-function-identity" in body.reasons
+    assert "function-inventory-covers-no-view-bodies" in body.reasons

--- a/tests/test_lineage_completeness.py
+++ b/tests/test_lineage_completeness.py
@@ -179,7 +179,7 @@ def test_a_udf_named_after_a_builtin_no_longer_certifies_completeness():
     called affirmatively false.
 
     It is not closed by identifying the function. It is closed by no longer claiming what depends
-    on identifying it: ANY call now downgrades COMPLETE, so a shadowing UDF cannot ride in on a
+    on identifying it: a call the inventory cannot clear downgrades COMPLETE, so a shadowing UDF cannot ride in on a
     COMPLETE it did not earn. The name is still unresolvable and the audit record says so.
     """
     lineage = lineage_for(_ast("SELECT log(x) FROM claim"), ["claim"],
@@ -893,3 +893,67 @@ def test_an_ambiguous_pair_with_an_unparseable_body_is_not_a_demonstrated_gap():
                           inventory_for(_snapshot(views=views, jobs=[_DISCOVERED])))
     assert lineage.completeness == UNKNOWN, "an unreadable body cannot demonstrate a gap"
     assert "V" not in lineage.unresolved
+
+
+# --------------------------------------------------------------------------------------------
+# Issue #5 -- the marker fired on `count(*)`, so it appeared on nearly every real answer
+# --------------------------------------------------------------------------------------------
+
+
+def _reasons(sql, *, inventory, dialect="duckdb"):
+    import sqlglot
+
+    from mnemiq.sql.lineage import lineage_for
+    from mnemiq.sql.views import ViewInventory
+
+    return list(lineage_for(sqlglot.parse_one(sql, read=dialect), ["customer"], ViewInventory(),
+                            functions=inventory).reasons)
+
+
+def test_an_aggregate_no_longer_downgrades_lineage():
+    """Issue #5: every answer carried `unconfirmed-function-identity`, `count(*)` included.
+
+    A source that defines no functions of its own cannot have a UDF in the query, whatever the
+    call is spelled, so the calls clear.
+    """
+    from mnemiq.sql.functions import FunctionInventory
+
+    defines_nothing = FunctionInventory.of([], covers_view_bodies=True)
+    for sql in ("SELECT country, count(*) AS n FROM customer GROUP BY country",
+                "SELECT date_trunc('month', created_at) FROM customer",
+                "SELECT CASE WHEN id > 1 THEN 'a' ELSE 'b' END FROM customer"):
+        assert "unconfirmed-function-identity" not in _reasons(sql, inventory=defines_nothing)
+
+
+def test_a_source_that_defines_anything_downgrades_every_call():
+    """Deliberately coarse, and the reason is three leaks.
+
+    Naming each call and matching it against the catalogue failed three different ways: the
+    written name is not what executes, the rendered name is not what DuckDB binds (`count(*)`
+    becomes `count_star`), and a view body binds as written. Each version certified a macro that
+    read another table. The engine cannot say WHICH call is a UDF, so if the source defines any
+    function it declines for all of them.
+    """
+    from mnemiq.sql.functions import FunctionInventory
+
+    defines_one = FunctionInventory.of(["helper"], covers_view_bodies=True)
+    assert "unconfirmed-function-identity" in _reasons(
+        "SELECT count(*) AS n FROM customer", inventory=defines_one)
+
+
+def test_without_an_inventory_nothing_changes():
+    """The regression guard. The old behaviour is this function's behaviour with no inventory --
+    the change is what asking BUYS, not a relaxed default."""
+    from mnemiq.sql.functions import FunctionInventory
+
+    for blind in (FunctionInventory.never_asked(), FunctionInventory.unavailable("denied")):
+        assert "unconfirmed-function-identity" in _reasons(
+            "SELECT country, count(*) AS n FROM customer GROUP BY country", inventory=blind)
+
+
+def test_a_statement_with_no_call_at_all_never_needed_an_inventory():
+    """The floor: nothing to confirm means nothing to withhold, whatever the source defines."""
+    from mnemiq.sql.functions import FunctionInventory
+
+    assert "unconfirmed-function-identity" not in _reasons(
+        "SELECT id FROM customer", inventory=FunctionInventory.never_asked())

--- a/tests/test_lineage_completeness.py
+++ b/tests/test_lineage_completeness.py
@@ -985,7 +985,10 @@ def test_the_trace_says_why_it_could_not_confirm():
 
     # A source that simply defines a helper gets the bare marker: nothing failed, nothing was
     # unasked, and the licence is not the reason.
-    plain = _reasons(sql, inventory=FunctionInventory.of(["helper"], covers_view_bodies=True))
+    # `covers_view_bodies=False` on purpose. With True the fourth code's `not inventory.names`
+    # half is never consulted, so dropping it would leave the suite green -- and an attachment
+    # that defines a helper AND cannot cover bodies would then blame view bodies for the helper.
+    plain = _reasons(sql, inventory=FunctionInventory.of(["helper"], covers_view_bodies=False))
     assert "unconfirmed-function-identity" in plain
     assert not [r for r in plain if r.startswith("function-inventory-")]
 


### PR DESCRIPTION
The marker fired on **any** call, so `count(*)` tripped it and it appeared on
nearly every analytical answer. A warning on every answer is worth nothing on
the answer that matters.

### What this asks instead

Not *"which name is this call"* but *"could any call here be a UDF"*. If the
source defines no functions of its own, no call can be one, however it is
spelled. If it defines any, the engine cannot say which call is which, and
declines for all of them.

Coarser than per-call matching, and sound, which the precise version never was.

### Why it is coarse — three leaks, one assumption

I tried three times to name each call and match it against the catalogue. The
review gate escalated after six blockers in three rounds, all from one wrong
premise: **a call's bound name is not recoverable from the text or the tree.**

| approach | what it missed |
|---|---|
| as **written** | `len(name)` reaches the source as `LENGTH(name)` and bound a macro named `length` |
| as **rendered** | DuckDB binds `count(*)` to `count_star`, `EXTRACT(…)` to `date_part`, `CURRENT_DATE` to `current_date()` — none appear in sqlglot's output |
| a **view body** | binds as written, since the source stored that text, so the rendering argument inverts |

Each version returned `complete` over a macro reading another table and handing
back an SSN. M56, three times. All six of those macros are kept as a regression
set.

### What it buys

Issue #5's own query is clean, and so are `CASE`, `::VARCHAR` and `date_trunc`
against an ordinary database. `SELECT median(id)` against a source defining a
`median` macro is not — **M43's disclosed residual, visible in an audit record
for the first time**.

Without an inventory nothing changes; the old rule is this code's behaviour with
`never_asked()`. A test enforces that, so the change is what asking buys rather
than a relaxed default.

### Diagnosis in the trace

Three sub-reasons, because all the states used to write one marker: a source
whose `user_functions` fails every request read exactly like one defining a
helper. `function-inventory-unavailable`, `-never-asked`, and
`-covers-no-view-bodies` — the last for the fourth cause I first miscounted,
where a source defines nothing and the licence still does not reach a view body.

### Notes

The view-body licence keys on the **attach type**, an allowlist of one. It used
to key on `_fk_via_postgres`, a flag named for foreign-key discovery, which gave
SQLite the licence and would have given it to any future attachment kind.

`1904 passed.` Every mutation the gate named now fails a test.