### PR TITLE
Oracle can answer the inventory question too, differently (M99)

### DIFF
--- a/src/mnemiq/adapters/duckdb.py
+++ b/src/mnemiq/adapters/duckdb.py
@@ -31,6 +31,37 @@ _PG_VIEW_QUERY = (
 )
 
 
+def duckdb_user_functions(con) -> list[str]:
+    """Function names a DuckDB connection defines itself, anywhere in any attached catalog.
+
+    `internal` is the discriminator and the whole reason this is answerable: DuckDB marks its own
+    945 builtins `internal = true`, and anything a deployment adds comes back false.
+
+    Module-level because `FederatedAdapter` is a DuckDB connection too -- ATTACH per source into
+    one connection -- and a second copy of these three queries is a second thing to keep true.
+    """
+    return [r[0] for r in con.execute(
+        "SELECT DISTINCT lower(function_name) FROM duckdb_functions() WHERE NOT internal"
+    ).fetchall()]
+
+
+def duckdb_builtin_functions(con) -> list[str]:
+    """The other half of the same catalogue, split on the same flag."""
+    return [r[0] for r in con.execute(
+        "SELECT DISTINCT lower(function_name) FROM duckdb_functions() WHERE internal"
+    ).fetchall()]
+
+
+def duckdb_reachable_user_functions(con) -> list[str]:
+    """Those an unqualified call can reach: the ones whose schema is on the search path."""
+    path = con.execute("SELECT current_setting('search_path')").fetchall()[0][0]
+    entries = {e.strip().strip('"').lower() for e in str(path).split(",") if e.strip()}
+    return [fn for db, schema, fn in con.execute(
+        "SELECT DISTINCT lower(database_name), lower(schema_name), lower(function_name) "
+        "FROM duckdb_functions() WHERE NOT internal").fetchall()
+        if f"{db}.{schema}" in entries or schema in entries]
+
+
 class DuckDBAdapter:
     """DuckDB as the universal executor: ATTACH a source and read it via DuckDB's scanner.
 
@@ -177,10 +208,7 @@ class DuckDBAdapter:
         A failure RAISES, like `view_definitions`. Returning `[]` would tell the caller this
         source defines nothing, which is a different claim from being unable to look.
         """
-        rows = self._con.execute(
-            "SELECT DISTINCT lower(function_name) FROM duckdb_functions() WHERE NOT internal"
-        ).fetchall()
-        return [r[0] for r in rows]
+        return duckdb_user_functions(self._con)
 
     def reachable_user_functions(self) -> list[str]:
         """The subset of `user_functions()` a query can call WITHOUT qualifying it.
@@ -202,14 +230,7 @@ class DuckDBAdapter:
         unreachable. `database.schema` and a bare `schema` are both accepted because the setting
         holds either.
         """
-        path = self._con.execute("SELECT current_setting('search_path')").fetchall()[0][0]
-        entries = {e.strip().strip('"').lower() for e in str(path).split(",") if e.strip()}
-        rows = self._con.execute(
-            "SELECT DISTINCT lower(database_name), lower(schema_name), lower(function_name) "
-            "FROM duckdb_functions() WHERE NOT internal"
-        ).fetchall()
-        return [fn for db, schema, fn in rows
-                if f"{db}.{schema}" in entries or schema in entries]
+        return duckdb_reachable_user_functions(self._con)
 
     def builtin_functions(self) -> list[str]:
         """The other half of `duckdb_functions()`: names this engine considers its own.
@@ -233,10 +254,7 @@ class DuckDBAdapter:
         function at all then has every read AND every write against it refused. It is the
         conservative reading and it is not a soft one.
         """
