### PR TITLE
The retry loop reads the classification it was ignoring (M98)

### DIFF
--- a/src/mnemiq/contract/seams.py
+++ b/src/mnemiq/contract/seams.py
@@ -43,6 +43,16 @@ class DeferralReason(StrEnum):
     # them together is M6 exactly, and a flaky judge would raise the measured deferral rate while
     # the cause stayed readable only in `verify_layer`, case by case.
     VERIFIER_UNAVAILABLE = "verifier_unavailable"
+    # The decider refused for a reason that is about the SOURCE or the POLICY rather than the
+    # question, and no rewrite can change it: a source that redefines a builtin's name so no
+    # call on it can be resolved, or a row filter that is not a valid predicate. NOT a source
+    # that will not list its views -- `plan_query`'s own fast path catches that one first and
+    # calls it `policy_unavailable`, which is worth knowing before adding it to this list. Distinct
+    # from `policy_unavailable`, which means the policy could not be READ, and from
+    # `invalid_query`, which claims the engine tried and failed to write valid SQL -- it did
+    # not try, because trying could not have worked. The caller's move is to page an operator,
+    # and telling them to rephrase would waste their time as well as the model's.
+    UNGOVERNABLE = "ungovernable"
 
 
 class IdentityContext(BaseModel):

--- a/src/mnemiq/generate/plan_query.py
+++ b/src/mnemiq/generate/plan_query.py
@@ -47,6 +47,34 @@ class Feedback:
     from_source: bool
 
 
+# What a caller is told when the decider refuses in a way no rewrite can fix: the deferral code,
+# and a sentence to use INSTEAD of the refusal's own when that one would echo source words back.
+# `UNGOVERNABLE` is the default and says the true thing -- the engine cannot establish that this
+# query is governed -- for the source and policy failures that make up the rest, whose subjects
+# are the engine's own (a view name from the snapshot, a function name from the catalogue).
+#
+# INVALID_ROW_FILTER is deliberately NOT mapped to `policy_unavailable`, which was the first
+# answer and reads well until an operator sees the card: that code's title is "The access policy
+# could not be read", and here it was read and one predicate in it is invalid. UNGOVERNABLE is
+# what this codebase already calls that, and the contract enum lists this case under it.
+#
+# UNAUTHORIZED_TABLE is absent because it keeps its own branch, the one that logs and suppresses
+# its subject: its sentence is worded for the caller's next move rather than the model's.
+_UNREPAIRABLE: dict[RefusalCode, tuple[DeferralReason, str | None]] = {
+    # Grants, exactly like the table case, and it used to spend three attempts inviting the model
+    # to find another route to a column this identity may not read -- one it FINDS answers a
+    # subtly different question than the one that was asked.
+    #
+    # And the subject is MODEL-AUTHORED, read off `exp.Column` in the model's own SQL, so a model
+    # handed the source's words can name a "column" spelled out of them. Same provenance as the
+    # table branch's subject and the same suppression, which is the third exit of that kind.
+    RefusalCode.UNAUTHORIZED_COLUMN: (
+        DeferralReason.AUTHORIZATION,
+        "Answering this would require access to a column you do not have.",
+    ),
+}
+
+
 def plan_query(
     packet: ContextPacket,
     snapshot: Snapshot,
@@ -234,6 +262,31 @@ def plan_query(
                     else "Answering this would require access you do not have."
                 ),
                 code=DeferralReason.AUTHORIZATION,
+            )
+
+        if not verdict.repairable:
+            # The generalisation of the branch above, and it took until M98 to notice the branch
+            # WAS one. `REPAIRABLE` existed with ten codes and `Refusal.repairable` read it, and
+            # nothing else did: every other refusal was retried whatever the classification said,
+            # so an unrepairable one cost three model calls to reach the verdict the first one
+            # already had, and arrived as INVALID_QUERY -- "could not produce a valid query after
+            # 3 attempts", which claims an attempt that could not have worked.
+            #
+            # The message goes back whole, because these refusals are the ones that say what an
+            # OPERATOR must change, and burying that under a retry count is what made the useful
+            # sentence look like a footnote to a failure.
+            # The subject too, and that is not decoration: when it is withheld from the caller
+            # below, the deployment's own log is the only place the denied name is written. Same
+            # rule the table branch follows -- what cannot be said to the caller still has to be
+            # said somewhere -- and the server log is inside the boundary that holds the DSN.
+            logger.warning("unrepairable refusal, not retried: %s (%r)",
+                           verdict.code.value, verdict.subject)
+            code, without_subject = _UNREPAIRABLE.get(
+                verdict.code, (DeferralReason.UNGOVERNABLE, None))
+            return Deferred(
+                reason=(without_subject if without_subject and carries_source_words
+                        else verdict.message),
+                code=code,
             )
 
         last = verdict

--- a/src/mnemiq/generate/plan_query.py
+++ b/src/mnemiq/generate/plan_query.py
@@ -50,8 +50,10 @@ class Feedback:
 # What a caller is told when the decider refuses in a way no rewrite can fix: the deferral code,
 # and a sentence to use INSTEAD of the refusal's own when that one would echo source words back.
 # `UNGOVERNABLE` is the default and says the true thing -- the engine cannot establish that this
-# query is governed -- for the source and policy failures that make up the rest, whose subjects
-# are the engine's own (a view name from the snapshot, a function name from the catalogue).
+# query is governed -- for the source and policy failures that make up the rest, whose subject
+# is the engine's own where they have one at all: today a shadowed function name read off the
+# source's catalogue, and nothing else. Every view code with a subject is repairable, and
+# VIEW_INVENTORY_UNAVAILABLE carries none and is caught by the fast path above this loop.
 #
 # INVALID_ROW_FILTER is deliberately NOT mapped to `policy_unavailable`, which was the first
 # answer and reads well until an operator sees the card: that code's title is "The access policy

--- a/src/mnemiq/generate/plan_query.py
+++ b/src/mnemiq/generate/plan_query.py
@@ -13,7 +13,7 @@ from mnemiq.sql.decide import decide
 from mnemiq.sql.views import inventory_for
 from mnemiq.sql.policy import build_access_policy
 from mnemiq.sql.schema import visible_schema
