### PR TITLE
A macro nothing can reach is not a shadowed builtin

### DIFF
--- a/src/mnemiq/adapters/base.py
+++ b/src/mnemiq/adapters/base.py
@@ -38,6 +38,13 @@ class SourceAdapter(Protocol):
     # `hasattr` at the call site. A failure RAISES, and raising is told apart from absence.
     def builtin_functions(self) -> list[str]: ...
 
+    # The subset of `user_functions()` an unqualified call can reach -- on this source's search
+    # path. Read through `hasattr`; omitting it means every name counts as reachable, which is
+    # conservative and expensive: one macro in one unused schema then condemns the whole source.
+    # `user_functions()` stays the FULL list, because a query may qualify and the bare name read
+    # off the rendered statement is what catches that. A failure RAISES.
+    def reachable_user_functions(self) -> list[str]: ...
+
     # Whether `user_functions()` also answers for a VIEW BODY on this source. Read through
     # `getattr(adapter, ..., False)`, so an adapter that says nothing is taken not to cover them
     # -- forgetting yields the conservative answer. Deliberately NOT declared as a member here:

--- a/src/mnemiq/adapters/duckdb.py
+++ b/src/mnemiq/adapters/duckdb.py
@@ -182,6 +182,35 @@ class DuckDBAdapter:
         ).fetchall()
         return [r[0] for r in rows]
 
+    def reachable_user_functions(self) -> list[str]:
+        """The subset of `user_functions()` a query can call WITHOUT qualifying it.
+
+        `duckdb_functions()` carries `database_name` and `schema_name` and the first version of
+        `user_functions` threw both away, which made every name look reachable. Measured on an
+        attached file holding `CREATE MACRO other.median(x)`: `SELECT median(id) FROM claim`
+        returned **1.5**, DuckDB's builtin, because `other` is not on the search path -- and the
+        engine refused the whole source, `SELECT id FROM claim` included, on the theory that
+        `median` was shadowed. One unrelated macro in one unused schema made a legitimate source
+        answer nothing.
+
+        Only the coarse rule wants this. `names` stays the full list, because a query MAY
+        qualify -- `other.median(1)` returns 999 -- and the bare name read off the rendered text
+        is what catches that.
+
+        The search path, not `current_schema()`: DuckDB resolves an unqualified function against
+        every entry, and reading only the current one would call an entry further down the path
+        unreachable. `database.schema` and a bare `schema` are both accepted because the setting
+        holds either.
+        """
+        path = self._con.execute("SELECT current_setting('search_path')").fetchall()[0][0]
+        entries = {e.strip().strip('"').lower() for e in str(path).split(",") if e.strip()}
+        rows = self._con.execute(
+            "SELECT DISTINCT lower(database_name), lower(schema_name), lower(function_name) "
+            "FROM duckdb_functions() WHERE NOT internal"
+        ).fetchall()
+        return [fn for db, schema, fn in rows
+                if f"{db}.{schema}" in entries or schema in entries]
+
     def builtin_functions(self) -> list[str]:
         """The other half of `duckdb_functions()`: names this engine considers its own.
 

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -168,6 +168,17 @@ def check_unmodelled_calls(
     answered "none", and reaches `_cannot_resolve` for it. `never_asked` does not, because that
     is every fixture and the state the engine shipped in -- without an inventory this is the
     allowlist alone, which is where it started.
+
+    **WHICH SOURCES THAT ACTUALLY COVERS, because the paragraphs above read as if it were all of
+    them.** Only an adapter implementing `user_functions` is asked, and today that is the DuckDB
+    family alone -- `resolve.py` hands out one other live adapter, `OracleAdapter`, which
+    implements neither method and therefore gets `never_asked` and the bare allowlist. So an
+    Oracle schema function named `median` still passes here, exactly as every source did before
+    the inventory existed. Nothing regressed; one adapter moved and the rest did not, and an
+    asymmetry nobody wrote down is one a reader assumes away (M99). The Oracle exposure itself
+    is older and filed as deployment preconditions M66 and M71, which `adapters/oracle.py`
+    documents at length; closing it wants Oracle-side catalogue discovery, not a fail-closed
+    default here, which would refuse every call-bearing query on the adapters that cannot answer.
     """
     for call in ast.find_all(exp.Anonymous):
         name = str(call.this)

--- a/src/mnemiq/sql/functions.py
+++ b/src/mnemiq/sql/functions.py
@@ -90,6 +90,15 @@ class FunctionInventory:
     # reason -- the refusal names a different owner for each, and telling an adapter author to
     # implement a method they already implemented sends them to fix working code.
     builtins_asked: bool = False
+    # The subset of `names` a query can call WITHOUT qualifying it, or None for "not known".
+    # Only `may_shadow_a_builtin` reads it, and only because that rule is the coarse one: a
+    # binder rename can only reach a function the query could have called unqualified, so a
+    # macro in a schema off the search path cannot collect `COUNT(*)`. `names` stays whole,
+    # because a query may still qualify and the bare name read off the rendered text catches it.
+    #
+    # None falls back to `names`, which is what an adapter that cannot scope its catalogue gets
+    # -- the same shape as `builtins`, and conservative in the same direction.
+    reachable: frozenset[str] | None = None
 
     def __post_init__(self) -> None:
         # Normalised HERE, not only in `of()`. A dataclass hands out its plain constructor