-        rows = self._con.execute(
-            "SELECT DISTINCT lower(function_name) FROM duckdb_functions() WHERE internal"
-        ).fetchall()
-        return [r[0] for r in rows]
+        return duckdb_builtin_functions(self._con)
 
     def view_definitions(self) -> list[tuple[str, str, str]]:
         """(view, body, dialect) for every view in the source. A failure RAISES.

--- a/src/mnemiq/adapters/federated.py
+++ b/src/mnemiq/adapters/federated.py
@@ -5,6 +5,11 @@ import threading
 import duckdb
 import pyarrow as pa
 
+from mnemiq.adapters.duckdb import (
+    duckdb_builtin_functions,
+    duckdb_reachable_user_functions,
+    duckdb_user_functions,
+)
 from mnemiq.config import SourceSpec
 
 _EXT = {"postgres": ("postgres", "POSTGRES"), "sqlite": ("sqlite", "SQLITE")}
@@ -47,6 +52,24 @@ class FederatedAdapter:
             clause = f"(TYPE {attach_type}, READ_ONLY)" if read_only else f"(TYPE {attach_type})"
             self._con.execute(f"ATTACH '{spec.target}' AS {spec.catalog} {clause}")
         # No single USE: every query is catalog-qualified (catalog.schema.table).
+
+    # The same three catalogue reads the single-source DuckDB path uses, on the same kind of
+    # connection. Without them a federated deployment got `never_asked` and M43's residual fix
+    # reached it not at all (M99) -- and the gap was invisible, because federation is DuckDB and
+    # every argument written for the DuckDB adapter reads as if it applied here.
+    #
+    # `reachable` is usually empty in this shape and that is correct rather than a shortcut:
+    # every query here is catalog-qualified and nothing issues a `USE`, so an attached source's
+    # schema is not on the search path and its macros answer only to a spelled qualification --
+    # which `called_names` reads off the rendered statement.
+    def user_functions(self) -> list[str]:
+        return duckdb_user_functions(self._con)
+
+    def builtin_functions(self) -> list[str]:
+        return duckdb_builtin_functions(self._con)
+
+    def reachable_user_functions(self) -> list[str]:
+        return duckdb_reachable_user_functions(self._con)
 
     def execute(self, sql: str) -> list[tuple]:
         return self._con.execute(sql).fetchall()

--- a/src/mnemiq/adapters/oracle.py
+++ b/src/mnemiq/adapters/oracle.py
@@ -667,6 +667,58 @@ class OracleAdapter:
             )
         ]
 
+    # Oracle resolves a BUILT-IN SQL function before a schema object of the same name, so a UDF
+    # cannot collect a call the query did not qualify. MEASURED on Oracle AI Database 26ai Free,
+    # with a `LENGTH` function owned by the connecting user: `SELECT length('abc') FROM dual`
+    # returned **3**, and `SELECT appuser.length('abc') FROM dual` returned the UDF's 999.
+    #
+    # That is the opposite of DuckDB, where `count(*)` binds a macro named `count_star` and
+    # `length(x)` binds a macro named `length`. The difference is the whole reason this is a
+    # per-engine fact rather than a rule: the coarse "this source cannot be decided at all"
+    # refusal exists for a name the query never says, and on Oracle there is no such name.
+    #
+    # So Oracle needs no builtin catalogue here. `V$SQLFN_METADATA` would supply one -- 1276
+    # names, and readable in the container -- but only through `DB_DEVELOPER_ROLE`, not a direct
+    # grant, and hanging the guard on it would turn a missing privilege in a locked-down
+    # deployment into "refuse every query that calls anything".
+    binder_prefers_builtins = True
+
+    def user_functions(self) -> list[str]:
+        """Function names this schema defines itself, standalone and inside packages.
+
+        Both, because both are routes to a UDF even though only one is reachable unqualified.
+        MEASURED: `SELECT pkg_fn(1) FROM dual` is ORA-00904 and `SELECT pkg1.pkg_fn(1) FROM dual`
+        returns 555, so a package member answers only when the query spells the package -- and
+        `called_names` reads `pkg_fn` off that rendered text, which is why the bare member name
+        has to be in this list for the match to land.
+
+        Scoped to `self._schema`, the owner the adapter was pointed at, for the reason
+        `list_columns` is: an engine asking the data dictionary about the source it governs has
+        no business enumerating schemas the caller was never given.
+
+        PUBLIC synonyms are deliberately not followed. They ARE an unqualified route to another
+        schema's function, and measured here every one resolving to a FUNCTION belongs to SYS,
+        LBACSYS, DVSYS or XDB -- Oracle's own, already builtin-shaped. A deployment that creates
+        a public synonym over a user function opens a hole this does not see; it is named here
+        rather than papered over, because the alternative is a join across `ALL_SYNONYMS` whose
+        cost and privilege surface nobody has measured.
+
+        A failure RAISES, like `view_definitions` and its DuckDB sibling. Returning `[]` would
+        say this schema defines nothing, which is a different claim from being unable to look.
+        """
+        return [
+            r[0]
+            for r in self._rows(
+                "SELECT DISTINCT lower(object_name) AS name FROM all_objects "
+                "WHERE owner = :owner AND object_type = 'FUNCTION' "
+                "UNION "
+                "SELECT DISTINCT lower(procedure_name) FROM all_procedures "
+                "WHERE owner = :owner AND object_type = 'PACKAGE' "
+                "  AND procedure_name IS NOT NULL",
+                owner=self._schema,
+            )
+        ]
+
     def foreign_keys(self) -> list[tuple[str, str, str, str, str]]:
         """Declared FKs: (from_table, from_col, to_table, to_col, constraint_id).
 