-from mnemiq.sql.verdict import Approved, Refusal, RefusalCode
+from mnemiq.sql.verdict import REPAIRABLE, Approved, Refusal, RefusalCode
 
 logger = logging.getLogger(__name__)
 
@@ -283,20 +283,44 @@ def plan_query(
             # said somewhere -- and the server log is inside the boundary that holds the DSN.
             logger.warning("unrepairable refusal, not retried: %s (%r)",
                            verdict.code.value, verdict.subject)
-            code, without_subject = _UNREPAIRABLE.get(
-                verdict.code, (DeferralReason.UNGOVERNABLE, None))
-            return Deferred(
-                reason=(without_subject if without_subject and carries_source_words
-                        else verdict.message),
-                code=code,
-            )
+            return _not_our_sql(verdict, carries_source_words)
 
         last = verdict
         carries_source_words = verdict.source_detail is not None
         feedback = Feedback(verdict.repair_text, from_source=carries_source_words)
 
+    if last is not None and last.code not in REPAIRABLE:
+        # Retried only because the INSTANCE said to -- a source whose catalogue call raised is
+        # worth asking again, and `decide` re-asks it live every attempt. After the last one the
+        # CODE's judgment stands, and reporting this as INVALID_QUERY would be the thing M98 set
+        # out to retire: "could not produce a valid query after 3 attempts" over a query that was
+        # never the problem, hiding the sentence naming what an operator has to fix.
+        logger.warning("unrepairable refusal survived %d attempts: %s (%r)",
+                       max_attempts, last.code.value, last.subject)
+        return _not_our_sql(last, carries_source_words)
+
     reason = last.message if last else "The query could not be made valid."
     return Deferred(
         reason=f"Could not produce a valid query after {max_attempts} attempts. {reason}",
         code=DeferralReason.INVALID_QUERY,
+    )
+
+
+def _not_our_sql(verdict, carries_source_words: bool) -> Deferred:
+    """Answer with a refusal no rewrite can fix, under the code that says whose problem it is.
+
+    Both exits above land here, and they have to agree: one gives up at once and the other after
+    the attempts run out, and a caller cannot tell those apart from the answer -- nor should the
+    reason change because the engine happened to try first.
+
+    The message goes back whole, because these refusals are the ones that say what an OPERATOR
+    must change, and burying that under a retry count is what made the useful sentence look like
+    a footnote to a failure.
+    """
+    code, without_subject = _UNREPAIRABLE.get(verdict.code,
+                                              (DeferralReason.UNGOVERNABLE, None))
+    return Deferred(
+        reason=(without_subject if without_subject and carries_source_words
+                else verdict.message),
+        code=code,
     )

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -241,10 +241,11 @@ def _cannot_resolve(inventory: FunctionInventory, *, unreadable: bool = False) -
       * `user_functions` itself raised -- likewise, and earlier
       * this one statement would not render -- about the STATEMENT, not the source at all
 
-    The last two are also the two worth RETRYING, and they say so with
-    `repairable_override`: a rewrite can fix the statement, and `decide` re-asks the source on
-    every attempt, so a blip resolves itself. The first three are properties of the source that
-    no attempt of ours changes, and the retry loop stops on them (M98).
+    Worth RETRYING, and saying so with `repairable_override`: the statement that would not
+    render, since a rewrite can fix it, and both catalogue calls that RAISED, since `decide`
+    re-asks the source on every attempt and a blip resolves itself. Not worth retrying: a source
+    that redefines a builtin's name, and an adapter with no `builtin_functions` at all. Neither
+    is a thing an attempt of ours changes, and the loop stops on them (M98).
 
     Two of them were caught borrowing another's sentence, and both times the effect was to send
     someone to fix working code. That is the failure this list is arranged against.
@@ -274,21 +275,29 @@ def _cannot_resolve(inventory: FunctionInventory, *, unreadable: bool = False) -
             ),
             repairable_override=True,
         )
-    # What is left is a property of the SOURCE, which no attempt of ours changes.
     shadowed = sorted(inventory.names & inventory.builtins) if inventory.builtins else []
     if shadowed:
+        # The source's own configuration. Every attempt lands here until someone renames it.
         detail = f"This source defines {shadowed[0]!r} under a name it also lists as a builtin"
+        retry = False
     elif inventory.builtins_asked:
+        # ASKED and failed, so the same call that raised is made again next attempt -- the same
+        # argument as the `user_functions` arrival above, which is why leaving this one out was
+        # a contradiction rather than a nuance.
         detail = ("This source defines functions of its own and could not say which names are "
                   "its builtins")
+        retry = True
     else:
+        # The adapter has no such method, which is not a thing an attempt changes.
         detail = ("This source defines functions of its own and was never asked which names are "
                   "its builtins")
+        retry = False
     return Refusal(
         code=RefusalCode.UNRESOLVABLE_CALLS,
         message=(
             f"{detail}, so this engine cannot confirm what this query executes against it. "
-            "No query can be decided against this source."
+            + ("Try again." if retry else "No query can be decided against this source.")
         ),
         subject=shadowed[0] if shadowed else None,
+        repairable_override=True if retry else None,
     )

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -241,6 +241,11 @@ def _cannot_resolve(inventory: FunctionInventory, *, unreadable: bool = False) -
       * `user_functions` itself raised -- likewise, and earlier
       * this one statement would not render -- about the STATEMENT, not the source at all
 
