### PR TITLE
Refuse a call the source itself defines (M43's residual)

### DIFF
--- a/src/mnemiq/adapters/base.py
+++ b/src/mnemiq/adapters/base.py
@@ -28,6 +28,14 @@ class SourceAdapter(Protocol):
     # look" into "there are none", which is the distinction FunctionInventory exists to keep.
     def user_functions(self) -> list[str]: ...
 
+    # The other half of the same catalogue: names this source considers its OWN builtins. Read
+    # through `hasattr`, so an adapter may omit it -- but an adapter that implements
+    # `user_functions` should implement this too. Their INTERSECTION is what the decider needs:
+    # a call can be reached under a name the query never spells only if that name is a builtin,
+    # so without this every source holding one macro has every query against it refused, under
+    # a code that is not repairable. A failure RAISES, like its sibling.
+    def builtin_functions(self) -> list[str]: ...
+
     # Whether `user_functions()` also answers for a VIEW BODY on this source. Read through
     # `getattr(adapter, ..., False)`, so an adapter that says nothing is taken not to cover them
     # -- forgetting yields the conservative answer. Deliberately NOT declared as a member here:

--- a/src/mnemiq/adapters/base.py
+++ b/src/mnemiq/adapters/base.py
@@ -29,13 +29,13 @@ class SourceAdapter(Protocol):
     def user_functions(self) -> list[str]: ...
 
     # The other half of the same catalogue: names this source considers its OWN builtins.
-    # Declared, like `user_functions` and unlike the flag below, because an adapter that
-    # implements one of the pair should implement both -- their INTERSECTION is what the
-    # decider needs. A call can be reached under a name the query never spells only if that
-    # name is a builtin, so an adapter offering the first method alone has every source holding
-    # one macro refuse every query against it, under a code that is not repairable. Reached
-    # through `hasattr` at the call site all the same, since a Protocol binds nothing at
-    # runtime. A failure RAISES, like its sibling.
+    # Declared beside `user_functions` because the two are one question -- their INTERSECTION
+    # is what the decider needs, since a call can be reached under a name the query never
+    # spells only if that name is a builtin. Declaring it cannot ENFORCE the pairing, and the
+    # objection recorded under the flag below applies here too: no adapter but DuckDB's has
+    # either method. It is here to be read, not to bind, and what it says is what omitting it
+    # costs -- every source holding one macro refuses every query against it, under a code
+    # that is not repairable. Reached through `hasattr` at the call site. A failure RAISES.
     def builtin_functions(self) -> list[str]: ...
 
     # Whether `user_functions()` also answers for a VIEW BODY on this source. Read through

--- a/src/mnemiq/adapters/base.py
+++ b/src/mnemiq/adapters/base.py
@@ -34,8 +34,8 @@ class SourceAdapter(Protocol):
     # spells only if that name is a builtin. Declaring it cannot ENFORCE the pairing, and the
     # objection recorded under the flag below applies here too: no adapter but DuckDB's has
     # either method. It is here to be read, not to bind, and what it says is what omitting it
-    # costs -- every source holding one macro refuses every query against it, under a code
-    # that is not repairable. Reached through `hasattr` at the call site. A failure RAISES.
+    # costs -- every source holding one macro refuses every query against it. Reached through
+    # `hasattr` at the call site. A failure RAISES, and raising is told apart from absence.
     def builtin_functions(self) -> list[str]: ...
 
     # Whether `user_functions()` also answers for a VIEW BODY on this source. Read through

--- a/src/mnemiq/adapters/base.py
+++ b/src/mnemiq/adapters/base.py
@@ -28,12 +28,14 @@ class SourceAdapter(Protocol):
     # look" into "there are none", which is the distinction FunctionInventory exists to keep.
     def user_functions(self) -> list[str]: ...
 
-    # The other half of the same catalogue: names this source considers its OWN builtins. Read
-    # through `hasattr`, so an adapter may omit it -- but an adapter that implements
-    # `user_functions` should implement this too. Their INTERSECTION is what the decider needs:
-    # a call can be reached under a name the query never spells only if that name is a builtin,
-    # so without this every source holding one macro has every query against it refused, under
-    # a code that is not repairable. A failure RAISES, like its sibling.
+    # The other half of the same catalogue: names this source considers its OWN builtins.
+    # Declared, like `user_functions` and unlike the flag below, because an adapter that
+    # implements one of the pair should implement both -- their INTERSECTION is what the
+    # decider needs. A call can be reached under a name the query never spells only if that
+    # name is a builtin, so an adapter offering the first method alone has every source holding
+    # one macro refuse every query against it, under a code that is not repairable. Reached
+    # through `hasattr` at the call site all the same, since a Protocol binds nothing at
+    # runtime. A failure RAISES, like its sibling.
     def builtin_functions(self) -> list[str]: ...
 
     # Whether `user_functions()` also answers for a VIEW BODY on this source. Read through

--- a/src/mnemiq/adapters/duckdb.py
+++ b/src/mnemiq/adapters/duckdb.py
@@ -201,8 +201,8 @@ class DuckDBAdapter:
 
         A failure RAISES, like its sibling, and `inventory_from` turns that into "builtins not
         known". Know what that costs before omitting this method: a source with any user
-        function at all then has every read AND every write against it refused, under a code
-        that is not repairable. It is the conservative reading and it is not a soft one.
+        function at all then has every read AND every write against it refused. It is the
+        conservative reading and it is not a soft one.
         """
         rows = self._con.execute(
             "SELECT DISTINCT lower(function_name) FROM duckdb_functions() WHERE internal"

--- a/src/mnemiq/adapters/duckdb.py
+++ b/src/mnemiq/adapters/duckdb.py
@@ -182,6 +182,33 @@ class DuckDBAdapter:
         ).fetchall()
         return [r[0] for r in rows]
 
+    def builtin_functions(self) -> list[str]:
+        """The other half of `duckdb_functions()`: names this engine considers its own.
+
+        Only ever used to intersect with `user_functions()`, and that intersection is the set of
+        names a call can reach WITHOUT the query spelling them. Measured on an attached
+        read-only DuckDB file holding `CREATE MACRO count_star() AS (SELECT ssn FROM secret)`:
+        `SELECT count(*) FROM claim` returned the SSN. `count_star` is DuckDB's binder name for
+        `COUNT(*)` and appears in no spelling of that query, in any dialect -- and it could only
+        be reached because `count_star` is a builtin. A macro named `safe_helper` has no such
+        route, which is why the intersection and not the mere presence of macros is the test.
+
+        The same catalogue query as `user_functions`, so the two partitions are of one table and
+        cannot disagree about what `internal` means. Two round trips rather than one because
+        `user_functions` shipped first and its callers do not all want this; the window between
+        them is the same staleness a single query already has against a source someone is
+        editing.
+
+        A failure RAISES, like its sibling. `inventory_from` turns that into "not asked", which
+        makes every call on a source with any user function unconfirmable -- the conservative
+        reading, and the reason this method may be omitted entirely by an adapter that has
+        nothing to say.
+        """
+        rows = self._con.execute(
+            "SELECT DISTINCT lower(function_name) FROM duckdb_functions() WHERE internal"
+        ).fetchall()
+        return [r[0] for r in rows]
+
     def view_definitions(self) -> list[tuple[str, str, str]]:
         """(view, body, dialect) for every view in the source. A failure RAISES.
 

--- a/src/mnemiq/adapters/duckdb.py
+++ b/src/mnemiq/adapters/duckdb.py
@@ -199,10 +199,10 @@ class DuckDBAdapter:
         them is the same staleness a single query already has against a source someone is
         editing.
 
-        A failure RAISES, like its sibling. `inventory_from` turns that into "not asked", which
-        makes every call on a source with any user function unconfirmable -- the conservative
-        reading, and the reason this method may be omitted entirely by an adapter that has
-        nothing to say.
+        A failure RAISES, like its sibling, and `inventory_from` turns that into "builtins not
+        known". Know what that costs before omitting this method: a source with any user
+        function at all then has every read AND every write against it refused, under a code
+        that is not repairable. It is the conservative reading and it is not a soft one.
         """
         rows = self._con.execute(
             "SELECT DISTINCT lower(function_name) FROM duckdb_functions() WHERE internal"

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -230,8 +230,10 @@ def check_unmodelled_calls(
 def _cannot_resolve(inventory: FunctionInventory, *, unreadable: bool = False) -> Refusal:
     """Nothing here can be attributed, so nothing here can be decided.
 
-    Several ways to arrive, kept apart in the message because each has a DIFFERENT OWNER, and a
-    refusal that sends the reader to the wrong one is worse than a vague refusal:
+    Several ways to arrive, and each gets its OWN SENTENCE, because a refusal that sends the
+    reader to the wrong place is worse than a vague one. Two of them share an owner and still
+    read differently, since "no such method" and "the method raised" are found in different
+    places even when the same person goes looking:
 
       * the source defines a name it also lists as a builtin -- the DEPLOYER renames it
       * the adapter has no `builtin_functions` -- its AUTHOR implements it

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -208,9 +208,11 @@ def check_unmodelled_calls(
     try:
         called = called_names(ast, *dialects)
     except UnreadableCalls:
-        # Cannot enumerate, so cannot clear. The same answer as shadowing, and for the same
-        # reason: an empty set read as "no calls" would clear all of them.
-        return _cannot_resolve(inventory)
+        # Cannot enumerate, so cannot clear. The same verdict as shadowing, and for the same
+        # reason -- an empty set read as "no calls" would clear all of them -- but its own
+        # sentence: this one is about THIS statement, and blaming the adapter for it would
+        # send the deployer to fix a catalogue method that is working.
+        return _cannot_resolve(inventory, unreadable=True)
 
     for name in sorted(called & inventory.names):
         return Refusal(
@@ -225,16 +227,27 @@ def check_unmodelled_calls(
     return None
 
 
-def _cannot_resolve(inventory: FunctionInventory) -> Refusal:
-    """Nothing on this source can be attributed, so nothing on it can be decided.
+def _cannot_resolve(inventory: FunctionInventory, *, unreadable: bool = False) -> Refusal:
+    """Nothing here can be attributed, so nothing here can be decided.
 
-    Three ways to arrive, kept apart in the message because each has a different owner. The
-    source defines a name it also lists as a builtin, which the DEPLOYER resolves by renaming
-    it. The source never said what its builtins are, which the ADAPTER resolves by implementing
-    `builtin_functions`. Or the source could not be asked at all, which is the source's own
-    problem and may be transient -- a missing method and a hostile database should not read
-    alike in a trace.
+    Four ways to arrive, kept apart in the message because each has a DIFFERENT OWNER, and a
+    refusal that sends the reader to the wrong one is worse than a vague refusal. The source
+    defines a name it also lists as a builtin, which the deployer resolves by renaming it. The
+    source never said what its builtins are, which the adapter author resolves by implementing
+    `builtin_functions`. The source could not be asked at all, which is the source's own
+    problem and may be transient. Or this one statement would not render, which is about the
+    statement and not the source at all -- it reached the shared message once, and told a
+    deployer with a working catalogue that their adapter was incomplete.
     """
+    if unreadable:
+        return Refusal(
+            code=RefusalCode.UNRESOLVABLE_CALLS,
+            message=(
+                "This query could not be rendered, so this engine cannot confirm which "
+                "functions it asks the source for, and this source defines functions of its "
+                "own. Answer using only the listed tables and columns and standard SQL."
+            ),
+        )
     if not inventory.available:
         detail = "This source could not say which functions it defines"
         shadowed = []

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -177,20 +177,33 @@ def check_unmodelled_calls(
         )
 
     inventory = inventory if inventory is not None else FunctionInventory.never_asked()
-    if not inventory.names or next(ast.find_all(exp.Func), None) is None:
-        # Nothing defined, or nothing called. The second half is what keeps a source with one
-        # helper from refusing `SELECT id FROM claim`.
+    if inventory.asked and not inventory.available:
+        # Asked and could not answer, which is not the same as answering "none" -- and the
+        # empty `names` an `unavailable` inventory carries would otherwise fall through every
+        # test below and clear the statement. The collapse this type exists to prevent, in the
+        # guard written to use it: measured, a raising `user_functions()` on a source holding a
+        # `median` macro left `SELECT median(id) FROM claim` approved.
+        return _cannot_resolve(inventory)
+    if not inventory.names:
         return None
 
     if inventory.may_shadow_a_builtin:
-        return _shadowed(inventory)
+        # No `exp.Func` test in front of this, deliberately, and that absence is the fix for a
+        # leak this function's first version had. `exp.Add`, `exp.DPipe` and `exp.AtTimeZone`
+        # are not `exp.Func` subclasses, while DuckDB lists `+`, `||` and `timezone` as
+        # internal functions a macro can shadow -- measured, `SELECT id + 1 FROM claim` was
+        # APPROVED and returned an SSN with a `"+"` macro in the source. Enumerating the node
+        # types that bind to a catalogue entry is the blocklist this codebase keeps refusing to
+        # write; proving a statement CALL-FREE is as hard as naming its calls, so a source
+        # whose names cannot be trusted answers nothing.
+        return _cannot_resolve(inventory)
 
     try:
         called = called_names(ast, *dialects)
     except UnreadableCalls:
         # Cannot enumerate, so cannot clear. The same answer as shadowing, and for the same
         # reason: an empty set read as "no calls" would clear all of them.
-        return _shadowed(inventory)
+        return _cannot_resolve(inventory)
 
     for name in sorted(called & inventory.names):
         return Refusal(
@@ -205,29 +218,32 @@ def check_unmodelled_calls(
     return None
 
 
-def _shadowed(inventory: FunctionInventory) -> Refusal:
-    """No call on this source can be read off the text, so none of them can be decided.
+def _cannot_resolve(inventory: FunctionInventory) -> Refusal:
+    """Nothing on this source can be attributed, so nothing on it can be decided.
 
-    Two ways to arrive, kept apart in the message because they need different fixes. The source
-    defines a name it also calls a builtin, which the deployer resolves by renaming it. Or the
-    source never said what its builtins are, which the ADAPTER resolves by implementing
-    `builtin_functions` -- a missing method should not read in a trace like a hostile database.
+    Three ways to arrive, kept apart in the message because each has a different owner. The
+    source defines a name it also lists as a builtin, which the DEPLOYER resolves by renaming
+    it. The source never said what its builtins are, which the ADAPTER resolves by implementing
+    `builtin_functions`. Or the source could not be asked at all, which is the source's own
+    problem and may be transient -- a missing method and a hostile database should not read
+    alike in a trace.
     """
-    shadowed = sorted(inventory.names & inventory.builtins) if inventory.builtins else []
-    if shadowed:
+    if not inventory.available:
+        detail = "This source could not say which functions it defines"
+        shadowed = []
+    else:
+        shadowed = sorted(inventory.names & inventory.builtins) if inventory.builtins else []
         detail = (
             f"This source defines {shadowed[0]!r} under a name it also lists as a builtin"
-        )
-    else:
-        detail = (
+            if shadowed else
             "This source defines functions of its own and did not report which names are "
             "builtins"
         )
     return Refusal(
-        code=RefusalCode.SHADOWED_FUNCTION,
+        code=RefusalCode.UNRESOLVABLE_CALLS,
         message=(
-            f"{detail}, so this engine cannot confirm what any call in this query executes. "
-            "No query using a function can be decided against this source."
+            f"{detail}, so this engine cannot confirm what this query executes against it. "
+            "No query can be decided against this source."
         ),
         subject=shadowed[0] if shadowed else None,
     )

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -230,14 +230,17 @@ def check_unmodelled_calls(
 def _cannot_resolve(inventory: FunctionInventory, *, unreadable: bool = False) -> Refusal:
     """Nothing here can be attributed, so nothing here can be decided.
 
-    Four ways to arrive, kept apart in the message because each has a DIFFERENT OWNER, and a
-    refusal that sends the reader to the wrong one is worse than a vague refusal. The source
-    defines a name it also lists as a builtin, which the deployer resolves by renaming it. The
-    source never said what its builtins are, which the adapter author resolves by implementing
-    `builtin_functions`. The source could not be asked at all, which is the source's own
-    problem and may be transient. Or this one statement would not render, which is about the
-    statement and not the source at all -- it reached the shared message once, and told a
-    deployer with a working catalogue that their adapter was incomplete.
+    Five ways to arrive, kept apart in the message because each has a DIFFERENT OWNER, and a
+    refusal that sends the reader to the wrong one is worse than a vague refusal:
+
+      * the source defines a name it also lists as a builtin -- the DEPLOYER renames it
+      * the adapter has no `builtin_functions` -- its AUTHOR implements it
+      * it has one and the call raised -- the SOURCE is the problem, and it may be transient
+      * `user_functions` itself raised -- likewise, and earlier
+      * this one statement would not render -- about the STATEMENT, not the source at all
+
+    The last three each borrowed one of the first two's sentences at some point, and each time
+    the effect was to send someone to fix working code.
     """
     if unreadable:
         return Refusal(
@@ -253,12 +256,18 @@ def _cannot_resolve(inventory: FunctionInventory, *, unreadable: bool = False) -
         shadowed = []
     else:
         shadowed = sorted(inventory.names & inventory.builtins) if inventory.builtins else []
-        detail = (
-            f"This source defines {shadowed[0]!r} under a name it also lists as a builtin"
-            if shadowed else
-            "This source defines functions of its own and did not report which names are "
-            "builtins"
-        )
+        if shadowed:
+            detail = f"This source defines {shadowed[0]!r} under a name it also lists as a builtin"
+        elif inventory.builtins_asked:
+            detail = (
+                "This source defines functions of its own and could not say which names are "
+                "its builtins"
+            )
+        else:
+            detail = (
+                "This source defines functions of its own and was never asked which names are "
+                "its builtins"
+            )
     return Refusal(
         code=RefusalCode.UNRESOLVABLE_CALLS,
         message=(

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -230,7 +230,7 @@ def check_unmodelled_calls(
 def _cannot_resolve(inventory: FunctionInventory, *, unreadable: bool = False) -> Refusal:
     """Nothing here can be attributed, so nothing here can be decided.
 
-    Five ways to arrive, kept apart in the message because each has a DIFFERENT OWNER, and a
+    Several ways to arrive, kept apart in the message because each has a DIFFERENT OWNER, and a
     refusal that sends the reader to the wrong one is worse than a vague refusal:
 
       * the source defines a name it also lists as a builtin -- the DEPLOYER renames it
@@ -239,8 +239,8 @@ def _cannot_resolve(inventory: FunctionInventory, *, unreadable: bool = False) -
       * `user_functions` itself raised -- likewise, and earlier
       * this one statement would not render -- about the STATEMENT, not the source at all
 
-    The last three each borrowed one of the first two's sentences at some point, and each time
-    the effect was to send someone to fix working code.
+    Two of them were caught borrowing another's sentence, and both times the effect was to send
+    someone to fix working code. That is the failure this list is arranged against.
     """
     if unreadable:
         return Refusal(

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -231,9 +231,9 @@ def _cannot_resolve(inventory: FunctionInventory, *, unreadable: bool = False) -
     """Nothing here can be attributed, so nothing here can be decided.
 
     Several ways to arrive, and each gets its OWN SENTENCE, because a refusal that sends the
-    reader to the wrong place is worse than a vague one. Two of them share an owner and still
-    read differently, since "no such method" and "the method raised" are found in different
-    places even when the same person goes looking:
+    reader to the wrong place is worse than a vague one. Sharing an owner is not enough to
+    share a sentence: two of these are the source failing, and "it would not name its builtins"
+    and "it would not name its own functions" are found by looking in different places.
 
       * the source defines a name it also lists as a builtin -- the DEPLOYER renames it
       * the adapter has no `builtin_functions` -- its AUTHOR implements it

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -156,11 +156,18 @@ def check_unmodelled_calls(
     no spelling of that query, because it is DuckDB's binder name for `COUNT(*)`.
 
     `inventory` closes that, in the two shapes the leak comes in. A call reachable under its
-    OWN name must be spelled, so `called_names` finds it however sqlglot rewrote the node. A
-    call reachable under a BUILTIN's name is not derivable at all, and cannot happen unless the
-    source defines something a builtin is also called -- so that case condemns every call here
-    rather than pretending to pick one. Without an inventory this is the allowlist alone, which
-    is where it started.
+    OWN name must be spelled, so `called_names` finds it however sqlglot rewrote the node, and
+    the refusal names it. A call reachable under a BUILTIN's name is not derivable at all, and
+    cannot happen unless the source defines a name a builtin also has -- so that case condemns
+    the whole SOURCE, every statement against it, whether or not anything here looks like a
+    call. `SELECT id + 1 FROM claim` was the measurement: no `exp.Func` node in it, `+` shadowed
+    by a macro, and an SSN in the result.
+
+    A third arrival, and it is the one that has to be written down rather than inferred: an
+    inventory that was ASKED and could not answer carries the same empty `names` as one that
+    answered "none", and reaches `_cannot_resolve` for it. `never_asked` does not, because that
+    is every fixture and the state the engine shipped in -- without an inventory this is the
+    allowlist alone, which is where it started.
     """
     for call in ast.find_all(exp.Anonymous):
         name = str(call.this)

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from sqlglot import exp
 from sqlglot.dialects.dialect import Dialect
 
+from mnemiq.sql.functions import FunctionInventory, UnreadableCalls, called_names
 from mnemiq.sql.qualify import object_key
 from mnemiq.sql.scope import base_tables, column_tables
 from mnemiq.sql.verdict import Refusal, RefusalCode
@@ -86,6 +87,9 @@ def check_access(ast: exp.Expression, visible: dict[str, set[str]],
     return None
 
 
+
+
+
 def _known_function_names() -> frozenset[str]:
     """Every function name sqlglot can model, in ANY dialect.
 
@@ -115,7 +119,11 @@ def _known_function_names() -> frozenset[str]:
 _KNOWN_FUNCTIONS = _known_function_names()
 
 
-def check_unmodelled_calls(ast: exp.Expression) -> Refusal | None:
+def check_unmodelled_calls(
+    ast: exp.Expression,
+    inventory: FunctionInventory | None = None,
+    *dialects: str,
+) -> Refusal | None:
     """Refuse a call this engine cannot model, because it cannot say what such a call reads.
 
     `check_access` re-checks every `exp.Table` against the identity's visible set, and the RLS
@@ -140,9 +148,19 @@ def check_unmodelled_calls(ast: exp.Expression) -> Refusal | None:
     and the decider's premise is that it sees every table a query reads. An opaque call makes
     that premise false, so the honest verdict is that this query cannot be decided.
 
-    Names, not identities: a UDF named `median` is modelled by sqlglot and passes here. That is
-    the acknowledged limit of any name-based allowlist, and it is bounded by the same
-    per-identity execution that dissolves M43 and M65 in v2.
+    The allowlist alone was names, not identities: a UDF named `median` is modelled by sqlglot
+    and passed. Measured through this function on the shipped default, with a macro in an
+    attached read-only DuckDB file, `SELECT median(id) FROM claim` was APPROVED with
+    `tables=['claim']` and returned an SSN from a table the identity was never granted. So did
+    `SELECT count(*) FROM claim`, against a macro named `count_star` -- a name that appears in
+    no spelling of that query, because it is DuckDB's binder name for `COUNT(*)`.
+
+    `inventory` closes that, in the two shapes the leak comes in. A call reachable under its
+    OWN name must be spelled, so `called_names` finds it however sqlglot rewrote the node. A
+    call reachable under a BUILTIN's name is not derivable at all, and cannot happen unless the
+    source defines something a builtin is also called -- so that case condemns every call here
+    rather than pretending to pick one. Without an inventory this is the allowlist alone, which
+    is where it started.
     """
     for call in ast.find_all(exp.Anonymous):
         name = str(call.this)
@@ -157,4 +175,59 @@ def check_unmodelled_calls(ast: exp.Expression) -> Refusal | None:
             ),
             subject=name,
         )
+
+    inventory = inventory if inventory is not None else FunctionInventory.never_asked()
+    if not inventory.names or next(ast.find_all(exp.Func), None) is None:
+        # Nothing defined, or nothing called. The second half is what keeps a source with one
+        # helper from refusing `SELECT id FROM claim`.
+        return None
+
+    if inventory.may_shadow_a_builtin:
+        return _shadowed(inventory)
+
+    try:
+        called = called_names(ast, *dialects)
+    except UnreadableCalls:
+        # Cannot enumerate, so cannot clear. The same answer as shadowing, and for the same
+        # reason: an empty set read as "no calls" would clear all of them.
+        return _shadowed(inventory)
+
+    for name in sorted(called & inventory.names):
+        return Refusal(
+            code=RefusalCode.UNMODELLED_CALL,
+            message=(
+                f"{name}() is defined by this source itself, so this engine cannot confirm "
+                "what the query reads. Answer using only the listed tables and columns and "
+                "standard SQL functions."
+            ),
+            subject=name,
+        )
     return None
+
+
+def _shadowed(inventory: FunctionInventory) -> Refusal:
+    """No call on this source can be read off the text, so none of them can be decided.
+
+    Two ways to arrive, kept apart in the message because they need different fixes. The source
+    defines a name it also calls a builtin, which the deployer resolves by renaming it. Or the
+    source never said what its builtins are, which the ADAPTER resolves by implementing
+    `builtin_functions` -- a missing method should not read in a trace like a hostile database.
+    """
+    shadowed = sorted(inventory.names & inventory.builtins) if inventory.builtins else []
+    if shadowed:
+        detail = (
+            f"This source defines {shadowed[0]!r} under a name it also lists as a builtin"
+        )
+    else:
+        detail = (
+            "This source defines functions of its own and did not report which names are "
+            "builtins"
+        )
+    return Refusal(
+        code=RefusalCode.SHADOWED_FUNCTION,
+        message=(
+            f"{detail}, so this engine cannot confirm what any call in this query executes. "
+            "No query using a function can be decided against this source."
+        ),
+        subject=shadowed[0] if shadowed else None,
+    )

--- a/src/mnemiq/sql/decide.py
+++ b/src/mnemiq/sql/decide.py
@@ -58,7 +58,13 @@ def decide(
     # projection position is not one -- so an opaque call slipped past both it and the RLS
     # rewrite (M43). This does not decide whether such a call is dangerous; it says the query
     # cannot be decided, which is the true thing.
-    opaque = check_unmodelled_calls(shaped)
+    # One inventory for the whole decision. `lineage_for` reads it too, and asking twice would
+    # let the gate and the report disagree about the same source in the same statement.
+    functions = inventory_from(adapter)
+    # Both dialects, because `called_names` renders to find what the tree does not carry, and
+    # more spellings can only over-refuse. `dialect` is what this was parsed as, `target` what
+    # will run it.
+    opaque = check_unmodelled_calls(shaped, functions, dialect, target)
     if opaque is not None:
         return opaque
 
@@ -117,7 +123,7 @@ def decide(
     # LIVE from the adapter, not the snapshot -- see `inventory_from` for why the two sources
     # differ.
     lineage = lineage_for(shaped, tables, {} if views is None else views,
-                          functions=inventory_from(adapter),
+                          functions=functions,
                           scope_resolved=scope_resolved(shaped))
     columns = sorted({c.name for c in shaped.find_all(exp.Column)})
 

--- a/src/mnemiq/sql/decide_write.py
+++ b/src/mnemiq/sql/decide_write.py
@@ -6,6 +6,7 @@ from sqlglot import exp
 from mnemiq.authz.grants import GrantSet
 from mnemiq.contract import ViewDefinition
 from mnemiq.sql.authz_guard import check_access, check_unmodelled_calls
+from mnemiq.sql.functions import inventory_from
 from mnemiq.sql.cls import check_cls
 from mnemiq.sql.policy import AccessPolicy
 from mnemiq.sql.prove import prove
@@ -217,7 +218,11 @@ def decide_write(
     # amount = pg_read_file('/etc/passwd') WHERE id = 1` and `INSERT INTO claim (id, amount)
     # SELECT customer_rows(), 1` were both APPROVED with tables=['claim'] -- the same audit lie,
     # and here it persists what it read into a table.
-    opaque = check_unmodelled_calls(shaped)
+    # The inventory too, or the two paths diverge on the same source: without it this is the
+    # allowlist alone, so a macro named `length` or `count_star` could feed an approved UPDATE
+    # that stores what it read into a granted table. `target or dialect` because a write's
+    # target defaults to the parse dialect a few lines above and this runs before that.
+    opaque = check_unmodelled_calls(shaped, inventory_from(adapter), dialect, target or dialect)
     if opaque is not None:
         return opaque
 

--- a/src/mnemiq/sql/decide_write.py
+++ b/src/mnemiq/sql/decide_write.py
@@ -220,9 +220,10 @@ def decide_write(
     # and here it persists what it read into a table.
     # The inventory too, or the two paths diverge on the same source: without it this is the
     # allowlist alone, so a macro named `length` or `count_star` could feed an approved UPDATE
-    # that stores what it read into a granted table. `target or dialect` because a write's
-    # target defaults to the parse dialect a few lines above and this runs before that.
-    opaque = check_unmodelled_calls(shaped, inventory_from(adapter), dialect, target or dialect)
+    # that stores what it read into a granted table. Both dialects, as on the read path: the
+    # guard renders to find the names the source will be asked for, and `target` has already
+    # been defaulted to `dialect` at the top of this function.
+    opaque = check_unmodelled_calls(shaped, inventory_from(adapter), dialect, target)
     if opaque is not None:
         return opaque
 

--- a/src/mnemiq/sql/functions.py
+++ b/src/mnemiq/sql/functions.py
@@ -202,9 +202,12 @@ def inventory_from(adapter) -> FunctionInventory:
 def _builtins_from(adapter) -> frozenset[str] | None:
     """The source's own builtin catalogue, or None when it did not supply one.
 
-    Separate from `user_functions` because it is optional in a way that one is not: a consumer
-    that never asks still gets the conservative answer out of `may_shadow_a_builtin`, so an
-    adapter can implement the cheap half alone and lose precision rather than soundness.
+    Separate from `user_functions` because a consumer that never asks still gets the
+    conservative answer out of `may_shadow_a_builtin` -- soundness does not depend on it. What
+    depends on it is whether the source can answer anything at all: without this, a source
+    holding one macro has every read and every write against it refused, under a code that is
+    not repairable. Optional in the sense that omitting it cannot open a hole, not in the sense
+    that omitting it is cheap.
     """
     if adapter is None or not hasattr(adapter, "builtin_functions"):
         return None
@@ -212,8 +215,8 @@ def _builtins_from(adapter) -> frozenset[str] | None:
         return frozenset(n.lower() for n in adapter.builtin_functions())
     except Exception:
         # No reason recorded, unlike the `user_functions` failure. The two are not symmetric:
-        # that one changes what the inventory MEANS and has to reach a trace, while this one
-        # only costs precision -- the fail-closed reading is already the default here.
+        # that one changes what the inventory MEANS, while this one lands on the default the
+        # field already has. Loud enough on its own -- the source then answers nothing.
         return None
 
 

--- a/src/mnemiq/sql/functions.py
+++ b/src/mnemiq/sql/functions.py
@@ -2,17 +2,26 @@
 
 The engine cannot tell a builtin from a same-named user-defined function by parsing. sqlglot
 types `log` as a builtin before the source binds it, so a UDF called `log` is invisible, and two
-separate controls settle for less because of it: `lineage` marks ANY call unconfirmable (issue
-#5, which makes the marker fire on `count(*)` and so on nearly every real query), and
-`check_unmodelled_calls` allows any name sqlglot models, so a UDF called `median` passes (M43's
-open residual).
+separate controls settled for less because of it: `lineage` marked ANY call unconfirmable (issue
+#5, which made the marker fire on `count(*)` and so on nearly every real query), and
+`check_unmodelled_calls` allowed any name sqlglot models, so a UDF called `median` passed and
+returned an SSN from an ungranted table (M43's residual).
 
-Both want the same fact from the same place: which names on THIS source are not builtins.
+Both want the same fact from the same place: which names on THIS source are not builtins. They
+then ask it differently, and the difference is not an inconsistency. Lineage REPORTS, so the
+cheapest sound rule is right for it: any user function at all means no call is confirmable.
+The decider REFUSES, so the same rule would end the product on a source with one macro -- it
+splits the question instead, into the names a statement is written to ask for
+(`called_names`) and the names a binder can substitute without being asked
+(`may_shadow_a_builtin`).
 """
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
+
+from sqlglot import exp
 
 
 @dataclass(frozen=True)
@@ -62,6 +71,19 @@ class FunctionInventory:
     # its catalogue covers view bodies says so; forgetting yields the conservative answer, which
     # is the inversion `writes_enabled` took in M3 and `unrecognised_source` took for shapes.
     covers_view_bodies: bool = False
+    # What the source calls a BUILTIN, or None for "never asked". Only used to answer one
+    # question -- whether any name in `names` shadows one -- and that question is what makes a
+    # call's true binding underivable from the text. Measured: with a macro named `count_star`
+    # in an attached read-only DuckDB file, `SELECT count(*) FROM claim` returned an SSN from an
+    # ungranted table. `count_star` appears in no spelling of that query, in no dialect, because
+    # it is the BINDER's name for `COUNT(*)`. A macro can only be reached that way if its name
+    # is a builtin, so the intersection is exactly the set of sources where names cannot be
+    # trusted at all.
+    #
+    # `None`, not an empty frozenset, for the reason the type exists: an empty answer would
+    # assert "this source shadows nothing", which is the absence-and-failure collapse in the
+    # one place it would fail open. Defaulting to None makes forgetting conservative.
+    builtins: frozenset[str] | None = None
 
     def __post_init__(self) -> None:
         # Normalised HERE, not only in `of()`. A dataclass hands out its plain constructor
@@ -78,6 +100,11 @@ class FunctionInventory:
         if isinstance(names, str):
             names = [names]
         object.__setattr__(self, "names", frozenset(n.lower() for n in names))
+        builtins = self.builtins
+        if builtins is not None:
+            if isinstance(builtins, str):
+                builtins = [builtins]
+            object.__setattr__(self, "builtins", frozenset(b.lower() for b in builtins))
 
     @classmethod
     def of(cls, names, **kw) -> "FunctionInventory":
@@ -120,6 +147,27 @@ class FunctionInventory:
         """The same licence, for a call found inside a view body rather than the query."""
         return self.certain and self.covers_view_bodies
 
+    @property
+    def may_shadow_a_builtin(self) -> bool:
+        """Whether some call here could bind to a user function under a name the SQL never says.
+
+        A user function is reachable in two ways. Under its own name, which the statement must
+        then spell, so enumerating the names a statement calls finds it. Or under a builtin's
+        name, where the engine's binder supplies a name the statement never contains -- DuckDB
+        turns `COUNT(*)` into `count_star`, and a macro called `count_star` collects the call.
+        Only the second is underivable, and only a name that IS a builtin can be reached that
+        way. So this is the whole question of whether names can be trusted on this source.
+
+        Three answers rather than two. Nothing defined, nothing to shadow. Builtins never
+        asked, so assume the worst -- but only for a source that defines something, which keeps
+        the conservative default off every source that has no user functions at all.
+        """
+        if not self.names:
+            return False
+        if self.builtins is None:
+            return True
+        return bool(self.names & self.builtins)
+
 
 def inventory_from(adapter) -> FunctionInventory:
     """Ask an adapter what it defines, in the one place, so two callers cannot drift.
@@ -144,8 +192,28 @@ def inventory_from(adapter) -> FunctionInventory:
         # and can carry a DSN, and this reason reaches an audit record (M94).
         return FunctionInventory.unavailable(type(exc).__name__)
     return FunctionInventory.of(
-        names, covers_view_bodies=getattr(adapter, "functions_cover_view_bodies", False)
+        names,
+        covers_view_bodies=getattr(adapter, "functions_cover_view_bodies", False),
+        builtins=_builtins_from(adapter),
     )
+
+
+def _builtins_from(adapter) -> frozenset[str] | None:
+    """The source's own builtin catalogue, or None when it did not supply one.
+
+    Separate from `user_functions` because it is optional in a way that one is not: a consumer
+    that never asks still gets the conservative answer out of `may_shadow_a_builtin`, so an
+    adapter can implement the cheap half alone and lose precision rather than soundness.
+    """
+    if adapter is None or not hasattr(adapter, "builtin_functions"):
+        return None
+    try:
+        return frozenset(n.lower() for n in adapter.builtin_functions())
+    except Exception:
+        # No reason recorded, unlike the `user_functions` failure. The two are not symmetric:
+        # that one changes what the inventory MEANS and has to reach a trace, while this one
+        # only costs precision -- the fail-closed reading is already the default here.
+        return None
 
 
 def calls_are_confirmable(inventory: FunctionInventory, *, in_view_body: bool) -> bool:
@@ -176,3 +244,53 @@ def calls_are_confirmable(inventory: FunctionInventory, *, in_view_body: bool) -
     """
     licensed = inventory.certain_for_view_bodies if in_view_body else inventory.certain
     return licensed and not inventory.names
+
+
+# An identifier immediately before an open paren. Deliberately crude: it over-collects, and
+# over-collecting is the safe direction for the one use it has. `FROM customer AS c(id, name)`
+# yields `c`, which costs nothing unless the source also defines a function called `c` -- in
+# which case refusing is right anyway. An earlier attempt used a scan like this to CLEAR calls
+# by counting them, where the same over-collection was a leak (M56).
+_CALLED = re.compile(r"([A-Za-z_][A-Za-z_0-9$]*)\s*\(")
+
+
+class UnreadableCalls(Exception):
+    """The statement could not be rendered, so its call names could not be enumerated."""
+
+
+def called_names(ast: exp.Expression, *dialects: str) -> frozenset[str]:
+    """Every function name the SOURCE will see when this statement runs.
+
+    Read off the RENDERED statement, not the tree and not the model's text, because rendering
+    is what the source is handed: `decide` approves an AST and `target_sql` is generated from
+    it. Three earlier attempts got this wrong in the other direction and each leaked an SSN --
+    the written spelling is not what executes, `len(name)` arrives as `LENGTH(name)`.
+
+    Not the tree, because a node loses the word. `date_trunc(...)` parses to
+    `exp.TimestampTrunc`, whose declared names are `timestamp_trunc` and `trunc`, and renders
+    back to `DATE_TRUNC(...)`. Only the text has the name the binder will resolve.
+
+    A weaker question than the one those attempts failed at, and that is what makes it safe.
+    They asked which name a call BINDS to, so a missing spelling cleared a UDF. This asks which
+    names the source is asked for, so a missing spelling can only over-refuse -- and the one
+    thing text cannot show, the binder's own renames (`COUNT(*)` to `count_star`, `EXTRACT` to
+    `date_part`), is covered by `may_shadow_a_builtin` instead, because a rename can only ever
+    land on a builtin's name.
+
+    Rendered once per dialect given: the parse dialect and the execution target can spell the
+    same node differently, and more names can only over-refuse. Raises `UnreadableCalls` when
+    none of them renders, rather than returning an empty set -- a caller reading that as "no
+    calls" would clear every one of them.
+    """
+    found: set[str] = set()
+    rendered = False
+    for dialect in dialects or (None,):
+        try:
+            text = ast.sql(dialect=dialect) if dialect else ast.sql()
+        except Exception:
+            continue
+        rendered = True
+        found.update(m.lower() for m in _CALLED.findall(text))
+    if not rendered:
+        raise UnreadableCalls(type(ast).__name__)
+    return frozenset(found)

--- a/src/mnemiq/sql/functions.py
+++ b/src/mnemiq/sql/functions.py
@@ -177,7 +177,8 @@ def inventory_from(adapter) -> FunctionInventory:
     snapshot holds the body governance was reasoned about, and a body that drifted since is a
     governance change worth noticing. A function list is not policy, it is what names mean --
     and a UDF created since the snapshot would read as a builtin, failing open in exactly the
-    direction M43 is about. Measured at ~6ms against queries that take seconds.
+    direction M43 is about. Measured at ~13ms against queries that take seconds -- two scans of
+    `duckdb_functions()`, one per half.
 
     Three answers, matching the three the type keeps apart. An adapter with no `user_functions`
     was never asked. One that raises was asked and could not answer. Anything else is an answer,

--- a/src/mnemiq/sql/functions.py
+++ b/src/mnemiq/sql/functions.py
@@ -84,6 +84,12 @@ class FunctionInventory:
     # assert "this source shadows nothing", which is the absence-and-failure collapse in the
     # one place it would fail open. Defaulting to None makes forgetting conservative.
     builtins: frozenset[str] | None = None
+    # Whether anyone PUT the builtin question, which `builtins is None` cannot carry: an
+    # adapter with no `builtin_functions` and one whose call raised both leave it None. The
+    # same split as `available` and `asked` above, one level down, and it exists for the same
+    # reason -- the refusal names a different owner for each, and telling an adapter author to
+    # implement a method they already implemented sends them to fix working code.
+    builtins_asked: bool = False
 
     def __post_init__(self) -> None:
         # Normalised HERE, not only in `of()`. A dataclass hands out its plain constructor
@@ -192,32 +198,36 @@ def inventory_from(adapter) -> FunctionInventory:
         # The TYPE, not the message. A source's exception text is made of the caller's schema
         # and can carry a DSN, and this reason reaches an audit record (M94).
         return FunctionInventory.unavailable(type(exc).__name__)
+    builtins, builtins_asked = _builtins_from(adapter)
     return FunctionInventory.of(
         names,
         covers_view_bodies=getattr(adapter, "functions_cover_view_bodies", False),
-        builtins=_builtins_from(adapter),
+        builtins=builtins,
+        builtins_asked=builtins_asked,
     )
 
 
-def _builtins_from(adapter) -> frozenset[str] | None:
+def _builtins_from(adapter) -> tuple[frozenset[str] | None, bool]:
     """The source's own builtin catalogue, or None when it did not supply one.
 
     Separate from `user_functions` because a consumer that never asks still gets the
     conservative answer out of `may_shadow_a_builtin` -- soundness does not depend on it. What
     depends on it is whether the source can answer anything at all: without this, a source
-    holding one macro has every read and every write against it refused, under a code that is
-    not repairable. Optional in the sense that omitting it cannot open a hole, not in the sense
-    that omitting it is cheap.
+    holding one macro has every read and every write against it refused. Optional in the sense
+    that omitting it cannot open a hole, not in the sense that omitting it is cheap -- the
+    refusal is classified unrepairable, and until something reads `REPAIRABLE` that costs the
+    caller three model calls and a deferral rather than one clean refusal.
     """
     if adapter is None or not hasattr(adapter, "builtin_functions"):
-        return None
+        return None, False
     try:
-        return frozenset(n.lower() for n in adapter.builtin_functions())
+        return frozenset(n.lower() for n in adapter.builtin_functions()), True
     except Exception:
-        # No reason recorded, unlike the `user_functions` failure. The two are not symmetric:
-        # that one changes what the inventory MEANS, while this one lands on the default the
-        # field already has. Loud enough on its own -- the source then answers nothing.
-        return None
+        # No reason string, unlike the `user_functions` failure -- that one changes what the
+        # inventory MEANS, while this lands on the default the field already has. The fact that
+        # it was ASKED is kept, though: it is the difference between an adapter that has not
+        # implemented this and one whose source would not answer, and the refusal says which.
+        return None, True
 
 
 def calls_are_confirmable(inventory: FunctionInventory, *, in_view_body: bool) -> bool:

--- a/src/mnemiq/sql/functions.py
+++ b/src/mnemiq/sql/functions.py
@@ -108,6 +108,10 @@ class FunctionInventory:
         object.__setattr__(self, "names", frozenset(n.lower() for n in names))
         builtins = self.builtins
         if builtins is not None:
+            # An answer implies the question. Without this the constructor can build "the
+            # catalogue answered, but nobody asked", which the field's own comment forbids and
+            # which a later reader would take at face value.
+            object.__setattr__(self, "builtins_asked", True)
             if isinstance(builtins, str):
                 builtins = [builtins]
             object.__setattr__(self, "builtins", frozenset(b.lower() for b in builtins))
@@ -208,15 +212,15 @@ def inventory_from(adapter) -> FunctionInventory:
 
 
 def _builtins_from(adapter) -> tuple[frozenset[str] | None, bool]:
-    """The source's own builtin catalogue, or None when it did not supply one.
+    """The source's own builtin catalogue and whether the question was put at all.
 
     Separate from `user_functions` because a consumer that never asks still gets the
     conservative answer out of `may_shadow_a_builtin` -- soundness does not depend on it. What
     depends on it is whether the source can answer anything at all: without this, a source
     holding one macro has every read and every write against it refused. Optional in the sense
     that omitting it cannot open a hole, not in the sense that omitting it is cheap -- the
-    refusal is classified unrepairable, and until something reads `REPAIRABLE` that costs the
-    caller three model calls and a deferral rather than one clean refusal.
+    refusal is classified unrepairable, and until something reads `REPAIRABLE` the caller pays
+    for retries that cannot succeed rather than getting one clean refusal.
     """
     if adapter is None or not hasattr(adapter, "builtin_functions"):
         return None, False

--- a/src/mnemiq/sql/verdict.py
+++ b/src/mnemiq/sql/verdict.py
@@ -16,11 +16,11 @@ class RefusalCode(StrEnum):
     # A call this engine cannot model, so it cannot say what the query reads. Not
     # "a forbidden function" -- there is no list of those, and that is the point (M43).
     UNMODELLED_CALL = "unmodelled_call"
-    # The source defines a function under a name the source ALSO calls a builtin, so no call
-    # here can be read off the text. Kept apart from UNMODELLED_CALL because the two have
-    # opposite repairs: that one names a function to avoid, this one condemns every call in
-    # every query against this source until the source stops shadowing (M43's residual).
-    SHADOWED_FUNCTION = "shadowed_function"
+    # Nothing in this statement can be attributed, because this source's name resolution
+    # cannot be reproduced here: it defines a name a builtin also has, or it could not say.
+    # Kept apart from UNMODELLED_CALL because the two have opposite repairs -- that one names a
+    # function to avoid, this one condemns every query against this source (M43's residual).
+    UNRESOLVABLE_CALLS = "unresolvable_calls"
     LOGIC_LINT = "logic_lint"
     VALUE_GROUNDING = "value_grounding"
     NOT_A_WRITE = "not_a_write"
@@ -71,8 +71,8 @@ REPAIRABLE = frozenset(
         # and the repair loop can rewrite that into arithmetic the engine does model.
         # Without this the guard's false positives become deferrals instead of retries.
         RefusalCode.UNMODELLED_CALL,
-        # SHADOWED_FUNCTION is deliberately absent. Its repair would be "write a query with no
-        # function calls", which is impossible for any aggregate question, so a retry loop
+        # UNRESOLVABLE_CALLS is deliberately absent. It condemns every statement against the
+        # source, not one function, so there is nothing for a rewrite to avoid and a retry loop
         # would spend every attempt to reach the deferral it starts at. The fix belongs to the
         # deployer, who sees this in the trace, not to the model.
         RefusalCode.LOGIC_LINT,

--- a/src/mnemiq/sql/verdict.py
+++ b/src/mnemiq/sql/verdict.py
@@ -16,6 +16,11 @@ class RefusalCode(StrEnum):
     # A call this engine cannot model, so it cannot say what the query reads. Not
     # "a forbidden function" -- there is no list of those, and that is the point (M43).
     UNMODELLED_CALL = "unmodelled_call"
+    # The source defines a function under a name the source ALSO calls a builtin, so no call
+    # here can be read off the text. Kept apart from UNMODELLED_CALL because the two have
+    # opposite repairs: that one names a function to avoid, this one condemns every call in
+    # every query against this source until the source stops shadowing (M43's residual).
+    SHADOWED_FUNCTION = "shadowed_function"
     LOGIC_LINT = "logic_lint"
     VALUE_GROUNDING = "value_grounding"
     NOT_A_WRITE = "not_a_write"
@@ -66,6 +71,10 @@ REPAIRABLE = frozenset(
         # and the repair loop can rewrite that into arithmetic the engine does model.
         # Without this the guard's false positives become deferrals instead of retries.
         RefusalCode.UNMODELLED_CALL,
+        # SHADOWED_FUNCTION is deliberately absent. Its repair would be "write a query with no
+        # function calls", which is impossible for any aggregate question, so a retry loop
+        # would spend every attempt to reach the deferral it starts at. The fix belongs to the
+        # deployer, who sees this in the trace, not to the model.
         RefusalCode.LOGIC_LINT,
         RefusalCode.VALUE_GROUNDING,
     }

--- a/src/mnemiq/sql/verdict.py
+++ b/src/mnemiq/sql/verdict.py
@@ -16,10 +16,12 @@ class RefusalCode(StrEnum):
     # A call this engine cannot model, so it cannot say what the query reads. Not
     # "a forbidden function" -- there is no list of those, and that is the point (M43).
     UNMODELLED_CALL = "unmodelled_call"
-    # Nothing in this statement can be attributed, because this source's name resolution
-    # cannot be reproduced here: it defines a name a builtin also has, or it could not say.
-    # Kept apart from UNMODELLED_CALL because the two have opposite repairs -- that one names a
-    # function to avoid, this one condemns every query against this source (M43's residual).
+    # Nothing here can be attributed, because this source's name resolution cannot be
+    # reproduced: it defines a name a builtin also has, it could not say, or -- once -- the
+    # statement would not render, which is the one arrival that is about the statement rather
+    # than the source. Kept apart from UNMODELLED_CALL because the two have opposite repairs:
+    # that one names a function to avoid, this one usually condemns every query against the
+    # source (M43's residual). `_cannot_resolve` is where the five arrivals are told apart.
     UNRESOLVABLE_CALLS = "unresolvable_calls"
     LOGIC_LINT = "logic_lint"
     VALUE_GROUNDING = "value_grounding"
@@ -75,6 +77,11 @@ REPAIRABLE = frozenset(
         # source, not one function, so there is nothing for a rewrite to avoid and a retry loop
         # would spend every attempt to reach the deferral it starts at. The fix belongs to the
         # deployer, who sees this in the trace, not to the model.
+        #
+        # That is the INTENT. Nothing reads this set yet: `plan_query` retries every refusal but
+        # UNAUTHORIZED_TABLE, so today an unrepairable code still costs three model calls and
+        # arrives as INVALID_QUERY rather than as itself. Recorded rather than fixed here --
+        # wiring it changes the outcome of every code in the set, which wants its own measurement.
         RefusalCode.LOGIC_LINT,
         RefusalCode.VALUE_GROUNDING,
     }

--- a/src/mnemiq/sql/verdict.py
+++ b/src/mnemiq/sql/verdict.py
@@ -21,7 +21,7 @@ class RefusalCode(StrEnum):
     # statement would not render, which is the one arrival that is about the statement rather
     # than the source. Kept apart from UNMODELLED_CALL because the two have opposite repairs:
     # that one names a function to avoid, this one usually condemns every query against the
-    # source (M43's residual). `_cannot_resolve` is where the five arrivals are told apart.
+    # source (M43's residual). `_cannot_resolve` is where the arrivals are told apart.
     UNRESOLVABLE_CALLS = "unresolvable_calls"
     LOGIC_LINT = "logic_lint"
     VALUE_GROUNDING = "value_grounding"
@@ -79,8 +79,8 @@ REPAIRABLE = frozenset(
         # deployer, who sees this in the trace, not to the model.
         #
         # That is the INTENT. Nothing reads this set yet: `plan_query` retries every refusal but
-        # UNAUTHORIZED_TABLE, so today an unrepairable code still costs three model calls and
-        # arrives as INVALID_QUERY rather than as itself. Recorded rather than fixed here --
+        # UNAUTHORIZED_TABLE, so today an unrepairable code is retried until the attempts run
+        # out and usually arrives as something else. Recorded rather than fixed here --
         # wiring it changes the outcome of every code in the set, which wants its own measurement.
         RefusalCode.LOGIC_LINT,
         RefusalCode.VALUE_GROUNDING,

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -610,6 +610,20 @@ def test_an_adapter_that_cannot_say_what_a_builtin_is_gets_the_conservative_answ
     assert inventory_from(Angry()).may_shadow_a_builtin is True
     assert inventory_from(Plain()).may_shadow_a_builtin is False
 
+    # ...and the two are told apart, because the refusal names a different owner for each.
+    # Both leave `builtins` None, so without this flag an adapter whose catalogue call RAISED
+    # is told to implement the method it already implemented.
+    assert inventory_from(HalfAnswering()).builtins_asked is False
+    assert inventory_from(Angry()).builtins_asked is True
+
+    from mnemiq.sql.authz_guard import check_unmodelled_calls
+
+    ast = __import__("sqlglot").parse_one("SELECT count(*) FROM claim", read="duckdb")
+    assert "never asked" in check_unmodelled_calls(
+        ast, inventory_from(HalfAnswering()), "duckdb").message
+    assert "could not say which names" in check_unmodelled_calls(
+        ast, inventory_from(Angry()), "duckdb").message
+
 
 def test_a_source_that_could_not_be_asked_is_not_a_source_that_defines_nothing():
     """`unavailable` carries empty `names`, which every test in the guard below it would read

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -616,6 +616,12 @@ def test_an_adapter_that_cannot_say_what_a_builtin_is_gets_the_conservative_answ
     assert inventory_from(HalfAnswering()).builtins_asked is False
     assert inventory_from(Angry()).builtins_asked is True
 
+    # An answer implies the question, whoever built the instance. Nothing in the product can
+    # reach the contradictory state today, which is exactly why it would survive unnoticed
+    # until something could.
+    assert FunctionInventory.of(["x"], builtins=[]).builtins_asked is True
+    assert FunctionInventory.of(["x"], builtins=[], builtins_asked=False).builtins_asked is True
+
     from mnemiq.sql.authz_guard import check_unmodelled_calls
 
     ast = __import__("sqlglot").parse_one("SELECT count(*) FROM claim", read="duckdb")

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -207,11 +207,20 @@ def test_a_shadowing_macro_is_caught_however_the_call_is_spelled(sql, source_wit
     the written spelling, then the rendered one, then a count cross-check that read a column
     list as a call. They are kept as a regression set rather than as a spelling test -- nothing
     is looked up by name now, so what they demonstrate is that a source defining anything
-    downgrades whatever the query says. Renaming the macros would leave them green, which is
-    the point: the rule no longer depends on the spelling that defeated three versions.
+    stops the call being cleared, whatever the query says. Renaming the macros would leave them
+    green, which is the point: the rule no longer depends on the spelling that defeated three
+    versions.
+
+    They used to be APPROVED and carry a lineage marker, which reported the doubt and then ran
+    the query anyway. Both macros here are named after builtins, so the decider now refuses.
     """
-    lineage = _lineage_through_decide(sql, DuckDBAdapter.duckdb(source_with_a_shadowing_macro))
-    assert "unconfirmed-function-identity" in lineage.reasons
+    from mnemiq.sql.decide import decide
+    from mnemiq.sql.verdict import RefusalCode
+
+    verdict = decide(sql, {"customer": {"id", "name"}},
+                     adapter=DuckDBAdapter.duckdb(source_with_a_shadowing_macro),
+                     dialect="duckdb", target="duckdb")
+    assert getattr(verdict, "code", None) is RefusalCode.SHADOWED_FUNCTION, verdict
 
 
 @pytest.mark.parametrize("sql", [
@@ -444,3 +453,135 @@ def test_a_postgres_udf_is_unreachable_from_a_query_and_absent_from_the_answer()
                 pg(f"DROP SCHEMA {schema} CASCADE")
         finally:
             admin.close()
+
+
+# --------------------------------------------------------------------------------------------
+# The DECIDER half. Lineage reports doubt and the query still runs; this is the gate. Everything
+# below was measured as a leak first: on a source with a macro reading an ungranted table, both
+# `SELECT count(*) FROM claim` and `SELECT median(id) FROM claim` were APPROVED with
+# `tables=['claim']` and returned an SSN.
+# --------------------------------------------------------------------------------------------
+
+
+def _source(*macros, name="src.duckdb"):
+    path = os.path.join(tempfile.mkdtemp(), name)
+    con = duckdb.connect(path)
+    con.execute("CREATE TABLE secret(ssn VARCHAR)")
+    con.execute("INSERT INTO secret VALUES ('123-45-6789')")
+    con.execute("CREATE TABLE claim(id INTEGER)")
+    con.execute("INSERT INTO claim VALUES (1), (2), (3)")
+    for macro in macros:
+        con.execute(macro)
+    con.close()
+    return DuckDBAdapter.duckdb(path)
+
+
+def _verdict(sql, adapter):
+    from mnemiq.sql.decide import decide
+
+    return decide(sql, {"claim": {"id"}}, adapter=adapter, dialect="duckdb", target="duckdb")
+
+
+def _code(verdict):
+    return getattr(getattr(verdict, "code", None), "value", None)
+
+
+def test_a_macro_named_after_a_builtin_stops_every_call_being_decided():
+    """`count_star` is DuckDB's binder name for `COUNT(*)`, and it appears in no spelling of
+    `SELECT count(*) FROM claim` under any dialect. Measured before this: that query was
+    approved and returned an SSN from `secret`.
+
+    So the refusal covers EVERY call rather than the one it can name, which is the only sound
+    answer once a name the query never says can collect the call. A call-free query is
+    untouched, which is what keeps this from being "refuse everything on this source".
+    """
+    adapter = _source("CREATE MACRO count_star() AS (SELECT max(ssn) FROM secret)")
+
+    leak = _verdict("SELECT count(*) AS n FROM claim", adapter)
+    assert _code(leak) == "shadowed_function", leak
+    assert "count_star" in leak.message
+
+    assert _code(_verdict("SELECT median(id) AS m FROM claim", adapter)) == "shadowed_function"
+    assert not hasattr(_verdict("SELECT id FROM claim", adapter), "code")
+
+
+def test_a_macro_the_engine_actually_binds_is_refused_by_the_name_it_binds():
+    """The other half, and the one that keeps the first from swallowing it.
+
+    `add_days` is a name sqlglot models -- so the cross-dialect allowlist passes it -- and NOT a
+    DuckDB builtin, so nothing shadows and the coarse rule stays quiet. It survives rendering,
+    which is what makes it reachable: measured, `SELECT add_days(id) FROM claim` returned an SSN
+    on this source. 440 names sqlglot knows are reachable this way.
+
+    `count(*)` against the same source is approved, which is the whole reason both rules exist
+    instead of the coarse one alone.
+    """
+    adapter = _source("CREATE MACRO add_days(x) AS (SELECT max(ssn) FROM secret)")
+
+    refusal = _verdict("SELECT add_days(id) AS n FROM claim", adapter)
+    assert _code(refusal) == "unmodelled_call", refusal
+    assert "defined by this source itself" in refusal.message
+    assert refusal.subject == "add_days"
+
+    assert not hasattr(_verdict("SELECT count(*) AS n FROM claim", adapter), "code")
+
+
+@pytest.mark.parametrize("sql", [
+    "SELECT count(*) AS n FROM claim",
+    "SELECT median(id) AS m FROM claim",
+    "SELECT date_trunc('day', CURRENT_DATE) AS d",
+    "SELECT CAST(id AS VARCHAR) AS s FROM claim",
+])
+def test_a_helper_that_shadows_nothing_costs_nothing(sql):
+    """The degeneracy control. A source with a macro of its own, named after nothing, keeps
+    answering every ordinary question.
+
+    This is what fails if `builtin_functions` reads the wrong half of `duckdb_functions()`:
+    the user names would then intersect themselves, every source with any macro would look
+    like a shadowing one, and all four of these would be refused.
+    """
+    adapter = _source("CREATE MACRO commission_rate(x) AS (x * 0.05)")
+    assert not hasattr(_verdict(sql, adapter), "code"), sql
+
+
+def test_the_two_catalogue_halves_are_one_query_split_on_internal():
+    """`builtin_functions` is `user_functions` with the predicate flipped, and the intersection
+    of the two is the whole question. Asserting the flag on the adapter is not enough -- what
+    matters is that the macro lands on one side and DuckDB's own names on the other."""
+    adapter = _source("CREATE MACRO commission_rate(x) AS (x * 0.05)")
+    user, builtin = set(adapter.user_functions()), set(adapter.builtin_functions())
+
+    assert user == {"commission_rate"}
+    assert {"count_star", "median", "length"} <= builtin
+    assert not user & builtin
+
+    shadowing = _source("CREATE MACRO median(x) AS (SELECT max(ssn) FROM secret)")
+    assert set(shadowing.user_functions()) & set(shadowing.builtin_functions()) == {"median"}
+
+
+def test_an_adapter_that_cannot_say_what_a_builtin_is_gets_the_conservative_answer():
+    """`builtin_functions` is optional, and forgetting it must cost precision rather than
+    soundness. An adapter offering the cheap half alone still has every call on it declined,
+    because a binder rename it cannot rule out is exactly the leak this is about.
+
+    A source that defines NOTHING is untouched either way, which is what keeps the conservative
+    default off every ordinary database.
+    """
+    from mnemiq.sql.functions import inventory_from
+
+    class HalfAnswering:
+        def user_functions(self):
+            return ["commission_rate"]
+
+    class Angry(HalfAnswering):
+        def builtin_functions(self):
+            raise RuntimeError("no catalogue for you")
+
+    class Plain:
+        def user_functions(self):
+            return []
+
+    assert inventory_from(HalfAnswering()).builtins is None
+    assert inventory_from(HalfAnswering()).may_shadow_a_builtin is True
+    assert inventory_from(Angry()).may_shadow_a_builtin is True
+    assert inventory_from(Plain()).may_shadow_a_builtin is False

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -583,9 +583,10 @@ def test_the_two_catalogue_halves_are_one_query_split_on_internal():
 
 
 def test_an_adapter_that_cannot_say_what_a_builtin_is_gets_the_conservative_answer():
-    """`builtin_functions` is optional, and forgetting it must cost precision rather than
-    soundness. An adapter offering the cheap half alone still has every call on it declined,
-    because a binder rename it cannot rule out is exactly the leak this is about.
+    """`builtin_functions` may be omitted, and omitting it must cost answers rather than
+    soundness. An adapter offering the other half alone has every statement against such a
+    source declined, because a binder rename it cannot rule out is exactly the leak this is
+    about -- expensive, and in the safe direction.
 
     A source that defines NOTHING is untouched either way, which is what keeps the conservative
     default off every ordinary database.

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -220,7 +220,7 @@ def test_a_shadowing_macro_is_caught_however_the_call_is_spelled(sql, source_wit
     verdict = decide(sql, {"customer": {"id", "name"}},
                      adapter=DuckDBAdapter.duckdb(source_with_a_shadowing_macro),
                      dialect="duckdb", target="duckdb")
-    assert getattr(verdict, "code", None) is RefusalCode.SHADOWED_FUNCTION, verdict
+    assert getattr(verdict, "code", None) is RefusalCode.UNRESOLVABLE_CALLS, verdict
 
 
 @pytest.mark.parametrize("sql", [
@@ -463,46 +463,69 @@ def test_a_postgres_udf_is_unreachable_from_a_query_and_absent_from_the_answer()
 # --------------------------------------------------------------------------------------------
 
 
-def _source(*macros, name="src.duckdb"):
+def _source(*macros, name="src.duckdb", read_only=True):
     path = os.path.join(tempfile.mkdtemp(), name)
     con = duckdb.connect(path)
     con.execute("CREATE TABLE secret(ssn VARCHAR)")
     con.execute("INSERT INTO secret VALUES ('123-45-6789')")
-    con.execute("CREATE TABLE claim(id INTEGER)")
-    con.execute("INSERT INTO claim VALUES (1), (2), (3)")
+    con.execute("CREATE TABLE claim(id INTEGER, name VARCHAR, ts TIMESTAMP)")
+    con.execute("INSERT INTO claim VALUES (1, 'a', TIMESTAMP '2020-01-01'), (2, 'b', NULL)")
     for macro in macros:
         con.execute(macro)
     con.close()
-    return DuckDBAdapter.duckdb(path)
+    return DuckDBAdapter.duckdb(path, read_only=read_only)
 
 
 def _verdict(sql, adapter):
     from mnemiq.sql.decide import decide
 
-    return decide(sql, {"claim": {"id"}}, adapter=adapter, dialect="duckdb", target="duckdb")
+    return decide(sql, {"claim": {"id", "name", "ts"}}, adapter=adapter,
+                  dialect="duckdb", target="duckdb")
 
 
 def _code(verdict):
     return getattr(getattr(verdict, "code", None), "value", None)
 
 
-def test_a_macro_named_after_a_builtin_stops_every_call_being_decided():
+def test_a_macro_named_after_a_builtin_stops_the_source_being_decided_at_all():
     """`count_star` is DuckDB's binder name for `COUNT(*)`, and it appears in no spelling of
     `SELECT count(*) FROM claim` under any dialect. Measured before this: that query was
     approved and returned an SSN from `secret`.
 
-    So the refusal covers EVERY call rather than the one it can name, which is the only sound
-    answer once a name the query never says can collect the call. A call-free query is
-    untouched, which is what keeps this from being "refuse everything on this source".
+    The refusal covers the whole SOURCE, not the calls anything can find in the statement. The
+    first version stopped at `find_all(exp.Func)`, which reads a plain `SELECT id FROM claim`
+    as call-free and is right, and reads `SELECT id + 1 FROM claim` as call-free and is wrong:
+    `exp.Add` is not an `exp.Func`, DuckDB lists `+` as an internal function, and with a `"+"`
+    macro that query was APPROVED and returned the SSN. Enumerating the node types that reach
+    the catalogue is the blocklist this codebase refuses to write, so the coarse answer is the
+    honest one -- a source whose names cannot be trusted answers nothing.
     """
     adapter = _source("CREATE MACRO count_star() AS (SELECT max(ssn) FROM secret)")
 
     leak = _verdict("SELECT count(*) AS n FROM claim", adapter)
-    assert _code(leak) == "shadowed_function", leak
+    assert _code(leak) == "unresolvable_calls", leak
     assert "count_star" in leak.message
 
-    assert _code(_verdict("SELECT median(id) AS m FROM claim", adapter)) == "shadowed_function"
-    assert not hasattr(_verdict("SELECT id FROM claim", adapter), "code")
+    assert _code(_verdict("SELECT median(id) AS m FROM claim", adapter)) == "unresolvable_calls"
+    assert _code(_verdict("SELECT id FROM claim", adapter)) == "unresolvable_calls"
+
+
+@pytest.mark.parametrize("sql, macro", [
+    ("SELECT id + 1 AS x FROM claim", 'CREATE MACRO "+"(a, b) AS (SELECT max(ssn) FROM secret)'),
+    ("SELECT name || 'x' AS x FROM claim", 'CREATE MACRO "||"(a, b) AS (SELECT max(ssn) FROM secret)'),
+    ("SELECT ts AT TIME ZONE 'UTC' AS t FROM claim",
+     "CREATE MACRO timezone(a, b) AS (SELECT max(ssn) FROM secret)"),
+])
+def test_an_operator_is_a_catalogue_call_too(sql, macro):
+    """Three shapes with no `exp.Func` node anywhere, each APPROVED and each returning an SSN.
+
+    `exp.Add`, `exp.DPipe` and `exp.AtTimeZone` are not function nodes, and `+`, `||` and
+    `timezone` are all `internal` in `duckdb_functions()`, so all three are shadowable. They
+    are the measurement behind refusing per-source rather than per-call: three node types were
+    found by looking, which says nothing about how many are left.
+    """
+    adapter = _source(macro, name="ops.duckdb")
+    assert _code(_verdict(sql, adapter)) == "unresolvable_calls", sql
 
 
 def test_a_macro_the_engine_actually_binds_is_refused_by_the_name_it_binds():
@@ -585,3 +608,59 @@ def test_an_adapter_that_cannot_say_what_a_builtin_is_gets_the_conservative_answ
     assert inventory_from(HalfAnswering()).may_shadow_a_builtin is True
     assert inventory_from(Angry()).may_shadow_a_builtin is True
     assert inventory_from(Plain()).may_shadow_a_builtin is False
+
+
+def test_a_source_that_could_not_be_asked_is_not_a_source_that_defines_nothing():
+    """`unavailable` carries empty `names`, which every test in the guard below it would read
+    as "defines nothing" and clear. Measured on the first version: with a raising
+    `user_functions()`, `SELECT median(id) FROM claim` came back approved on a source holding a
+    `median` macro -- the collapse `FunctionInventory` exists to prevent, in the guard written
+    to use it.
+
+    `never_asked` is the other empty answer and must stay permissive: no adapter, or an adapter
+    without the method, is every fixture in this suite and the state the engine shipped in.
+    """
+    import sqlglot
+
+    from mnemiq.sql.authz_guard import check_unmodelled_calls
+
+    ast = sqlglot.parse_one("SELECT median(id) FROM claim", read="duckdb")
+    refused = check_unmodelled_calls(ast, FunctionInventory.unavailable("RuntimeError"), "duckdb")
+    assert refused is not None and refused.code.value == "unresolvable_calls"
+    assert "could not say" in refused.message
+    assert "RuntimeError" not in refused.message, "the reason is for the trace, not the model"
+
+    assert check_unmodelled_calls(ast, FunctionInventory.never_asked(), "duckdb") is None
+
+
+def test_the_write_path_asks_the_same_source_the_same_question():
+    """`decide_write` called the guard without an inventory, so the two paths disagreed about
+    the same source in the same deployment: a read of `median(id)` was refused while an UPDATE
+    computing the same value was approved, and a write persists what it read into a granted
+    table that every later plain SELECT returns.
+
+    The ordinary write beside it is the control. Without one this asserts only that the write
+    path refuses everything, which is what a wrong grant set looks like.
+    """
+    from mnemiq.authz.grants import GrantSet
+    from mnemiq.sql.decide_write import decide_write
+    from mnemiq.sql.policy import AccessPolicy
+
+    def write(sql, adapter):
+        return decide_write(
+            sql, {"claim": {"id", "name", "ts"}},
+            GrantSet(frozenset({"claim"}), writable=frozenset({"claim"})),
+            policy=AccessPolicy(), adapter=adapter, dialect="duckdb", target="duckdb",
+            writes_enabled=True,
+        )
+
+    shadowing = _source("CREATE MACRO count_star() AS (SELECT max(ssn) FROM secret)")
+    assert _code(write("UPDATE claim SET id = 2 WHERE id = 1", shadowing)) == "unresolvable_calls"
+
+    # Writable, because the control has to reach `prove`, and EXPLAIN on a write is refused by
+    # a read-only attach -- which would make it pass for the wrong reason.
+    named = _source("CREATE MACRO add_days(x) AS (SELECT max(ssn) FROM secret)",
+                    name="w.duckdb", read_only=False)
+    leak = write("UPDATE claim SET name = add_days(id) WHERE id = 1", named)
+    assert _code(leak) == "unmodelled_call", leak
+    assert not hasattr(write("UPDATE claim SET id = 2 WHERE id = 1", named), "code")

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -648,8 +648,17 @@ def test_a_source_that_could_not_be_asked_is_not_a_source_that_defines_nothing()
     ast = sqlglot.parse_one("SELECT median(id) FROM claim", read="duckdb")
     refused = check_unmodelled_calls(ast, FunctionInventory.unavailable("RuntimeError"), "duckdb")
     assert refused is not None and refused.code.value == "unresolvable_calls"
-    assert "could not say" in refused.message
     assert "RuntimeError" not in refused.message, "the reason is for the trace, not the model"
+
+    # Distinguished from the OTHER source failure, not merely non-empty. Both sentences begin
+    # "could not say", so asserting that substring alone let the two be swapped: a source that
+    # would not list its builtins and one that would not list its own functions are found by
+    # looking in different places, and the sentence is the only thing that says which.
+    could_not_name_builtins = check_unmodelled_calls(
+        ast, FunctionInventory.of(["median"], builtins_asked=True), "duckdb")
+    assert "which functions it defines" in refused.message
+    assert "which names are its builtins" in could_not_name_builtins.message
+    assert refused.message != could_not_name_builtins.message
 
     assert check_unmodelled_calls(ast, FunctionInventory.never_asked(), "duckdb") is None
 

--- a/tests/test_sql_authz_guard.py
+++ b/tests/test_sql_authz_guard.py
@@ -379,8 +379,8 @@ def test_a_statement_that_will_not_render_refuses_rather_than_passes():
     refusal = check_unmodelled_calls(WillNotRender(), inventory, "duckdb")
     assert refusal.code == RefusalCode.UNRESOLVABLE_CALLS
     # ...and says whose problem it is. This source's catalogue answered both halves, so any of
-    # the source-level sentences would send a deployer to fix something that is working. Each
-    # arrival at this code has a different owner.
+    # the source-level sentences would send a deployer to fix something that is working. Two
+    # arrivals can share an owner; none of them shares a sentence.
     assert "could not be rendered" in refusal.message
     assert "builtins" not in refusal.message
 

--- a/tests/test_sql_authz_guard.py
+++ b/tests/test_sql_authz_guard.py
@@ -317,3 +317,84 @@ def test_an_opaque_call_cannot_be_decided_on_the_write_path_either(sql, dialect)
     v = _decide_write(sql, dialect)
     assert isinstance(v, Refusal), f"{sql!r} was approved under {dialect}"
     assert v.code == RefusalCode.UNMODELLED_CALL
+
+
+# --------------------------------------------------------------------------------------------
+# What the source is asked for, versus what the model wrote. Three earlier attempts at this
+# question read the written spelling or the tree and each cleared a UDF that then returned an
+# SSN (M56). `called_names` reads the RENDERED statement, because that is what the source gets.
+# --------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dialect", _DIALECTS)
+def test_a_call_is_named_by_what_the_source_receives_not_by_what_was_written(dialect):
+    """`len(name)` reaches the source as `LENGTH(name)`, so `length` is the name that binds and
+    `len` is not. Reading the written word cleared a macro named `length` and returned an SSN.
+    """
+    from mnemiq.sql.functions import called_names
+
+    written_len = sqlglot.parse_one("SELECT len(name) FROM claim", read=dialect)
+    assert "length" in called_names(written_len, dialect)
+
+
+@pytest.mark.parametrize("dialect", _DIALECTS)
+def test_a_name_the_tree_does_not_carry_is_still_found(dialect):
+    """`date_trunc` parses to `exp.TimestampTrunc`, which declares `timestamp_trunc` and
+    `trunc` and has forgotten the word by the time anything can walk it. Rendering puts it
+    back, which is why the scan is over text rather than over nodes."""
+    from mnemiq.sql.functions import called_names
+
+    assert "DATE_TRUNC" not in sqlglot.exp.TimestampTrunc.sql_names()
+    ast = sqlglot.parse_one("SELECT date_trunc('day', created_at) FROM claim", read=dialect)
+    assert "date_trunc" in called_names(ast, dialect)
+
+
+def test_a_statement_that_will_not_render_is_not_read_as_call_free():
+    """The absence-and-failure collapse, in the place it would fail open: an empty set of names
+    intersects nothing, so a caller reading a render failure as "no calls" clears all of them.
+    """
+    from mnemiq.sql.functions import UnreadableCalls, called_names
+
+    class WillNotRender(sqlglot.exp.Expression):
+        def sql(self, *a, **kw):
+            raise ValueError("no")
+
+    with pytest.raises(UnreadableCalls):
+        called_names(WillNotRender(), "duckdb")
+
+
+def test_a_statement_that_will_not_render_refuses_rather_than_passes():
+    """And the guard takes that the same way it takes shadowing, for the same reason."""
+    from mnemiq.sql.authz_guard import check_unmodelled_calls
+    from mnemiq.sql.functions import FunctionInventory
+
+    class WillNotRender(sqlglot.exp.Expression):
+        def sql(self, *a, **kw):
+            raise ValueError("no")
+
+        def find_all(self, *types):
+            yield sqlglot.exp.Anonymous(this="count")
+
+    inventory = FunctionInventory.of(["commission_rate"], builtins=["count_star"])
+    refusal = check_unmodelled_calls(WillNotRender(), inventory, "duckdb")
+    assert refusal.code == RefusalCode.SHADOWED_FUNCTION
+
+
+def test_without_an_inventory_the_guard_is_the_allowlist_it_was():
+    """The default has to be the old behaviour exactly. Every caller that does not pass an
+    inventory -- fixtures, the write path, a source with no adapter -- would otherwise change
+    verdict, and a conservative default here would refuse every call in the suite."""
+    from mnemiq.sql.authz_guard import check_unmodelled_calls
+
+    ast = sqlglot.parse_one("SELECT count(*), median(id) FROM claim", read="duckdb")
+    assert check_unmodelled_calls(ast) is None
+
+
+def test_a_shadowed_source_is_not_repaired_into_an_answer():
+    """UNMODELLED_CALL is repairable because a model can route around one named function.
+    SHADOWED_FUNCTION cannot be: its repair is "use no functions at all", which no aggregate
+    question has, so a loop would spend every attempt to arrive where it started."""
+    from mnemiq.sql.verdict import REPAIRABLE
+
+    assert RefusalCode.UNMODELLED_CALL in REPAIRABLE
+    assert RefusalCode.SHADOWED_FUNCTION not in REPAIRABLE

--- a/tests/test_sql_authz_guard.py
+++ b/tests/test_sql_authz_guard.py
@@ -379,8 +379,8 @@ def test_a_statement_that_will_not_render_refuses_rather_than_passes():
     refusal = check_unmodelled_calls(WillNotRender(), inventory, "duckdb")
     assert refusal.code == RefusalCode.UNRESOLVABLE_CALLS
     # ...and says whose problem it is. This source's catalogue answered both halves, so any of
-    # the source-level sentences would send a deployer to fix something that is working. Two
-    # arrivals can share an owner; none of them shares a sentence.
+    # the source-level sentences would send a deployer to fix something that is working.
+    # Sharing an owner is not enough to share a sentence.
     assert "could not be rendered" in refusal.message
     assert "builtins" not in refusal.message
 

--- a/tests/test_sql_authz_guard.py
+++ b/tests/test_sql_authz_guard.py
@@ -378,6 +378,11 @@ def test_a_statement_that_will_not_render_refuses_rather_than_passes():
     inventory = FunctionInventory.of(["commission_rate"], builtins=["count_star"])
     refusal = check_unmodelled_calls(WillNotRender(), inventory, "duckdb")
     assert refusal.code == RefusalCode.UNRESOLVABLE_CALLS
+    # ...and says whose problem it is. This source's catalogue answered both halves, so the
+    # shared "did not report which names are builtins" text would send a deployer to fix an
+    # adapter that is working. Four causes reach this code and each has a different owner.
+    assert "could not be rendered" in refusal.message
+    assert "builtins" not in refusal.message
 
 
 def test_without_an_inventory_the_guard_is_the_allowlist_it_was():

--- a/tests/test_sql_authz_guard.py
+++ b/tests/test_sql_authz_guard.py
@@ -377,7 +377,7 @@ def test_a_statement_that_will_not_render_refuses_rather_than_passes():
 
     inventory = FunctionInventory.of(["commission_rate"], builtins=["count_star"])
     refusal = check_unmodelled_calls(WillNotRender(), inventory, "duckdb")
-    assert refusal.code == RefusalCode.SHADOWED_FUNCTION
+    assert refusal.code == RefusalCode.UNRESOLVABLE_CALLS
 
 
 def test_without_an_inventory_the_guard_is_the_allowlist_it_was():
@@ -390,11 +390,11 @@ def test_without_an_inventory_the_guard_is_the_allowlist_it_was():
     assert check_unmodelled_calls(ast) is None
 
 
-def test_a_shadowed_source_is_not_repaired_into_an_answer():
+def test_an_unresolvable_source_is_not_repaired_into_an_answer():
     """UNMODELLED_CALL is repairable because a model can route around one named function.
-    SHADOWED_FUNCTION cannot be: its repair is "use no functions at all", which no aggregate
-    question has, so a loop would spend every attempt to arrive where it started."""
+    UNRESOLVABLE_CALLS cannot be: it condemns every statement against the source, so there is
+    nothing for a rewrite to avoid and a loop would spend every attempt where it started."""
     from mnemiq.sql.verdict import REPAIRABLE
 
     assert RefusalCode.UNMODELLED_CALL in REPAIRABLE
-    assert RefusalCode.SHADOWED_FUNCTION not in REPAIRABLE
+    assert RefusalCode.UNRESOLVABLE_CALLS not in REPAIRABLE

--- a/tests/test_sql_authz_guard.py
+++ b/tests/test_sql_authz_guard.py
@@ -378,9 +378,9 @@ def test_a_statement_that_will_not_render_refuses_rather_than_passes():
     inventory = FunctionInventory.of(["commission_rate"], builtins=["count_star"])
     refusal = check_unmodelled_calls(WillNotRender(), inventory, "duckdb")
     assert refusal.code == RefusalCode.UNRESOLVABLE_CALLS
-    # ...and says whose problem it is. This source's catalogue answered both halves, so the
-    # shared "did not report which names are builtins" text would send a deployer to fix an
-    # adapter that is working. Four causes reach this code and each has a different owner.
+    # ...and says whose problem it is. This source's catalogue answered both halves, so any of
+    # the source-level sentences would send a deployer to fix something that is working. Each
+    # arrival at this code has a different owner.
     assert "could not be rendered" in refusal.message
     assert "builtins" not in refusal.message
 


### PR DESCRIPTION
The decider's function allowlist was names, not identities, and #18 closed the
*reporting* half of that while leaving the gate open. Measured through `decide`
on the shipped default, against macros in an attached **read-only** DuckDB file:

| query | verdict before | returned |
|---|---|---|
| `SELECT median(id) FROM claim` | Approved, `tables=['claim']` | an SSN from `secret` |
| `SELECT count(*) FROM claim` | Approved, `tables=['claim']` | an SSN from `secret` |
| `SELECT id + 1 FROM claim` | Approved, `tables=['claim']` | an SSN from `secret` |

The identity was granted `claim` and nothing else. Lineage's marker fired on all
three and they ran anyway — a report is not a gate.

### The two routes, and why one rule cannot cover both

A user function is reachable **under its own name**, which the statement then
has to spell. `called_names` reads those off the **rendered** statement, because
that is what the source is handed: `decide` approves an AST and `target_sql` is
generated from it. Not the written word, which is where three earlier attempts
leaked, and not the tree, which forgets it — `date_trunc` parses to
`TimestampTrunc` and declares neither name.

Or **under a builtin's name**, where the binder supplies a name the statement
never contains. `COUNT(*)` becomes `count_star`; `EXTRACT` becomes `date_part`.
Nothing in the text can find those, and nothing needs to: a rename can only land
on a builtin, so `names ∩ builtins` is exactly the set of sources where names
cannot be trusted at all. `builtin_functions()` is the same catalogue query with
the predicate flipped.

Splitting it is what keeps the coarse half from ending the product. A source
with one macro named after nothing still answers `count(*)`; a source with one
named `count_star` answers nothing. 440 of sqlglot's names are reachable by the
first route on DuckDB, `add_days` among them.

### What review caught that I had wrong

**An operator is a catalogue call.** The first version gated the coarse rule on
`find_all(exp.Func)`. `exp.Add`, `exp.DPipe` and `exp.AtTimeZone` are not
function nodes, and DuckDB lists `+`, `||` and `timezone` as internal. Three
node types found by looking says nothing about how many are left, so a source
whose names cannot be trusted now answers nothing at all — `SELECT id FROM
claim` included. Proving a statement call-free is as hard as naming its calls.

**A failed lookup is not an empty one.** `unavailable()` carries empty `names`,
which every test below it read as "defines nothing".

**The write path threaded no inventory**, so the two paths disagreed about the
same source: a read of `median(id)` refused while an UPDATE computing it was
approved, into a table every later plain SELECT returns.

### Diagnosis

Five arrivals reach `UNRESOLVABLE_CALLS` and each gets its own sentence, because
a refusal that sends the reader to the wrong place is worse than a vague one.
The deployer renames a macro; the adapter author implements a method; the source
is having a bad day; or this one statement would not render, which is not about
the source at all. Three of them were caught wearing another's sentence.

### Also recorded, not fixed

`REPAIRABLE` is documented intent and nothing else — `plan_query` retries every
refusal but `UNAUTHORIZED_TABLE`. Wiring it changes the outcome of every code in
the set and wants its own measurement.

`1925 passed.` Every rule here has a mutation that fails a test; the operator
shapes and the three original spelling leaks are kept as regression sets.