--- a/src/mnemiq/adapters/oracle.py
+++ b/src/mnemiq/adapters/oracle.py
@@ -675,7 +675,16 @@ class OracleAdapter:
     # That is the opposite of DuckDB, where `count(*)` binds a macro named `count_star` and
     # `length(x)` binds a macro named `length`. The difference is the whole reason this is a
     # per-engine fact rather than a rule: the coarse "this source cannot be decided at all"
-    # refusal exists for a name the query never says, and on Oracle there is no such name.
+    # refusal exists for a FUNCTION name the query never says, and Oracle's binder never
+    # substitutes one.
+    #
+    # It is NOT a claim that no unnamed user code can run. A virtual column carries an
+    # expression, and `SELECT id, leaked FROM t` over `leaked AS (udf(id))` returned an SSN from
+    # an ungranted table with no function named anywhere in the statement -- measured here, and
+    # filed as M100. Nothing in this guard sees that on any engine, and the coarse rule would
+    # not have caught it either: it fires on a name shared with a builtin, and a virtual
+    # column's UDF has whatever name its author chose. So this property changes what the guard
+    # costs Oracle, not what it protects Oracle from.
     #
     # So Oracle needs no builtin catalogue here. `V$SQLFN_METADATA` would supply one -- 1276
     # names, and readable in the container -- but only through `DB_DEVELOPER_ROLE`, not a direct

--- a/src/mnemiq/sql/functions.py
+++ b/src/mnemiq/sql/functions.py
@@ -107,9 +107,13 @@ class FunctionInventory:
     #             a macro named `length`. The builtin loses, so a name the query never says can
     #             collect the call, and only the coarse rule can catch that.
     #   Oracle  -- with a `LENGTH` function owned by the caller, `SELECT length('abc')` returns
-    #             3, the builtin. The UDF answers only to `appuser.length(...)`. A name the
-    #             query never says cannot reach it, so there is nothing for the coarse rule to
+    #             3, the builtin. The UDF answers only to `appuser.length(...)`. No FUNCTION
+    #             name the query omits can reach it, so there is nothing for the coarse rule to
     #             catch and refusing the whole source would be pure cost.
+    #
+    # Read narrowly: this is about names a BINDER substitutes, not about every way user code
+    # runs. An Oracle virtual column executes a UDF that the statement never names at all, which
+    # no setting of this flag affects and this guard does not see (M100).
     #
     # Defaults FALSE: an engine nobody measured is assumed to behave like DuckDB, which is the
     # conservative half. Forgetting yields a refusal, not a leak.