+    The last two are also the two worth RETRYING, and they say so with
+    `repairable_override`: a rewrite can fix the statement, and `decide` re-asks the source on
+    every attempt, so a blip resolves itself. The first three are properties of the source that
+    no attempt of ours changes, and the retry loop stops on them (M98).
+
     Two of them were caught borrowing another's sentence, and both times the effect was to send
     someone to fix working code. That is the failure this list is arranged against.
     """
@@ -252,24 +257,33 @@ def _cannot_resolve(inventory: FunctionInventory, *, unreadable: bool = False) -
                 "functions it asks the source for, and this source defines functions of its "
                 "own. Answer using only the listed tables and columns and standard SQL."
             ),
+            # The one arrival that is about the STATEMENT, so the one a rewrite can fix -- and
+            # the message asks for one. The code alone would send it to the no-retry path with
+            # the other arrivals, under a card saying rephrasing will not help.
+            repairable_override=True,
         )
     if not inventory.available:
-        detail = "This source could not say which functions it defines"
-        shadowed = []
+        # Retried, because it may be transient and `decide` re-asks the source on every attempt
+        # (`inventory_from` reads LIVE, not from the snapshot). A single blip should not tell a
+        # caller to page an operator. If it is not a blip the attempts run out and it says so.
+        return Refusal(
+            code=RefusalCode.UNRESOLVABLE_CALLS,
+            message=(
+                "This source could not say which functions it defines, so this engine cannot "
+                "confirm what this query executes against it."
+            ),
+            repairable_override=True,
+        )
+    # What is left is a property of the SOURCE, which no attempt of ours changes.
+    shadowed = sorted(inventory.names & inventory.builtins) if inventory.builtins else []
+    if shadowed:
+        detail = f"This source defines {shadowed[0]!r} under a name it also lists as a builtin"
+    elif inventory.builtins_asked:
+        detail = ("This source defines functions of its own and could not say which names are "
+                  "its builtins")
     else:
-        shadowed = sorted(inventory.names & inventory.builtins) if inventory.builtins else []
-        if shadowed:
-            detail = f"This source defines {shadowed[0]!r} under a name it also lists as a builtin"
-        elif inventory.builtins_asked:
-            detail = (
-                "This source defines functions of its own and could not say which names are "
-                "its builtins"
-            )
-        else:
-            detail = (
-                "This source defines functions of its own and was never asked which names are "
-                "its builtins"
-            )
+        detail = ("This source defines functions of its own and was never asked which names are "
+                  "its builtins")
     return Refusal(
         code=RefusalCode.UNRESOLVABLE_CALLS,
         message=(

--- a/src/mnemiq/sql/functions.py
+++ b/src/mnemiq/sql/functions.py
@@ -219,8 +219,8 @@ def _builtins_from(adapter) -> tuple[frozenset[str] | None, bool]:
     depends on it is whether the source can answer anything at all: without this, a source
     holding one macro has every read and every write against it refused. Optional in the sense
     that omitting it cannot open a hole, not in the sense that omitting it is cheap -- the
-    refusal is classified unrepairable, and until something reads `REPAIRABLE` the caller pays
-    for retries that cannot succeed rather than getting one clean refusal.
+    refusal is classified unrepairable, so the caller gets it at once (M98) rather than after a
+    round of retries that cannot succeed -- one clean refusal naming what to change.
     """
     if adapter is None or not hasattr(adapter, "builtin_functions"):
         return None, False

--- a/src/mnemiq/sql/verdict.py
+++ b/src/mnemiq/sql/verdict.py
@@ -73,15 +73,29 @@ REPAIRABLE = frozenset(
         # and the repair loop can rewrite that into arithmetic the engine does model.
         # Without this the guard's false positives become deferrals instead of retries.
         RefusalCode.UNMODELLED_CALL,
+        # The three below were absent while nothing read this set, so nothing had checked them
+        # against the loop that ignored it. Each says what to do differently, in its own
+        # message, which is the test for belonging here:
+        #
+        #   MASKED_COLUMN_IN_PREDICATE -- "may only be selected, not used in a filter"
+        #   UNGOVERNED_VIEW            -- "Query the table directly."
+        #   UNRESOLVABLE_VIEW          -- the view is the problem, and the model chose to use it
+        #
+        # The last is the weakest of the three: its messages name the view without saying to
+        # avoid it, and a self-referential view is the source's DDL rather than anything the
+        # model did. Listed anyway, because the safe direction here is the one that changes no
+        # behaviour, and a wasted retry costs a model call while a wrong refusal costs an answer.
+        RefusalCode.MASKED_COLUMN_IN_PREDICATE,
+        RefusalCode.UNGOVERNED_VIEW,
+        RefusalCode.UNRESOLVABLE_VIEW,
         # UNRESOLVABLE_CALLS is deliberately absent. It condemns every statement against the
         # source, not one function, so there is nothing for a rewrite to avoid and a retry loop
         # would spend every attempt to reach the deferral it starts at. The fix belongs to the
         # deployer, who sees this in the trace, not to the model.
         #
-        # That is the INTENT. Nothing reads this set yet: `plan_query` retries every refusal but
-        # UNAUTHORIZED_TABLE, so today an unrepairable code is retried until the attempts run
-        # out and usually arrives as something else. Recorded rather than fixed here --
-        # wiring it changes the outcome of every code in the set, which wants its own measurement.
+        # `plan_query` reads this now (M98). It used to retry every refusal but
+        # UNAUTHORIZED_TABLE, so an unrepairable code was retried until the attempts ran out and
+        # arrived as INVALID_QUERY -- three model calls to reach a verdict the first one had.
         RefusalCode.LOGIC_LINT,
         RefusalCode.VALUE_GROUNDING,
     }
@@ -114,8 +128,16 @@ class Refusal:
     # a partial-containment check is a guard with a false-positive rate nobody has measured.
     source_detail: str | None = None
 
+    # When the CODE is not enough to say. One code can be reached by arrivals that differ on
+    # this: `UNRESOLVABLE_CALLS` condemns the whole source when it defines a name a builtin also
+    # has, and is about this one statement when the statement would not render -- whose message
+    # asks for a rewrite. Left None, the code decides, which is what every other refusal wants.
+    repairable_override: bool | None = None
+
     @property
     def repairable(self) -> bool:
+        if self.repairable_override is not None:
+            return self.repairable_override
         return self.code in REPAIRABLE
 
     @property

--- a/tests/test_plan_query.py
+++ b/tests/test_plan_query.py
@@ -1,11 +1,13 @@
 import logging
 
+import pytest
+
 from mnemiq.authz.grants import GrantSet
 from mnemiq.contract import Column, Snapshot
 from mnemiq.generate.generator import FakeGenerator
 from mnemiq.generate.plan_query import Deferred, plan_query
 from mnemiq.semantic.retrieval import ContextPacket, RetrievedCard