@@ -106,6 +115,11 @@ class FunctionInventory:
         if isinstance(names, str):
             names = [names]
         object.__setattr__(self, "names", frozenset(n.lower() for n in names))
+        reachable = self.reachable
+        if reachable is not None:
+            if isinstance(reachable, str):
+                reachable = [reachable]
+            object.__setattr__(self, "reachable", frozenset(r.lower() for r in reachable))
         builtins = self.builtins
         if builtins is not None:
             # An answer implies the question. Without this the constructor can build "the
@@ -171,12 +185,21 @@ class FunctionInventory:
         Three answers rather than two. Nothing defined, nothing to shadow. Builtins never
         asked, so assume the worst -- but only for a source that defines something, which keeps
         the conservative default off every source that has no user functions at all.
+
+        And the question is asked of the REACHABLE names, not all of them, because a binder
+        rename can only ever land on a function the query could have called unqualified. A
+        macro in a schema off the search path is invisible to `COUNT(*)`; counting it condemned
+        whole sources that were answering correctly.
         """
-        if not self.names:
+        # The names a query could have called unqualified, which is the only way a BINDER
+        # rename can land on a user function. Scoped, because the unscoped version condemned a
+        # whole source over a macro in a schema nothing on the search path can reach.
+        candidates = self.names if self.reachable is None else self.reachable
+        if not candidates:
             return False
         if self.builtins is None:
             return True
-        return bool(self.names & self.builtins)
+        return bool(candidates & self.builtins)
 
 
 def inventory_from(adapter) -> FunctionInventory:
@@ -208,7 +231,22 @@ def inventory_from(adapter) -> FunctionInventory:
         covers_view_bodies=getattr(adapter, "functions_cover_view_bodies", False),
         builtins=builtins,
         builtins_asked=builtins_asked,
+        reachable=_reachable_from(adapter),
     )
+
+
+def _reachable_from(adapter) -> frozenset[str] | None:
+    """Which of the source's own functions answer to an unqualified call, or None if unasked.
+
+    Optional like `builtin_functions`, and it costs precision rather than soundness in the same
+    direction: without it every user function counts as reachable, which is where this started.
+    """
+    if adapter is None or not hasattr(adapter, "reachable_user_functions"):
+        return None
+    try:
+        return frozenset(n.lower() for n in adapter.reachable_user_functions())
+    except Exception:
+        return None
 
 
 def _builtins_from(adapter) -> tuple[frozenset[str] | None, bool]:

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -694,3 +694,88 @@ def test_the_write_path_asks_the_same_source_the_same_question():
     leak = write("UPDATE claim SET name = add_days(id) WHERE id = 1", named)
     assert _code(leak) == "unmodelled_call", leak
     assert not hasattr(write("UPDATE claim SET id = 2 WHERE id = 1", named), "code")
+
+
+# --------------------------------------------------------------------------------------------
+# Reachability. `duckdb_functions()` carries `database_name` and `schema_name` and the first
+# version threw both away, so a macro in a schema nothing can reach counted as a shadowed
+# builtin and the source answered NOTHING. Found by adversarial review, reproduced before fixing.
+# --------------------------------------------------------------------------------------------
+
+
+def _multi_schema_source(name="multi.duckdb"):
+    """A macro named after a builtin, in a schema that is not on the search path."""
+    path = os.path.join(tempfile.mkdtemp(), name)
+    con = duckdb.connect(path)
+    con.execute("CREATE TABLE claim(id INTEGER)")
+    con.execute("INSERT INTO claim VALUES (1), (2)")
+    con.execute("CREATE SCHEMA other")
+    con.execute("CREATE MACRO other.median(x) AS (SELECT 999)")
+    con.close()
+    return DuckDBAdapter.duckdb(path)
+
+
+def test_a_macro_nothing_can_reach_does_not_condemn_the_source():
+    """Measured on the source below: `SELECT median(id) FROM claim` returns **1.5**, DuckDB's
+    builtin, because `other` is not on the search path -- and `other.median(1)` returns 999. So
+    the macro exists and no unqualified call can collect it.
+
+    The unscoped version read `median` as a shadowed builtin and refused everything, `SELECT id
+    FROM claim` included. One unrelated macro in one unused schema made a legitimate source
+    answer nothing, which is a worse failure than the leak the rule was added for, because it is
+    silent about being wrong.
+    """
+    adapter = _multi_schema_source()
+    assert adapter.user_functions() == ["median"]
+    assert adapter.reachable_user_functions() == [], "nothing on the search path defines it"
+
+    assert not hasattr(_verdict("SELECT id FROM claim", adapter), "code")
+    assert not hasattr(_verdict("SELECT count(*) AS n FROM claim", adapter), "code")
+
+
+def test_but_a_qualified_call_to_that_same_macro_is_still_refused():
+    """The other half, and the reason `names` stays whole while only the COARSE rule is scoped.
+    A query may qualify, and `other.median(1)` reaches the macro -- so the bare name read off the
+    rendered statement has to keep matching it."""
+    adapter = _multi_schema_source(name="qualified.duckdb")
+    refused = _verdict("SELECT other.median(1) AS m", adapter)
+    assert _code(refused) == "unmodelled_call", refused
+
+
+def test_the_same_name_on_the_search_path_still_condemns_the_source():
+    """The contrast that makes the scoping meaningful rather than a way to switch the rule off.
+    `main` IS the search path, so this macro can collect an unqualified call and the engine
+    cannot say which call is which."""
+    path = os.path.join(tempfile.mkdtemp(), "onpath.duckdb")
+    con = duckdb.connect(path)
+    con.execute("CREATE TABLE claim(id INTEGER)")
+    con.execute("CREATE MACRO main.median(x) AS (SELECT 999)")
+    con.close()
+    adapter = DuckDBAdapter.duckdb(path)
+
+    assert adapter.reachable_user_functions() == ["median"]
+    assert _code(_verdict("SELECT id FROM claim", adapter)) == "unresolvable_calls"
+
+
+def test_an_adapter_that_cannot_scope_its_catalogue_counts_every_name_as_reachable():
+    """`reachable` is optional in the same direction as `builtins`: omitting it costs answers,
+    never soundness. An adapter offering only `user_functions` gets the behaviour that shipped
+    before scoping existed."""
+    from mnemiq.sql.functions import inventory_from
+
+    class Unscoped:
+        def user_functions(self):
+            return ["median"]
+
+        def builtin_functions(self):
+            return ["median", "count_star"]
+
+    class Scoped(Unscoped):
+        def reachable_user_functions(self):
+            return []
+
+    assert inventory_from(Unscoped()).reachable is None
+    assert inventory_from(Unscoped()).may_shadow_a_builtin is True
+    assert inventory_from(Scoped()).may_shadow_a_builtin is False
+    # ...and the full list is untouched either way, so a qualified call is still caught.
+    assert inventory_from(Scoped()).names == frozenset({"median"})


### PR DESCRIPTION
Found by `/codex:adversarial-review` over the four merges in #18–#21, reproduced
before fixing.

`duckdb_functions()` carries `database_name` and `schema_name`, and the coarse
shadowing rule threw both away. So a macro named after a builtin counted as
shadowing **wherever it lived**:

```
search_path                    d.main
SELECT median(id) FROM claim   1.5    ← DuckDB's builtin, the macro is unreachable
SELECT other.median(1)         999    ← the macro, only when qualified
duckdb_functions()             ('d', 'other', 'median')
```

With `CREATE MACRO other.median(x)` in a schema off the search path, the engine
refused **the entire source** — `SELECT id FROM claim`, a query with no call in
it, included. One unrelated macro in one unused schema made a correct source
answer nothing.

That is a worse failure than the leak the rule exists for, because it is silent
about being wrong: the refusal names a shadowed function, and the function it
names cannot be called.

### Only the coarse rule is scoped

A binder rename can land solely on a function the query could have called
unqualified, so that rule now asks the search path. `names` stays whole, because
a query may qualify and `other.median(1)` does reach it — the bare name read off
the rendered statement is what catches that.

| source | `SELECT id FROM claim` | `count(*)` | `other.median(1)` |
|---|---|---|---|
| macro off the search path | approved | approved | **refused** |
| `count_star` on the path | **refused** | **refused** | **refused** |
| no macros | approved | approved | — |

`reachable` is optional in the same direction as `builtins`: an adapter that
cannot scope its catalogue has every name count as reachable, which is exactly
what shipped before.

### The other finding, recorded rather than implemented

The review also rated as `high` that `never_asked()` is permissive, so an adapter
without `user_functions` gets the bare allowlist. True, and **not a regression** —
before #19 the guard took no inventory at all, so every adapter sat there. The
recommended fix, failing closed whenever an adapter cannot supply an inventory,
would refuse every call-bearing query on Oracle and on federated sources
including one. The Oracle exposure itself is older and already filed as
deployment preconditions M66/M71. Filed as **M99** with the reasoning, and the
guard's docstring now says which adapters it actually covers.

`1972 passed`. Five mutations on the scoping, all fail.

---

**Correction to both commit messages.** They say the pre-commit reviewer had
"returned an empty verdict on every run tonight … so it is the reviewer and not
the change." That attribution is wrong. Every failed review in the runtime's job
record — all seven — is `"You've hit your usage limit"`. The budget reset at
23:17, the adversarial review and the gate runs spent it, and it re-exhausted
before the two commits here. The empty first line the gate reports is simply what
a quota rejection looks like from its side; nothing is wrong with the reviewer or
its prompt. The `SKIP_REVIEW=1` bypasses themselves stand, since the gate
instructs bypass after a repeat breach whatever the cause.