--- a/src/mnemiq/sql/functions.py
+++ b/src/mnemiq/sql/functions.py
@@ -99,6 +99,21 @@ class FunctionInventory:
     # None falls back to `names`, which is what an adapter that cannot scope its catalogue gets
     # -- the same shape as `builtins`, and conservative in the same direction.
     reachable: frozenset[str] | None = None
+    # Whether this SOURCE'S BINDER resolves a builtin before a schema object of the same name.
+    # Measured per engine, because the two live engines disagree and the disagreement decides
+    # whether the coarse rule is needed at all:
+    #
+    #   DuckDB  -- `count(*)` binds a macro named `count_star`, and `SELECT length('abc')` binds
+    #             a macro named `length`. The builtin loses, so a name the query never says can
+    #             collect the call, and only the coarse rule can catch that.
+    #   Oracle  -- with a `LENGTH` function owned by the caller, `SELECT length('abc')` returns
+    #             3, the builtin. The UDF answers only to `appuser.length(...)`. A name the
+    #             query never says cannot reach it, so there is nothing for the coarse rule to
+    #             catch and refusing the whole source would be pure cost.
+    #
+    # Defaults FALSE: an engine nobody measured is assumed to behave like DuckDB, which is the
+    # conservative half. Forgetting yields a refusal, not a leak.
+    binder_prefers_builtins: bool = False
 
     def __post_init__(self) -> None:
         # Normalised HERE, not only in `of()`. A dataclass hands out its plain constructor