-from mnemiq.sql.verdict import Approved
+from mnemiq.sql.verdict import Approved, RefusalCode
 
 
 def _snapshot() -> Snapshot:
@@ -362,3 +364,198 @@ def test_a_table_the_source_never_named_is_still_named_to_the_caller():
 
     assert isinstance(outcome, Deferred)
     assert "person" in outcome.reason
+
+
+# --------------------------------------------------------------------------------------------
+# M98. `REPAIRABLE` classified ten codes and nothing read it: every refusal but
+# UNAUTHORIZED_TABLE was retried, so an unrepairable one cost `max_attempts` model calls to reach
+# the verdict the first one already had, and arrived as INVALID_QUERY -- "could not produce a
+# valid query after 3 attempts", claiming an attempt that could not have worked.
+# --------------------------------------------------------------------------------------------
+
+
+def _pii_snapshot() -> Snapshot:
+    """A column the identity's clearance denies, so `check_cls` refuses on it."""
+    return Snapshot(
+        version="v1", source_id="acme", created_at="2026-07-13T00:00:00Z",
+        columns=[
+            Column(id="claim.claim_identifier", object_id="claim", name="claim_identifier"),
+            Column(id="claim.ssn", object_id="claim", name="ssn", pii_level="direct"),
+        ],
+    )
+
+
+def test_a_denied_column_is_not_a_puzzle_to_solve_with_another_attempt():
+    """The same argument the table branch makes, on the code beside it. Retrying spent three
+    calls inviting the model to find another route to a column this identity may not read, and
+    a route it FINDS answers a subtly different question than the one that was asked."""
+    from mnemiq.contract import DeferralReason
+
+    generator = FakeGenerator([
+        '{"sql": "SELECT ssn FROM claim"}',
+        '{"sql": "SELECT claim_identifier FROM claim"}',   # must never be reached
+    ])
+    outcome = plan_query(_packet(), _pii_snapshot(), _GRANTS, generator, target="duckdb")
+
+    assert isinstance(outcome, Deferred)
+    assert outcome.code is DeferralReason.AUTHORIZATION
+    assert len(generator.calls) == 1
+    assert "3 attempts" not in outcome.reason, "it did not make three attempts"
+
+
+def test_a_source_the_engine_cannot_govern_is_not_retried_either():
+    """The default arm of the mapping, and the reason the new code exists. A source that
+    redefines a builtin's name cannot be decided at all, so no rewrite is a rewrite of anything
+    -- and the refusal names what an OPERATOR must change, which three retries buried under a
+    count of attempts that were never made."""
+    import os
+    import tempfile
+
+    import duckdb
+
+    from mnemiq.adapters.duckdb import DuckDBAdapter
+    from mnemiq.contract import DeferralReason
+
+    path = os.path.join(tempfile.mkdtemp(), "shadow.duckdb")
+    con = duckdb.connect(path)
+    con.execute("CREATE TABLE claim(claim_identifier INTEGER, status VARCHAR)")
+    con.execute("CREATE MACRO count_star() AS (SELECT 1)")
+    con.close()
+
+    generator = FakeGenerator([
+        '{"sql": "SELECT count(*) AS n FROM claim"}',
+        '{"sql": "SELECT claim_identifier FROM claim"}',   # must never be reached
+    ])
+    outcome = plan_query(_packet(), _snapshot(), _GRANTS, generator,
+                         adapter=DuckDBAdapter.duckdb(path), dialect="duckdb", target="duckdb")
+
+    assert isinstance(outcome, Deferred)
+    assert outcome.code is DeferralReason.UNGOVERNABLE
+    assert len(generator.calls) == 1
+    assert "count_star" in outcome.reason, "the sentence an operator needs, not a retry count"
+
+
+def test_a_repairable_refusal_is_still_retried():
+    """The control, and the half that could quietly break. Reading `REPAIRABLE` where nothing
+    read it before turns every membership decision into behaviour, and a code wrongly left out
+    of the set now costs an answer rather than a retry."""
+    outcome, generator = _plan([
+        '{"sql": "SELECT * FROM claim"}',
+        '{"sql": "SELECT claim_identifier FROM claim"}',
+    ])
+    assert isinstance(outcome, Approved) and len(generator.calls) == 2
+
+
+def test_a_denied_columns_name_is_withheld_once_source_words_are_in_play():
+    """`check_cls` reads the subject off `exp.Column` in the model's own SQL, so a model handed
+    the source's words can name a "column" spelled out of them -- the same provenance as the
+    table branch's subject, and the same suppression. The generic path would otherwise print
+    whatever the model wrote.
+
+    The seeded `Feedback` is how the agent hands back what the DATABASE said, which is the way
+    source words enter this loop in production.
+    """
+    from mnemiq.contract import DeferralReason
+    from mnemiq.generate.plan_query import Feedback
+
+    generator = FakeGenerator(['{"sql": "SELECT ssn FROM claim"}'])
+    outcome = plan_query(_packet(), _pii_snapshot(), _GRANTS, generator, target="duckdb",
+                         feedback=Feedback("the source said: no column 'ssn'", from_source=True))
+
+    assert isinstance(outcome, Deferred) and outcome.code is DeferralReason.AUTHORIZATION
+    assert "ssn" not in outcome.reason, "the subject is model-authored and source words are live"
+
+    # ...and it IS named when nothing source-derived reached the model, because a caller told
+    # which column they lack can ask for it. Withholding it always would cost that for nothing.
+    plain = FakeGenerator(['{"sql": "SELECT ssn FROM claim"}'])
+    named = plan_query(_packet(), _pii_snapshot(), _GRANTS, plain, target="duckdb")
+    assert "ssn" in named.reason
+
+
+# The loop's contract, one row per refusal code, written out INDEPENDENTLY of `REPAIRABLE`.
+# Reading the set here would make the test agree with the code by construction, which is exactly
+# what it must not do: the set's membership only became behaviour when `plan_query` started
+# reading it (M98), and until then a wrong entry cost nothing and so was never checked. Deleting
+# `UNGOVERNED_VIEW` from the set has to fail something.
+#
+# True = the model is asked again. False = the caller is answered at once.
+_RETRIED = {
+    # The model's own SQL, and the message says what to change.
+    RefusalCode.PARSE_ERROR: True,
+    RefusalCode.NOT_A_SINGLE_STATEMENT: True,
+    RefusalCode.NOT_SELECT_ONLY: True,
+    RefusalCode.SELECT_STAR: True,
+    RefusalCode.UNKNOWN_TABLE: True,
+    RefusalCode.UNKNOWN_COLUMN: True,
+    RefusalCode.EXPLAIN_FAILED: True,
+    RefusalCode.UNMODELLED_CALL: True,
+    RefusalCode.LOGIC_LINT: True,
+    RefusalCode.VALUE_GROUNDING: True,
+    # "may only be selected, not used in a filter" / "Query the table directly." Both name a
+    # different query, which is the test for belonging here.
+    RefusalCode.MASKED_COLUMN_IN_PREDICATE: True,
+    RefusalCode.UNGOVERNED_VIEW: True,
+    # The weakest of the three: the model chose to use the view, and the messages name it
+    # without saying to avoid it. Retried because the safe direction changes no behaviour.
+    RefusalCode.UNRESOLVABLE_VIEW: True,
+    # Grants. A guard that can be retried is a puzzle, not a guard, and a route the model FINDS
+    # answers a subtly different question than the one that was asked.
+    RefusalCode.UNAUTHORIZED_TABLE: False,
+    RefusalCode.UNAUTHORIZED_COLUMN: False,
+    # Properties of the source or the policy. No rewrite is a rewrite of anything.
+    RefusalCode.UNRESOLVABLE_CALLS: False,
+    RefusalCode.VIEW_INVENTORY_UNAVAILABLE: False,
+    RefusalCode.INVALID_ROW_FILTER: False,
+    # Write-path codes. `decide_write` is called from the runtime, not through this loop, so
+    # none of these can arrive here -- listed so a future caller that routes writes through
+    # `plan_query` finds a decision already made rather than a default.
+    RefusalCode.NOT_A_WRITE: False,
+    RefusalCode.UNBOUNDED_WRITE: False,
+    RefusalCode.UNAUTHORIZED_WRITE: False,
+    RefusalCode.WRITES_DISABLED: False,
+    RefusalCode.AMBIGUOUS_WRITE_TARGET: False,
+    RefusalCode.UNSCOPED_CTE: False,
+}
+
+
+def _attempts_for(code, monkeypatch):
+    """Drive the loop with a refusal of `code`, then an approval. Returns the generator calls.
+
+    The refusal is INJECTED rather than provoked: what is under test is the loop's response to a
+    code, not the twenty different fixtures it takes to make `decide` emit each one -- several of
+    which (an invalid row filter, a self-referential view) need a snapshot shaped for that one
+    case and would say nothing about the branch that reads them.
+    """
+    from mnemiq.sql.verdict import Refusal
+
+    calls = {"n": 0}
+
+    def fake_decide(sql, *a, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return Refusal(code=code, message="refused for a test", subject="thing")
+        return Approved(plan_sql=sql, target_sql=sql)
+
+    monkeypatch.setattr("mnemiq.generate.plan_query.decide", fake_decide)
+    generator = FakeGenerator(['{"sql": "SELECT claim_identifier FROM claim"}'] * 3)
+    outcome = plan_query(_packet(), _snapshot(), _GRANTS, generator, target="duckdb")
+    return outcome, generator.calls
+
+
+@pytest.mark.parametrize("code, retried", sorted(_RETRIED.items(), key=lambda kv: kv[0].value))
+def test_the_loop_retries_exactly_what_the_classification_says(code, retried, monkeypatch):
+    outcome, calls = _attempts_for(code, monkeypatch)
+
+    if retried:
+        assert isinstance(outcome, Approved), f"{code.value} was not retried"
+        assert len(calls) == 2
+    else:
+        assert isinstance(outcome, Deferred), f"{code.value} was retried"
+        assert len(calls) == 1
+        assert "attempts" not in outcome.reason, "it made one attempt, not three"
+
+
+def test_every_refusal_code_has_a_row_above():
+    """A new code otherwise inherits `not repairable` from the set's default and is answered at
+    once, which is the safe direction and still a decision somebody should make on purpose."""
+    assert set(_RETRIED) == set(RefusalCode), set(_RETRIED) ^ set(RefusalCode)

--- a/tests/test_plan_query.py
+++ b/tests/test_plan_query.py
@@ -76,6 +76,12 @@ def test_the_loop_is_bounded():
     outcome, generator = _plan(['{"sql": "SELECT * FROM claim"}'] * 5, max_attempts=3)
     assert isinstance(outcome, Deferred)
     assert len(generator.calls) == 3
+    # ...and a model that never writes valid SQL is exactly what INVALID_QUERY is for. The
+    # exhaustion exit hands a SOURCE fault to `_not_our_sql` instead, and dropping the guard
+    # that tells the two apart would report this one as ungovernable -- blaming the deployment
+    # for three attempts at `SELECT *`.
+    assert outcome.code is DeferralReason.INVALID_QUERY
+    assert "3 attempts" in outcome.reason
 
 
 def test_a_model_deferral_is_passed_through():
@@ -584,3 +590,46 @@ def test_the_denied_column_is_written_where_the_caller_cannot_see_it(caplog):
     assert "ssn" not in outcome.reason
     assert "ssn" in caplog.text, "the operator still has to be able to see what was refused"
     assert "unauthorized_column" in caplog.text
+
+
+def test_a_source_fault_that_survives_every_attempt_is_still_a_source_fault():
+    """The exhaustion exit is the one M98 was about, and retrying an override-marked refusal put
+    it back: a catalogue call that fails on all three attempts used to leave as INVALID_QUERY --
+    "could not produce a valid query after 3 attempts" over a query that was never the problem,
+    with the sentence naming what an operator must fix demoted to a trailing clause.
+
+    Both endings are pinned, because the retry only earns its cost if recovery is real: the
+    source that answers on the second attempt gets an answer, and the one that never answers
+    gets the same code it would have got without the attempts.
+    """
+    from mnemiq.contract import DeferralReason
+    from mnemiq.sql.verdict import Refusal
+
+    def blips(n_failures):
+        calls = {"n": 0}
+
+        def fake_decide(sql, *a, **kw):
+            calls["n"] += 1
+            if calls["n"] <= n_failures:
+                return Refusal(code=RefusalCode.UNRESOLVABLE_CALLS,
+                               message="This source could not say. Try again.",
+                               repairable_override=True)
+            return Approved(plan_sql=sql, target_sql=sql)
+        return fake_decide
+
+    import pytest as _pytest
+    for failures, check in ((1, "recovers"), (9, "exhausts")):
+        mp = _pytest.MonkeyPatch()
+        mp.setattr("mnemiq.generate.plan_query.decide", blips(failures))
+        generator = FakeGenerator(['{"sql": "SELECT claim_identifier FROM claim"}'] * 5)
+        outcome = plan_query(_packet(), _snapshot(), _GRANTS, generator, target="duckdb")
+        mp.undo()
+
+        if check == "recovers":
+            assert isinstance(outcome, Approved), "the retry has to be able to succeed"
+            assert len(generator.calls) == 2
+        else:
+            assert isinstance(outcome, Deferred)
+            assert outcome.code is DeferralReason.UNGOVERNABLE, outcome.code
+            assert "attempts" not in outcome.reason
+            assert len(generator.calls) == 3, "it did use the whole budget"

--- a/tests/test_plan_query.py
+++ b/tests/test_plan_query.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 
 from mnemiq.authz.grants import GrantSet
-from mnemiq.contract import Column, Snapshot
+from mnemiq.contract import Column, DeferralReason, Snapshot
 from mnemiq.generate.generator import FakeGenerator
 from mnemiq.generate.plan_query import Deferred, plan_query
 from mnemiq.semantic.retrieval import ContextPacket, RetrievedCard
@@ -478,7 +478,10 @@ def test_a_denied_columns_name_is_withheld_once_source_words_are_in_play():
 # reading it (M98), and until then a wrong entry cost nothing and so was never checked. Deleting
 # `UNGOVERNED_VIEW` from the set has to fail something.
 #
-# True = the model is asked again. False = the caller is answered at once.
+# True = the model is asked again. Otherwise the DeferralReason the caller is answered with at
+# once, because "it deferred" is not the claim -- routing a code to the wrong reason sends the
+# operator to the wrong place, and `policy_unavailable` over an invalid row filter would tell
+# them the policy could not be read when it was read and one predicate in it is invalid.
 _RETRIED = {
     # The model's own SQL, and the message says what to change.
     RefusalCode.PARSE_ERROR: True,
@@ -500,21 +503,21 @@ _RETRIED = {
     RefusalCode.UNRESOLVABLE_VIEW: True,
     # Grants. A guard that can be retried is a puzzle, not a guard, and a route the model FINDS
     # answers a subtly different question than the one that was asked.
-    RefusalCode.UNAUTHORIZED_TABLE: False,
-    RefusalCode.UNAUTHORIZED_COLUMN: False,
+    RefusalCode.UNAUTHORIZED_TABLE: DeferralReason.AUTHORIZATION,
+    RefusalCode.UNAUTHORIZED_COLUMN: DeferralReason.AUTHORIZATION,
     # Properties of the source or the policy. No rewrite is a rewrite of anything.
-    RefusalCode.UNRESOLVABLE_CALLS: False,
-    RefusalCode.VIEW_INVENTORY_UNAVAILABLE: False,
-    RefusalCode.INVALID_ROW_FILTER: False,
+    RefusalCode.UNRESOLVABLE_CALLS: DeferralReason.UNGOVERNABLE,
+    RefusalCode.VIEW_INVENTORY_UNAVAILABLE: DeferralReason.UNGOVERNABLE,
+    RefusalCode.INVALID_ROW_FILTER: DeferralReason.UNGOVERNABLE,
     # Write-path codes. `decide_write` is called from the runtime, not through this loop, so
     # none of these can arrive here -- listed so a future caller that routes writes through
     # `plan_query` finds a decision already made rather than a default.
-    RefusalCode.NOT_A_WRITE: False,
-    RefusalCode.UNBOUNDED_WRITE: False,
-    RefusalCode.UNAUTHORIZED_WRITE: False,
-    RefusalCode.WRITES_DISABLED: False,
-    RefusalCode.AMBIGUOUS_WRITE_TARGET: False,
-    RefusalCode.UNSCOPED_CTE: False,
+    RefusalCode.NOT_A_WRITE: DeferralReason.UNGOVERNABLE,
+    RefusalCode.UNBOUNDED_WRITE: DeferralReason.UNGOVERNABLE,
+    RefusalCode.UNAUTHORIZED_WRITE: DeferralReason.UNGOVERNABLE,
+    RefusalCode.WRITES_DISABLED: DeferralReason.UNGOVERNABLE,
+    RefusalCode.AMBIGUOUS_WRITE_TARGET: DeferralReason.UNGOVERNABLE,
+    RefusalCode.UNSCOPED_CTE: DeferralReason.UNGOVERNABLE,
 }
 
 
@@ -542,20 +545,42 @@ def _attempts_for(code, monkeypatch):
     return outcome, generator.calls
 
 
-@pytest.mark.parametrize("code, retried", sorted(_RETRIED.items(), key=lambda kv: kv[0].value))
-def test_the_loop_retries_exactly_what_the_classification_says(code, retried, monkeypatch):
+@pytest.mark.parametrize("code, expected", sorted(_RETRIED.items(), key=lambda kv: kv[0].value))
+def test_the_loop_retries_exactly_what_the_classification_says(code, expected, monkeypatch):
     outcome, calls = _attempts_for(code, monkeypatch)
 
-    if retried:
+    if expected is True:
         assert isinstance(outcome, Approved), f"{code.value} was not retried"
         assert len(calls) == 2
     else:
         assert isinstance(outcome, Deferred), f"{code.value} was retried"
         assert len(calls) == 1
         assert "attempts" not in outcome.reason, "it made one attempt, not three"
+        assert outcome.code is expected, f"{code.value} deferred as {outcome.code}"
 
 
 def test_every_refusal_code_has_a_row_above():
     """A new code otherwise inherits `not repairable` from the set's default and is answered at
     once, which is the safe direction and still a decision somebody should make on purpose."""
     assert set(_RETRIED) == set(RefusalCode), set(_RETRIED) ^ set(RefusalCode)
+
+
+def test_the_denied_column_is_written_where_the_caller_cannot_see_it(caplog):
+    """When the name is withheld from the caller, the deployment's log is the only place it is
+    written. The table branch pins the same rule, which is what made its absence here a gap
+    rather than a preference: an operator asked "why did this defer" has nothing otherwise.
+
+    The server log is the right destination and deliberately so -- it already sits inside the
+    boundary that holds the connection settings.
+    """
+    from mnemiq.generate.plan_query import Feedback
+
+    generator = FakeGenerator(['{"sql": "SELECT ssn FROM claim"}'])
+    with caplog.at_level(logging.WARNING):
+        outcome = plan_query(
+            _packet(), _pii_snapshot(), _GRANTS, generator, target="duckdb",
+            feedback=Feedback("the source said: no column 'ssn'", from_source=True))
+
+    assert "ssn" not in outcome.reason
+    assert "ssn" in caplog.text, "the operator still has to be able to see what was refused"
+    assert "unauthorized_column" in caplog.text

--- a/tests/test_sql_authz_guard.py
+++ b/tests/test_sql_authz_guard.py
@@ -409,12 +409,16 @@ def test_one_code_two_answers_about_whether_to_try_again():
     """`UNRESOLVABLE_CALLS` is reached by arrivals that disagree about retrying, so the CODE
     cannot decide it and `repairable_override` says which (M98).
 
-    Two are worth another attempt. A statement that would not render is about the statement, and
-    its message asks for a rewrite. A source whose `user_functions` raised may be having a blip,
-    and `decide` re-asks it live on every attempt, so the loop resolves that by itself. The rest
-    are properties of the source that no attempt of ours changes -- retrying them spends the
-    caller's budget to arrive where the first refusal already was, under a card telling them
-    rephrasing will not help.
+    Worth another attempt: the statement that would not render, whose message asks for a
+    rewrite, and every catalogue call that RAISED, since `decide` re-asks the source live on
+    each attempt and a blip resolves itself. Not worth it: a source that redefines a builtin's
+    name, and an adapter with no `builtin_functions` at all. Retrying those spends the caller's
+    budget to arrive where the first refusal already was, under a card telling them rephrasing
+    will not help.
+
+    And the closing SENTENCE has to match, because it is the one the caller reads: telling
+    someone whose query is being retried that no query can be decided against this source is
+    the same defect one surface out.
     """
     from mnemiq.sql.authz_guard import check_unmodelled_calls
     from mnemiq.sql.functions import FunctionInventory
@@ -437,7 +441,9 @@ def test_one_code_two_answers_about_whether_to_try_again():
     # `builtin_functions()` having thrown, which the next attempt makes again -- leaving it out
     # while retrying its sibling was a contradiction, not a nuance.
     raised = FunctionInventory.of(["commission_rate"], builtins_asked=True)
-    assert check_unmodelled_calls(ast, raised, "duckdb").repairable is True
+    retried = check_unmodelled_calls(ast, raised, "duckdb")
+    assert retried.repairable is True
+    assert "Try again." in retried.message
 
     shadowing = FunctionInventory.of(["median"], builtins=["median"])
     no_such_method = FunctionInventory.of(["commission_rate"])   # builtins_asked stays False
@@ -445,3 +451,5 @@ def test_one_code_two_answers_about_whether_to_try_again():
         refusal = check_unmodelled_calls(ast, inventory, "duckdb")
         assert refusal.code is RefusalCode.UNRESOLVABLE_CALLS
         assert refusal.repairable is False, inventory
+        assert "No query can be decided against this source." in refusal.message, inventory
+        assert "Try again." not in refusal.message, inventory

--- a/tests/test_sql_authz_guard.py
+++ b/tests/test_sql_authz_guard.py
@@ -433,9 +433,15 @@ def test_one_code_two_answers_about_whether_to_try_again():
     assert check_unmodelled_calls(
         ast, FunctionInventory.unavailable("RuntimeError"), "duckdb").repairable is True
 
+    # ...and so is the OTHER catalogue call that raised. `builtins_asked` with no builtins is
+    # `builtin_functions()` having thrown, which the next attempt makes again -- leaving it out
+    # while retrying its sibling was a contradiction, not a nuance.
+    raised = FunctionInventory.of(["commission_rate"], builtins_asked=True)
+    assert check_unmodelled_calls(ast, raised, "duckdb").repairable is True
+
     shadowing = FunctionInventory.of(["median"], builtins=["median"])
-    never_asked_builtins = FunctionInventory.of(["commission_rate"])
-    for inventory in (shadowing, never_asked_builtins):
+    no_such_method = FunctionInventory.of(["commission_rate"])   # builtins_asked stays False
+    for inventory in (shadowing, no_such_method):
         refusal = check_unmodelled_calls(ast, inventory, "duckdb")
         assert refusal.code is RefusalCode.UNRESOLVABLE_CALLS
         assert refusal.repairable is False, inventory

--- a/tests/test_sql_authz_guard.py
+++ b/tests/test_sql_authz_guard.py
@@ -403,3 +403,39 @@ def test_an_unresolvable_source_is_not_repaired_into_an_answer():
 
     assert RefusalCode.UNMODELLED_CALL in REPAIRABLE
     assert RefusalCode.UNRESOLVABLE_CALLS not in REPAIRABLE
+
+
+def test_one_code_two_answers_about_whether_to_try_again():
+    """`UNRESOLVABLE_CALLS` is reached by arrivals that disagree about retrying, so the CODE
+    cannot decide it and `repairable_override` says which (M98).
+
+    Two are worth another attempt. A statement that would not render is about the statement, and
+    its message asks for a rewrite. A source whose `user_functions` raised may be having a blip,
+    and `decide` re-asks it live on every attempt, so the loop resolves that by itself. The rest
+    are properties of the source that no attempt of ours changes -- retrying them spends the
+    caller's budget to arrive where the first refusal already was, under a card telling them
+    rephrasing will not help.
+    """
+    from mnemiq.sql.authz_guard import check_unmodelled_calls
+    from mnemiq.sql.functions import FunctionInventory
+
+    class WillNotRender(sqlglot.exp.Expression):
+        def sql(self, *a, **kw):
+            raise ValueError("no")
+
+        def find_all(self, *types):
+            yield sqlglot.exp.Anonymous(this="count")
+
+    defines_something = FunctionInventory.of(["commission_rate"], builtins=["count_star"])
+    ast = sqlglot.parse_one("SELECT median(id) FROM claim", read="duckdb")
+
+    assert check_unmodelled_calls(WillNotRender(), defines_something, "duckdb").repairable is True
+    assert check_unmodelled_calls(
+        ast, FunctionInventory.unavailable("RuntimeError"), "duckdb").repairable is True
+
+    shadowing = FunctionInventory.of(["median"], builtins=["median"])
+    never_asked_builtins = FunctionInventory.of(["commission_rate"])
+    for inventory in (shadowing, never_asked_builtins):
+        refusal = check_unmodelled_calls(ast, inventory, "duckdb")
+        assert refusal.code is RefusalCode.UNRESOLVABLE_CALLS
+        assert refusal.repairable is False, inventory

--- a/workbench/src/lib/types.ts
+++ b/workbench/src/lib/types.ts
@@ -24,7 +24,8 @@ export type DeferralReason =
   | "disagreement"
   | "execution_failed"
   | "model_unavailable"
-  | "verifier_unavailable";
+  | "verifier_unavailable"
+  | "ungovernable";
 
 /** Postgres numerics arrive as strings; nulls stay null rather than becoming "". */
 export type Cell = string | number | boolean | null;

--- a/workbench/src/lib/verdict.ts
+++ b/workbench/src/lib/verdict.ts
@@ -87,6 +87,14 @@ export const REASONS: Record<DeferralReason, { title: string; next: string }> = 
     // cases share is that nothing was judged, which is the part the operator needs.
     next: "The query ran; the verifier gave no usable answer, so the result was withheld rather than returned unchecked. Nothing here is a judgement about your data — check the verifier endpoint and its model.",
   },
+  // A deferral, NOT one of the three above that ride `failed: true`. The engine could not
+  // establish that the query is governed -- a source that redefines a builtin's name, a row
+  // filter that is not a valid predicate -- so rephrasing is the one thing that will not help.
+  // It is not retried either (M98): trying could not have worked.
+  ungovernable: {
+    title: "The engine cannot confirm this query is governed",
+    next: "Page an operator. Rephrasing will not help — the reason is in the source or the policy, not in your question.",
+  },
 };
 
 /** 412 ms / 8.5 s / 2 m 04 s -- always legible, never more precision than is useful. */


### PR DESCRIPTION
`REPAIRABLE` held ten refusal codes and `Refusal.repairable` read it, and
**nothing else did**. `plan_query` retried every refusal but `UNAUTHORIZED_TABLE`,
so an unrepairable one cost `max_attempts` model calls to reach the verdict the
first one already had, and arrived as `INVALID_QUERY` — *"could not produce a
valid query after 3 attempts"* — which claims an attempt that could not have
worked and buries the sentence naming what an operator must change.

Found while closing #2: the new code was deliberately left out of the set, and
checking what that bought found it bought nothing.

### Reading the set makes its membership behaviour

And the membership had never been checked against the loop that ignored it.
Three codes belonged in it and were not:

| code | its own message |
|---|---|
| `MASKED_COLUMN_IN_PREDICATE` | "may only be selected, not used in a filter" |
| `UNGOVERNED_VIEW` | "Query the table directly." |
| `UNRESOLVABLE_VIEW` | names the view — the weakest of the three |

Each names a different query, which is the test for belonging. The safe
direction is the one that changes no behaviour: a wasted retry costs a model
call, a wrong refusal costs an answer.

The write codes never reach this loop — `decide_write` is called from the
runtime, not through `plan_query` — so the blast radius was five codes, not the
thirteen the register row estimated.