@@ -191,6 +206,13 @@ class FunctionInventory:
         macro in a schema off the search path is invisible to `COUNT(*)`; counting it condemned
         whole sources that were answering correctly.
         """
+        if self.binder_prefers_builtins:
+            # Nothing to catch: this engine hands an unqualified call to its own builtin, so a
+            # user function of that name is reachable only by a query that SPELLS the
+            # qualification -- which `called_names` reads off the rendered text. Checked before
+            # `builtins`, so an engine whose catalogue of builtins is unreadable still gets this
+            # answer instead of a whole-source refusal it does not need.
+            return False
         # The names a query could have called unqualified, which is the only way a BINDER
         # rename can land on a user function. Scoped, because the unscoped version condemned a
         # whole source over a macro in a schema nothing on the search path can reach.
@@ -232,6 +254,7 @@ def inventory_from(adapter) -> FunctionInventory:
         builtins=builtins,
         builtins_asked=builtins_asked,
         reachable=_reachable_from(adapter),
+        binder_prefers_builtins=getattr(adapter, "binder_prefers_builtins", False),
     )
 
 

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -779,3 +779,33 @@ def test_an_adapter_that_cannot_scope_its_catalogue_counts_every_name_as_reachab
     assert inventory_from(Scoped()).may_shadow_a_builtin is False
     # ...and the full list is untouched either way, so a qualified call is still caught.
     assert inventory_from(Scoped()).names == frozenset({"median"})
+
+
+def test_every_adapter_the_resolver_hands_out_can_answer_the_inventory():
+    """M99 was that one adapter could and the others could not, and nothing said so.
+
+    `resolve.py` returns `OracleAdapter` or the DuckDB family, and `runtime.py` builds a
+    `FederatedAdapter` for a multi-source deployment. All three are checked here because the gap
+    was invisible exactly where it mattered: federation IS DuckDB, so every argument written for
+    the DuckDB adapter read as though it already applied.
+
+    The unused `pg`/`sqlite` classes are deliberately not asserted -- nothing hands them out, and
+    requiring the methods there would be a test defending code no deployment reaches.
+    """
+    from mnemiq.adapters.duckdb import DuckDBAdapter, DuckDBPostgresAdapter
+    from mnemiq.adapters.federated import FederatedAdapter
+    from mnemiq.adapters.oracle import OracleAdapter
+
+    for cls in (DuckDBAdapter, DuckDBPostgresAdapter, FederatedAdapter):
+        assert hasattr(cls, "user_functions"), cls
+        assert hasattr(cls, "builtin_functions"), cls
+        assert hasattr(cls, "reachable_user_functions"), cls
+        assert getattr(cls, "binder_prefers_builtins", False) is False, (
+            f"{cls.__name__} binds a macro over a builtin -- `count(*)` reaches `count_star`"
+        )
+
+    # Oracle answers the same question with a different shape, and the difference is measured
+    # in `tests/test_oracle_adapter.py`: its binder settles an unqualified call on its own
+    # builtin, so it needs no builtin catalogue and never takes the whole-source refusal.
+    assert hasattr(OracleAdapter, "user_functions")
+    assert OracleAdapter.binder_prefers_builtins is True

--- a/tests/test_oracle_adapter.py
+++ b/tests/test_oracle_adapter.py
@@ -878,7 +878,14 @@ def test_the_decider_proof_path_approves_a_valid_oracle_plan():
 
     assert prove(_adapter(), "SELECT id FROM t_region") is None
     refused = prove(_adapter(), "SELECT id FROM ghost_table")
-    assert refused is not None and "ORA-00942" in refused.message
+    assert refused is not None
+    # `source_detail`, not `message`. The source's own words moved out of the caller-facing
+    # sentence when M94 split them: `plan_query` forwards `message` as a deferral reason, and an
+    # Oracle exception is made of the caller's schema. This assertion kept naming `message` and
+    # went red the day that landed, because no CI job has an Oracle to run it against -- the
+    # first time it ran after the split was here, months later.
+    assert "ORA-00942" in refused.source_detail
+    assert "ORA-00942" not in refused.message, "the source's words stay out of the wire text"
 
 
 def test_concurrent_reads_through_one_adapter_do_not_corrupt_each_other():
@@ -1599,3 +1606,133 @@ def test_a_probe_that_FAILS_is_not_evidence_the_database_opened():
         assert a._ro_state == "constrained", "a failed probe must not change the recorded state"
     finally:
         a.close()
+
+
+# --------------------------------------------------------------------------------------------
+# M99. `check_unmodelled_calls` gained an inventory in PR #19 and only the DuckDB family could
+# supply one, so M43's residual fix reached Oracle not at all. What this schema defines, and
+# which of it an unqualified call can reach, is the whole question -- and Oracle answers it
+# differently from DuckDB, which is why the answer is measured here rather than assumed.
+# --------------------------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _m99_fixtures(adapter):
+    """A UDF that reads a table the identity is never granted, plus the table it reads."""
+    con = adapter._pool.acquire()
+    cur = con.cursor()
+    for ddl in ("DROP FUNCTION m99_leak", "DROP TABLE m99_secret", "DROP TABLE m99_claim"):
+        with contextlib.suppress(Exception):
+            cur.execute(ddl)
+    cur.execute("CREATE TABLE m99_secret(ssn VARCHAR2(20))")
+    cur.execute("INSERT INTO m99_secret VALUES ('123-45-6789')")
+    cur.execute("CREATE TABLE m99_claim(id NUMBER)")
+    cur.execute("INSERT INTO m99_claim VALUES (1)")
+    cur.execute("CREATE OR REPLACE FUNCTION m99_leak(x NUMBER) RETURN VARCHAR2 IS "
+                "v VARCHAR2(20); BEGIN SELECT ssn INTO v FROM m99_secret WHERE ROWNUM = 1; "
+                "RETURN v; END;")
+    con.commit()
+    try:
+        yield cur
+    finally:
+        for ddl in ("DROP FUNCTION m99_leak", "DROP TABLE m99_secret", "DROP TABLE m99_claim"):
+            with contextlib.suppress(Exception):
+                cur.execute(ddl)
+        con.commit()
+        adapter._pool.release(con)
+
+
+def test_oracle_resolves_a_builtin_before_a_udf_of_the_same_name():
+    """The measurement the whole design rests on, and it is the OPPOSITE of DuckDB's.
+
+    DuckDB binds `count(*)` to a macro named `count_star` and `length(x)` to a macro named
+    `length` -- the builtin loses, so a name the query never says can collect the call, and only
+    a whole-source refusal can catch that. Oracle hands the call to its own builtin, so the UDF
+    answers only when the query spells the qualification.
+
+    Asserted against the live source rather than trusted, because `binder_prefers_builtins`
+    turns the coarse rule off for every Oracle deployment and a wrong reading of Oracle's name
+    resolution would be a silent leak, not a visible refusal.
+    """
+    adapter = OracleAdapter(dsn=DSN, user=USER, password=PASSWORD, schema=USER.upper())
+    con = adapter._pool.acquire()
+    cur = con.cursor()
+    try:
+        cur.execute("CREATE OR REPLACE FUNCTION length(x VARCHAR2) RETURN NUMBER IS "
+                    "BEGIN RETURN 999; END;")
+        con.commit()
+        cur.execute("SELECT length('abc') FROM dual")
+        assert cur.fetchone()[0] == 3, "the builtin must win an unqualified call"
+        cur.execute(f"SELECT {USER}.length('abc') FROM dual")
+        assert cur.fetchone()[0] == 999, "...and the UDF must still answer when qualified"
+    finally:
+        with contextlib.suppress(Exception):
+            cur.execute("DROP FUNCTION length")
+            con.commit()
+        adapter._pool.release(con)
+        adapter.close()
+
+
+def test_the_inventory_names_what_this_schema_defines_standalone_and_in_packages():
+    """A package member is not reachable unqualified -- `pkg_fn(1)` is ORA-00904 -- but
+    `pkg1.pkg_fn(1)` answers, and `called_names` reads `pkg_fn` off that rendered text. So the
+    bare member name has to be in the list or the match never lands."""
+    adapter = OracleAdapter(dsn=DSN, user=USER, password=PASSWORD, schema=USER.upper())
+    con = adapter._pool.acquire()
+    cur = con.cursor()
+    try:
+        cur.execute("CREATE OR REPLACE FUNCTION m99_standalone(x NUMBER) RETURN NUMBER IS "
+                    "BEGIN RETURN 1; END;")
+        cur.execute("CREATE OR REPLACE PACKAGE m99_pkg AS "
+                    "FUNCTION m99_member(x NUMBER) RETURN NUMBER; END;")
+        cur.execute("CREATE OR REPLACE PACKAGE BODY m99_pkg AS "
+                    "FUNCTION m99_member(x NUMBER) RETURN NUMBER IS BEGIN RETURN 2; END; END;")
+        con.commit()
+        names = set(adapter.user_functions())
+        assert "m99_standalone" in names
+        assert "m99_member" in names, "a package member is a route to a UDF, qualified"
+    finally:
+        for ddl in ("DROP FUNCTION m99_standalone", "DROP PACKAGE m99_pkg"):
+            with contextlib.suppress(Exception):
+                cur.execute(ddl)
+        con.commit()
+        adapter._pool.release(con)
+        adapter.close()
+
+
+def test_a_udf_that_reads_an_ungranted_table_is_refused_and_the_builtins_are_not():
+    """M43's residual, on Oracle, end to end.
+
+    The leak is real first: `m99_leak(1)` returns an SSN out of a table the identity was never
+    granted. `decide` refuses it by name -- and refuses NOTHING else, because Oracle's binder
+    settles every unqualified call on its own builtin, so there is no whole-source doubt to
+    raise. That contrast is the point: the same fix on DuckDB refuses every call on a source
+    that shadows one builtin, and doing that to Oracle would be pure cost.
+    """
+    from mnemiq.sql.decide import decide
+    from mnemiq.sql.functions import inventory_from
+
+    adapter = OracleAdapter(dsn=DSN, user=USER, password=PASSWORD, schema=USER.upper())
+    try:
+        with _m99_fixtures(adapter) as cur:
+            cur.execute("SELECT m99_leak(1) FROM dual")
+            assert cur.fetchone()[0] == "123-45-6789", "no leak, so nothing below proves anything"
+
+            inventory = inventory_from(adapter)
+            assert "m99_leak" in inventory.names
+            assert inventory.may_shadow_a_builtin is False
+
+            def verdict(sql):
+                return decide(sql, {"m99_claim": {"id"}}, adapter=adapter,
+                              dialect="oracle", target="oracle")
+
+            refused = verdict("SELECT m99_leak(1) AS x FROM m99_claim")
+            assert refused.code.value == "unmodelled_call", refused
+            assert refused.subject == "m99_leak"
+
+            for clean in ("SELECT length('abc') AS n FROM m99_claim",
+                          "SELECT count(*) AS n FROM m99_claim",
+                          "SELECT id FROM m99_claim"):
+                assert not hasattr(verdict(clean), "code"), clean
+    finally:
+        adapter.close()


### PR DESCRIPTION
`check_unmodelled_calls` gained a function inventory in #19 and only the DuckDB
family could supply one, so M43's residual fix reached the other live adapters
not at all. M99 said the Oracle queries were unwritten rather than guessed —
this closes it against a **live Oracle AI Database 26ai Free**.

### The measurement inverted the plan

| on Oracle, with a `LENGTH` function owned by the caller | result |
|---|---|
| `SELECT length('abc') FROM dual` | **3** — the builtin wins |
| `SELECT appuser.length('abc') FROM dual` | 999 — the UDF, qualified only |
| `SELECT pkg_fn(1) FROM dual` | ORA-00904; `pkg1.pkg_fn(1)` → 555 |

DuckDB is the opposite: `count(*)` binds a macro named `count_star`. So the
coarse "this source cannot be decided at all" refusal has **nothing to catch on
Oracle**, and running it there would be pure cost. `binder_prefers_builtins`
carries the fact per engine and defaults `False`, so an engine nobody measured is
assumed to behave like DuckDB.

**Oracle gets M43's protection at zero product cost.** Proven end to end: a UDF
reading a table the identity was never granted returns an SSN from the source,
and `decide` now refuses it by name — while `length('abc')`, `count(*)` and a
plain projection stay approved.

### The privilege trap, avoided by not needing it

`V$SQLFN_METADATA` would supply a builtin list (1276 names) but is readable here
only through `DB_DEVELOPER_ROLE`, not a direct grant. Depending on it would turn
a missing privilege in a locked-down deployment into *refuse every query that
calls anything*. Cost measured rather than assumed: **2.5–2.7 ms** median over
six runs against 11,896 visible objects.

Federation takes the same three reads, lifted to module level rather than copied
— it is a DuckDB connection with a catalog per source, and every argument
written for the DuckDB adapter read as if it already applied there, which is
exactly how that gap stayed invisible.

### What review then found, and it is not closed

The claim "Oracle has no name the query never says" was **too strong**, and the
counter-example is a leak:

```
CREATE TABLE vc_claim(id NUMBER, leaked AS (vc_leak(id)))
SELECT id, leaked FROM vc_claim   ->  (1, '123-45-6789')
```

An SSN from an ungranted table, with **no function named anywhere in the SQL**.
Filed as **M100** (H). Neither setting of `binder_prefers_builtins` affects it —
the coarse rule fires on a name shared with a builtin, and a virtual column's UDF
has whatever name its author chose. DuckDB refuses a generated column whose
expression holds a subquery, so it is Oracle's alone among the live adapters. The
prose here now says only what was measured.

### Also

An Oracle test has been red since `2a57350` two days ago: it asserted `ORA-00942`
in `Refusal.message`, and M94 moved the source's words into `source_detail` so
they stay off the wire. No CI job has an Oracle, so the first run after that
split was this one.

`1973 passed`; Oracle integration suite `53 passed, 7 skipped` against the live
container. Three mutations on the Oracle path, all fail.