### One code is not classifiable by code

`UNRESOLVABLE_CALLS` is reached by five arrivals and they disagree. A statement
that would not render is about the statement, and its message asks for a rewrite.
A catalogue call that **raised** may be a blip, and `decide` re-asks the source
live on every attempt. The rest are properties of the source that no attempt of
ours changes. So the refusal carries `repairable_override` where the code cannot
answer.

Retrying those then put the original defect back one exit down: a catalogue call
that failed on all three attempts left as `INVALID_QUERY` again. Both exits
answer through one function now, so a caller cannot tell from the reason whether
the engine gave up at once or tried first — and a code the set calls repairable
that simply never came right is still `INVALID_QUERY`, which is what that code is
for.

### `UNGOVERNABLE`

New, because the rest have no home. `policy_unavailable` says the policy could
not be **read**; here it was read and one predicate in it is invalid. Mapping
`INVALID_ROW_FILTER` there was the first answer and reads well until an operator
sees the card title.

`UNAUTHORIZED_COLUMN` takes the table branch's suppression as well as its
argument — its subject is read off `exp.Column` in the model's own SQL — and the
log keeps the name the caller is not told, since the deployment's log is then the
only place it is written.

### The test owns the table

One row per refusal code, written out **independently of `REPAIRABLE`**: retried,
or the `DeferralReason` the caller gets at once. Reading the set there would make
the test agree with the code by construction, which is how a wrong entry stayed
free for as long as nothing read it. A completeness assertion means a new code
forces a decision rather than inheriting one.

`1968 passed`, workbench `109 passed`, `tsc` clean.

*The last commit was landed with `SKIP_REVIEW=1`: the local review gate's own
reviewer returned malformed output twice and its instructions say to bypass
rather than re-run. Everything before it went through the gate.*