### PR TITLE
A synonym is a route to a UDF (M99 follow-up)

### DIFF
--- a/src/mnemiq/adapters/oracle.py
+++ b/src/mnemiq/adapters/oracle.py
@@ -718,35 +718,137 @@ class OracleAdapter:
         -- was never approvable, since the `exp.Anonymous` check refuses an unlisted name whatever
         the inventory holds. The first version of this note claimed that one as the leak.
 
-        PUBLIC synonyms are NOT followed, and this time the reason is measured on both sides.
-        They add 368 names, all Oracle-maintained, and none is in sqlglot's vocabulary, so the
-        decider already refuses every one of them as an unmodelled call. What they would change
-        is `lineage`: `calls_are_confirmable` is false whenever the inventory holds ANY name, so
-        368 of them turn every Oracle answer containing any call into `completeness='unknown'`
-        with `unconfirmed-function-identity` -- issue #5 back, on a schema that defines nothing.
-        They also cost 48 ms a query against 2.3 ms for this one.
+        Chains and PUBLIC synonyms are handled in `_synonyms_reaching_functions`, which is where
+        the reasoning about which of them to REPORT lives. The short version: a PUBLIC synonym
+        counts when its ultimate target belongs to an owner Oracle does not maintain, and the 368
+        that reach Oracle's own packages stay out -- reporting those turns `calls_are_confirmable`
+        false for every Oracle source, which is issue #5 on a schema that defines nothing.
 
         A failure RAISES, like `view_definitions` and its DuckDB sibling. Returning `[]` would
         say this schema defines nothing, which is a different claim from being unable to look.
         """
-        return [
-            r[0]
-            for r in self._rows(
-                "SELECT DISTINCT lower(object_name) AS name FROM all_objects "
-                "WHERE owner = :owner AND object_type = 'FUNCTION' "
-                "UNION "
-                "SELECT DISTINCT lower(procedure_name) FROM all_procedures "
-                "WHERE owner = :owner AND object_type = 'PACKAGE' "
-                "  AND procedure_name IS NOT NULL "
-                "UNION "
-                "SELECT DISTINCT lower(s.synonym_name) FROM all_synonyms s "
-                "  JOIN all_objects o "
-                "    ON o.owner = s.table_owner AND o.object_name = s.table_name "
-                " WHERE s.owner = :owner "
-                "   AND o.object_type IN ('FUNCTION', 'PACKAGE')",
-                owner=self._schema,
+        direct = self._rows(
+            "SELECT DISTINCT lower(object_name) AS name FROM all_objects "
+            "WHERE owner = :owner AND object_type = 'FUNCTION' "
+            "UNION "
+            "SELECT DISTINCT lower(procedure_name) FROM all_procedures "
+            "WHERE owner = :owner AND object_type = 'PACKAGE' "
+            "  AND procedure_name IS NOT NULL",
+            owner=self._schema,
+        )
+        return sorted({r[0] for r in direct} | self._synonyms_reaching_functions())
+
+    def _synonyms_reaching_functions(self) -> set[str]:
+        """Aliases that end at a function, following chains, keyed by full identity.
+
+        Oracle resolves `a -> b -> udf` at call time: measured, all three of `chain_udf(1)`,
+        `chain_b(1)` and `chain_a(1)` returned 42. A join on the IMMEDIATE target sees only the
+        last hop, so a chained alias was missed.
+
+        Walked HERE rather than in SQL because the recursive form costs what the answer is not
+        worth: `WITH ... UNION ALL ... CYCLE` over `ALL_SYNONYMS` measured **141 ms** a call, and
+        116 ms even restricted to this schema, since each iteration rejoins a 7,869-row view with
+        no useful access path. Reading that view once is 23.8 ms.
+
+        **Keyed by (owner, name), not by name.** The first version keyed the walk on the target's
+        bare name, so when a private and a PUBLIC synonym shared one, which link the walk took
+        depended on set iteration order -- reached under PYTHONHASHSEED 0, 1, 4 and 7, missed
+        under 2, 3, 5 and 6. A control whose verdict moves with the hash seed is not a control.
+
+        The second version kept a by-name fallback to PUBLIC as the ONLY alternative to the
+        exact lookup, which read the commonest shape of all -- alias and target sharing a name,
+        `PUBLIC add_days FOR app2.add_days` -- as a link from the synonym back to itself, and
+        dropped it. The third claimed a target names exactly one object and dropped the fallback;
+        that was wrong too, and measured wrong: Oracle takes the PUBLIC synonym when the named
+        schema holds no such object. Both links are followed now and neither is preferred.
+
+        The WHOLE graph is read, and only the REPORTING is filtered. A chain may hop through a
+        schema this connection does not own, and an edge set narrowed first cannot follow it.
+        What comes back is an alias this schema owns, or a PUBLIC one whose ULTIMATE target
+        belongs to an owner Oracle does not maintain -- every PUBLIC synonym reaching a function
+        on this container is Oracle's own, 368 of them, and putting those in the inventory turns
+        `calls_are_confirmable` false for every Oracle source, which is issue #5 on a schema that
+        defines nothing.
+
+        Termination is `seen` over a set of visited objects, not a hop count. A planted `loop_a -> loop_b -> loop_a` raised
+        ORA-32044 from the recursive query, so a cycle is a real shape; a depth cap on top of
+        `seen` adds nothing to termination and silently drops a chain longer than the cap.
+
+        What this still does not reach is a synonym over a DB-LINK object: it has no local
+        `all_objects` row, so no walk from here can tell whether it ends at a function.
+        """
+        edges: dict[tuple[str, str], tuple[str, str]] = {}
+        for owner, name, target_owner, target_name in self._rows(
+            "SELECT lower(s.owner), lower(s.synonym_name), "
+            "       lower(s.table_owner), lower(s.table_name) FROM all_synonyms s"
+        ):
+            edges[(owner, name)] = (target_owner, target_name)
+        if not edges:
+            return set()
+        oracle_owned = {
+            r[0] for r in self._rows(
+                "SELECT lower(username) FROM all_users WHERE oracle_maintained = 'Y'")
+        }
+        mine = self._schema.lower()
+
+        def reachable_from(start: tuple[str, str]) -> set[tuple[str, str]]:
+            """Every object a chain from `start` can name.
+
+            BOTH links are followed -- the exact one and PUBLIC-by-name -- because Oracle takes
+            the PUBLIC one when the named schema holds no such object. Measured:
+            `CREATE SYNONYM zz FOR appuser.dbms_random` with no `APPUSER.DBMS_RANDOM` present,
+            and `SELECT zz.value FROM dual` returned 0.41 through `PUBLIC.DBMS_RANDOM`.
+
+            Which link applies depends on whether the named object exists, and that is the very
+            list this walk is computing an input to. So the order is not modelled at all: both
+            are collected and the alias counts if ANY of them is a function. Over-inclusive, and
+            over-inclusion here costs a refusal while under-inclusion costs an approval.
+            """
+            seen: set[tuple[str, str]] = set()
+            stack = [start]
+            while stack:
+                at = stack.pop()
+                if at in seen:
+                    continue
+                seen.add(at)
+                for step in (edges.get(at), edges.get(("public", at[1]))):
+                    if step is not None and step not in seen:
+                        stack.append(step)
+            return seen
+
+        # A PUBLIC alias is a candidate only when its IMMEDIATE target already leaves Oracle's
+        # own furniture, which is the same test the reporting filter applies at the end. Without
+        # it the walk runs from all ~7,800 PUBLIC synonyms on a stock instance and
+        # `user_functions` costs 167 ms instead of 14; with it, every one that survives is a
+        # route a deployment created. What it gives up is a PUBLIC alias whose chain leaves an
+        # Oracle-maintained schema on a LATER hop -- an Oracle synonym pointing into a user
+        # schema, which none of the 7,869 here does.
+        candidates = {
+            (o, n): reachable_from(edges[(o, n)])
+            for (o, n) in edges
+            if o == mine or (o == "public" and edges[(o, n)][0] not in oracle_owned)
+        }
+        ends = {end for reached in candidates.values() for end in reached}
+        if not ends:
+            return set()
+        owners = sorted({owner for owner, _ in ends})
+        binds = {f"o{i}": owner for i, owner in enumerate(owners)}
+        placeholders = ", ".join(f":{k}" for k in binds)
+        functions = {
+            (owner, name)
+            for owner, name in self._rows(
+                "SELECT lower(owner), lower(object_name) FROM all_objects "
+                "WHERE object_type IN ('FUNCTION', 'PACKAGE') "
+                f"  AND lower(owner) IN ({placeholders})",
+                **binds,
             )
-        ]
+        }
+        return {
+            name
+            for (owner, name), reached in candidates.items()
+            if any(end in functions and (owner == mine or end[0] not in oracle_owned)
+                   for end in reached)
+        }
 
     def foreign_keys(self) -> list[tuple[str, str, str, str, str]]:
         """Declared FKs: (from_table, from_col, to_table, to_col, constraint_id).

--- a/src/mnemiq/adapters/oracle.py
+++ b/src/mnemiq/adapters/oracle.py
@@ -705,12 +705,26 @@ class OracleAdapter:
         `list_columns` is: an engine asking the data dictionary about the source it governs has
         no business enumerating schemas the caller was never given.
 
-        PUBLIC synonyms are deliberately not followed. They ARE an unqualified route to another
-        schema's function, and measured here every one resolving to a FUNCTION belongs to SYS,
-        LBACSYS, DVSYS or XDB -- Oracle's own, already builtin-shaped. A deployment that creates
-        a public synonym over a user function opens a hole this does not see; it is named here
-        rather than papered over, because the alternative is a join across `ALL_SYNONYMS` whose
-        cost and privilege surface nobody has measured.
+        Synonyms in THIS schema are followed. The first version reasoned about PUBLIC synonyms,
+        measured that every existing one belongs to SYS, LBACSYS, DVSYS or XDB, and wrote the gap
+        down as acceptable -- while the reachable route was a private synonym in the caller's own
+        schema, needing only `CREATE SYNONYM`. The ALIAS is what a query spells, so the alias is
+        what has to be here.
+
+        It only matters for an alias sqlglot MODELS, and the measurement had to be redone to say
+        so. `CREATE SYNONYM add_days FOR real_udf` over a function reading an ungranted table:
+        `decide` APPROVED `SELECT add_days(1)` without this arm and refuses it with it, because
+        `add_days` is in the cross-dialect allowlist. An alias sqlglot does not know -- `syn_leak`
+        -- was never approvable, since the `exp.Anonymous` check refuses an unlisted name whatever
+        the inventory holds. The first version of this note claimed that one as the leak.
+
+        PUBLIC synonyms are NOT followed, and this time the reason is measured on both sides.
+        They add 368 names, all Oracle-maintained, and none is in sqlglot's vocabulary, so the
+        decider already refuses every one of them as an unmodelled call. What they would change
+        is `lineage`: `calls_are_confirmable` is false whenever the inventory holds ANY name, so
+        368 of them turn every Oracle answer containing any call into `completeness='unknown'`
+        with `unconfirmed-function-identity` -- issue #5 back, on a schema that defines nothing.
+        They also cost 48 ms a query against 2.3 ms for this one.
 
         A failure RAISES, like `view_definitions` and its DuckDB sibling. Returning `[]` would
         say this schema defines nothing, which is a different claim from being unable to look.
@@ -723,7 +737,13 @@ class OracleAdapter:
                 "UNION "
                 "SELECT DISTINCT lower(procedure_name) FROM all_procedures "
                 "WHERE owner = :owner AND object_type = 'PACKAGE' "
-                "  AND procedure_name IS NOT NULL",
+                "  AND procedure_name IS NOT NULL "
+                "UNION "
+                "SELECT DISTINCT lower(s.synonym_name) FROM all_synonyms s "
+                "  JOIN all_objects o "
+                "    ON o.owner = s.table_owner AND o.object_name = s.table_name "
+                " WHERE s.owner = :owner "
+                "   AND o.object_type IN ('FUNCTION', 'PACKAGE')",
                 owner=self._schema,
             )
         ]

--- a/src/mnemiq/adapters/oracle.py
+++ b/src/mnemiq/adapters/oracle.py
@@ -748,7 +748,11 @@ class OracleAdapter:
         Walked HERE rather than in SQL because the recursive form costs what the answer is not
         worth: `WITH ... UNION ALL ... CYCLE` over `ALL_SYNONYMS` measured **141 ms** a call, and
         116 ms even restricted to this schema, since each iteration rejoins a 7,869-row view with
-        no useful access path. Reading that view once is 23.8 ms.
+        no useful access path. Reading that view once is 23.8 ms, and `user_functions` as a
+        whole -- this read, the walk, and three other dictionary queries through `_rows` --
+        settles at 32 ms against DuckDB's 13. Both figures are on the container's stock
+        dictionary of 7,869 synonyms; see the note on the prefilter for what a much larger
+        one is not known to cost.
 
         **Keyed by (owner, name), not by name.** The first version keyed the walk on the target's
         bare name, so when a private and a PUBLIC synonym shared one, which link the walk took
@@ -819,10 +823,17 @@ class OracleAdapter:
         # A PUBLIC alias is a candidate only when its IMMEDIATE target already leaves Oracle's
         # own furniture, which is the same test the reporting filter applies at the end. Without
         # it the walk runs from all ~7,800 PUBLIC synonyms on a stock instance and
-        # `user_functions` costs 167 ms instead of 14; with it, every one that survives is a
+        # `user_functions` costs 167 ms instead of 32; with it, every one that survives is a
         # route a deployment created. What it gives up is a PUBLIC alias whose chain leaves an
         # Oracle-maintained schema on a LATER hop -- an Oracle synonym pointing into a user
         # schema, which none of the 7,869 here does.
+        #
+        # Both figures are this container's. A dictionary two orders larger -- an EBS-shaped
+        # instance runs to six figures of synonyms -- has not been measured, and the read is
+        # bounded only by the probe timeout: if it expires the inventory is `unavailable` and
+        # every statement on the source is refused, including ones that call nothing. Recorded
+        # as M101 rather than guessed at, because a number nobody ran is what this file keeps
+        # being wrong about.
         candidates = {
             (o, n): reachable_from(edges[(o, n)])
             for (o, n) in edges

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -809,3 +809,124 @@ def test_every_adapter_the_resolver_hands_out_can_answer_the_inventory():
     # builtin, so it needs no builtin catalogue and never takes the whole-source refusal.
     assert hasattr(OracleAdapter, "user_functions")
     assert OracleAdapter.binder_prefers_builtins is True
+
+
+# --------------------------------------------------------------------------------------------
+# Oracle's synonym walk, driven through a fake `_rows` so it needs no database. The shapes below
+# cannot be built on the test container at all -- `CREATE PUBLIC SYNONYM` is ORA-01031 for the
+# app user -- and the one that matters is a collision whose outcome USED to depend on the hash
+# seed, which is not something an integration test would have caught reliably either.
+# --------------------------------------------------------------------------------------------
+
+
+def _oracle_walk(synonyms, functions, oracle_owned=("sys",), schema="APP"):
+    """`_synonyms_reaching_functions` over a stubbed data dictionary."""
+    from mnemiq.adapters.oracle import OracleAdapter
+
+    adapter = OracleAdapter.__new__(OracleAdapter)
+    adapter._schema = schema
+
+    def rows(sql, **binds):
+        if "all_synonyms" in sql:
+            # The WHOLE graph, asserted here because a stub cannot honour a WHERE clause and
+            # would silently pass a version that narrowed the read before walking it -- which is
+            # the bug that stopped a chain at the first hop into another schema.
+            assert "where" not in sql.lower(), "the synonym graph must be read unfiltered"
+            return list(synonyms)
+        if "oracle_maintained" in sql:
+            return [(o,) for o in oracle_owned]
+        wanted = set(binds.values())
+        return [(o, n) for o, n in functions if o in wanted]
+
+    adapter._rows = rows
+    return adapter._synonyms_reaching_functions()
+
+
+def test_a_name_shared_by_a_private_and_a_public_synonym_resolves_the_same_way_every_time():
+    """The walk keyed on the target's bare NAME, so this resolved differently under different
+    hash seeds -- reached under PYTHONHASHSEED 0, 1, 4 and 7, missed under 2, 3, 5 and 6.
+
+    A control whose verdict moves with the hash seed is not a control. Both links are keyed by
+    (owner, name) and BOTH are followed, so nothing "wins" and nothing depends on iteration
+    order -- an alias counts if any object its chain can name is a function.
+    """
+    synonyms = [
+        ("app", "add_days", "app", "x"),     # the alias a query would spell
+        ("app", "x", "app", "udf"),          # private: reaches a function
+        ("public", "x", "app2", "some_tbl"),  # public: a red herring of the same name
+    ]
+    functions = [("app", "udf")]
+    assert _oracle_walk(synonyms, functions) == {"add_days", "x"}
+
+
+def test_a_chain_through_a_schema_this_connection_does_not_own_is_still_followed():
+    """The edge set used to be narrowed to this schema before the walk, so a hop through another
+    owner's synonym ended it. The whole graph is read and only the REPORTING is filtered."""
+    synonyms = [
+        ("app", "add_days", "shared", "mid"),
+        ("shared", "mid", "app", "udf"),
+    ]
+    assert "add_days" in _oracle_walk(synonyms, [("app", "udf")])
+
+
+def test_a_cycle_names_nothing_and_does_not_hang():
+    """`loop_a -> loop_b -> loop_a` raised ORA-32044 from the recursive SQL form, so it is a real
+    shape a deployment can hold. Termination is `seen`, and a cycle reaches no function, so
+    neither alias may be reported as one."""
+    synonyms = [("app", "loop_a", "app", "loop_b"), ("app", "loop_b", "app", "loop_a")]
+    assert _oracle_walk(synonyms, [("app", "udf")]) == set()
+
+
+def test_a_chain_longer_than_any_fixed_cap_still_resolves():
+    """A hop count on top of `seen` adds nothing to termination and silently drops a real chain:
+    with a cap of 8, a nine-hop chain left its first two aliases out of the inventory."""
+    synonyms = [("app", f"s{i}", "app", f"s{i+1}") for i in range(12)]
+    synonyms.append(("app", "s12", "app", "udf"))
+    assert "s0" in _oracle_walk(synonyms, [("app", "udf")])
+
+
+def test_oracles_own_public_synonyms_stay_out_so_lineage_survives():
+    """368 PUBLIC synonyms reach a function on the test container, every one Oracle-maintained.
+    Reporting them turns `calls_are_confirmable` false for every Oracle source -- issue #5 on a
+    schema that defines nothing of its own -- and they protect nothing, since none is in
+    sqlglot's vocabulary and the allowlist already refuses each as an unmodelled call.
+
+    The filter is on the ULTIMATE TARGET's owner, not the synonym's, which is what lets a PUBLIC
+    synonym over a deployment's own function back in.
+    """
+    oracle_side = [("public", "dbms_output", "sys", "dbms_output")]
+    deployment_side = [("public", "add_days", "app2", "udf")]
+    functions = [("sys", "dbms_output"), ("app2", "udf")]
+
+    assert _oracle_walk(oracle_side + deployment_side, functions,
+                        oracle_owned=("sys",)) == {"add_days"}
+
+
+def test_an_alias_and_its_target_may_share_a_name():
+    """`CREATE PUBLIC SYNONYM add_days FOR app2.add_days` is the commonest synonym of all, and a
+    by-name fallback to PUBLIC read it as a link from the synonym back to itself -- the walk then
+    ended on `seen` having found nothing, and the alias was dropped.
+
+    A target carries its owner, so there is no search order to model: the lookup is exact.
+    """
+    assert _oracle_walk([("public", "add_days", "app2", "add_days")],
+                        [("app2", "add_days")], oracle_owned=("sys",)) == {"add_days"}
+    # ...and the same shape privately owned.
+    assert _oracle_walk([("app", "udf", "app2", "udf")],
+                        [("app2", "udf")]) == {"udf"}
+
+
+def test_the_public_link_is_followed_when_the_named_schema_has_no_such_object():
+    """Oracle falls back to PUBLIC when the qualified target does not exist. Measured on the
+    container: `CREATE SYNONYM zz FOR appuser.dbms_random` with no `APPUSER.DBMS_RANDOM`, and
+    `SELECT zz.value FROM dual` returned a number through `PUBLIC.DBMS_RANDOM`.
+
+    An exact-only lookup dropped the alias, which is an approval. Which link applies depends on
+    whether the named object exists -- the very list this walk feeds -- so the order is not
+    modelled: both are followed, and over-inclusion costs a refusal rather than an approval.
+    """
+    synonyms = [
+        ("app", "add_days", "app", "calc"),   # app.calc does not exist...
+        ("public", "calc", "app2", "calc"),   # ...so Oracle takes the PUBLIC link
+    ]
+    assert "add_days" in _oracle_walk(synonyms, [("app2", "calc")])

--- a/tests/test_oracle_adapter.py
+++ b/tests/test_oracle_adapter.py
@@ -1736,3 +1736,90 @@ def test_a_udf_that_reads_an_ungranted_table_is_refused_and_the_builtins_are_not
                 assert not hasattr(verdict(clean), "code"), clean
     finally:
         adapter.close()
+
+
+def test_a_synonym_is_a_route_to_a_udf_and_the_alias_is_what_the_query_spells():
+    """A synonym named after something sqlglot MODELS is the reachable case, and the first
+    version of this test used one that was not.
+
+    `syn_leak` was never approvable: an alias sqlglot does not know reaches
+    `check_unmodelled_calls` as `exp.Anonymous`, and the cross-dialect allowlist refuses it
+    whatever the inventory holds -- so those assertions passed with the fix reverted and proved
+    nothing at all. `add_days` IS in that allowlist and is NOT an Oracle builtin, so Oracle binds
+    the synonym and the allowlist waves it through; only the inventory can catch it.
+
+    Measured both ways against this container: `decide` APPROVED `SELECT add_days(1)` with the
+    synonym arm removed from `user_functions`, and refuses it with the arm in place.
+    """
+    from mnemiq.sql.decide import decide
+
+    adapter = OracleAdapter(dsn=DSN, user=USER, password=PASSWORD, schema=USER.upper())
+    con = adapter._pool.acquire()
+    cur = con.cursor()
+    drops = ("DROP SYNONYM add_days", "DROP FUNCTION syn_udf",
+             "DROP TABLE syn_secret", "DROP TABLE syn_claim")
+    try:
+        for ddl in drops:
+            with contextlib.suppress(Exception):
+                cur.execute(ddl)
+        cur.execute("CREATE TABLE syn_secret(ssn VARCHAR2(20))")
+        cur.execute("INSERT INTO syn_secret VALUES ('123-45-6789')")
+        cur.execute("CREATE TABLE syn_claim(id NUMBER)")
+        cur.execute("INSERT INTO syn_claim VALUES (1)")
+        cur.execute("CREATE OR REPLACE FUNCTION syn_udf(x NUMBER) RETURN VARCHAR2 IS "
+                    "v VARCHAR2(20); BEGIN SELECT ssn INTO v FROM syn_secret WHERE ROWNUM = 1; "
+                    "RETURN v; END;")
+        cur.execute("CREATE SYNONYM add_days FOR syn_udf")
+        con.commit()
+
+        cur.execute("SELECT add_days(1) FROM dual")
+        assert cur.fetchone()[0] == "123-45-6789", "no leak, so nothing below proves anything"
+
+        # The ALIAS, which is what a query spells. Listing only the target was the bug.
+        names = set(adapter.user_functions())
+        assert "add_days" in names and "syn_udf" in names
+
+        def verdict(sql):
+            return decide(sql, {"syn_claim": {"id"}}, adapter=adapter,
+                          dialect="oracle", target="oracle")
+
+        refused = verdict("SELECT add_days(1) AS x FROM syn_claim")
+        assert refused.code.value == "unmodelled_call", refused
+        # ...from the INVENTORY branch, not the allowlist. They share a code and differ in what
+        # they say, and asserting only the code is how the first version passed while reverted.
+        assert "defined by this source itself" in refused.message, refused.message
+
+        for clean in ("SELECT count(*) AS n FROM syn_claim", "SELECT id FROM syn_claim"):
+            assert not hasattr(verdict(clean), "code"), clean
+    finally:
+        for ddl in drops:
+            with contextlib.suppress(Exception):
+                cur.execute(ddl)
+        con.commit()
+        adapter._pool.release(con)
+        adapter.close()
+
+
+def test_public_synonyms_stay_out_of_the_inventory_so_lineage_survives():
+    """368 PUBLIC synonyms resolve to a FUNCTION or PACKAGE here, every one Oracle-maintained.
+
+    Following them looked free on latency and is not. `calls_are_confirmable` is false whenever
+    the inventory holds ANY name, so 368 of them turn every Oracle answer containing any call
+    into `completeness='unknown'` -- issue #5 again, on a schema that defines nothing of its own.
+    They protect nothing either: none is in sqlglot's vocabulary, so the allowlist already
+    refuses each as an unmodelled call.
+    """
+    from mnemiq.sql.functions import FunctionInventory, calls_are_confirmable
+
+    adapter = OracleAdapter(dsn=DSN, user=USER, password=PASSWORD, schema=USER.upper())
+    try:
+        names = set(adapter.user_functions())
+        assert not [n for n in names if n.startswith("dbms_")], "a PUBLIC synonym got in"
+
+        # ...and the consequence, asserted where it bites rather than left to inference.
+        assert calls_are_confirmable(
+            FunctionInventory.of([], covers_view_bodies=True), in_view_body=False)
+        assert not calls_are_confirmable(
+            FunctionInventory.of(["dbms_advisor"], covers_view_bodies=True), in_view_body=False)
+    finally:
+        adapter.close()

--- a/tests/test_oracle_adapter.py
+++ b/tests/test_oracle_adapter.py
@@ -1800,14 +1800,15 @@ def test_a_synonym_is_a_route_to_a_udf_and_the_alias_is_what_the_query_spells():
         adapter.close()
 
 
-def test_public_synonyms_stay_out_of_the_inventory_so_lineage_survives():
-    """368 PUBLIC synonyms resolve to a FUNCTION or PACKAGE here, every one Oracle-maintained.
+def test_oracles_own_public_synonyms_do_not_reach_this_containers_inventory():
+    """368 PUBLIC synonyms resolve to a FUNCTION or PACKAGE here, every one Oracle-maintained,
+    and none of them may be reported: `calls_are_confirmable` is false whenever the inventory
+    holds ANY name, so they would turn every Oracle answer containing any call into
+    `completeness='unknown'` -- issue #5 again, on a schema that defines nothing of its own.
 
-    Following them looked free on latency and is not. `calls_are_confirmable` is false whenever
-    the inventory holds ANY name, so 368 of them turn every Oracle answer containing any call
-    into `completeness='unknown'` -- issue #5 again, on a schema that defines nothing of its own.
-    They protect nothing either: none is in sqlglot's vocabulary, so the allowlist already
-    refuses each as an unmodelled call.
+    This asserts the container's actual state. The FILTER that produces it -- ultimate target
+    owner, not synonym owner, so a deployment's own PUBLIC synonym still counts -- is pinned in
+    `tests/test_function_inventory.py`, because `CREATE PUBLIC SYNONYM` is ORA-01031 here.
     """
     from mnemiq.sql.functions import FunctionInventory, calls_are_confirmable
 
@@ -1822,4 +1823,59 @@ def test_public_synonyms_stay_out_of_the_inventory_so_lineage_survives():
         assert not calls_are_confirmable(
             FunctionInventory.of(["dbms_advisor"], covers_view_bodies=True), in_view_body=False)
     finally:
+        adapter.close()
+
+
+def test_a_synonym_chain_is_followed_and_a_cycle_does_not_stop_it():
+    """Oracle resolves `a -> b -> udf` at call time: measured, all three of `ch_udf(1)`,
+    `hop_mid(1)` and `add_days(1)` return the UDF. A join on the IMMEDIATE target sees only the
+    last hop, so a chained alias was missed -- and `add_days` is the reachable shape, since
+    sqlglot models it and the allowlist would otherwise wave it through.
+
+    The cycle is planted on purpose. The SQL form of this resolution needs a CYCLE clause or
+    Oracle raises ORA-32044, and a deployment can hold `loop_a -> loop_b -> loop_a` by accident;
+    the walk has to survive one whatever form it takes.
+    """
+    from mnemiq.sql.decide import decide
+
+    adapter = OracleAdapter(dsn=DSN, user=USER, password=PASSWORD, schema=USER.upper())
+    con = adapter._pool.acquire()
+    cur = con.cursor()
+    drops = ("DROP SYNONYM add_days", "DROP SYNONYM hop_mid", "DROP SYNONYM loop_a",
+             "DROP SYNONYM loop_b", "DROP FUNCTION ch_udf", "DROP TABLE ch_secret",
+             "DROP TABLE ch_claim")
+    try:
+        for ddl in drops:
+            with contextlib.suppress(Exception):
+                cur.execute(ddl)
+        cur.execute("CREATE TABLE ch_secret(ssn VARCHAR2(20))")
+        cur.execute("INSERT INTO ch_secret VALUES ('123-45-6789')")
+        cur.execute("CREATE TABLE ch_claim(id NUMBER)")
+        cur.execute("INSERT INTO ch_claim VALUES (1)")
+        cur.execute("CREATE OR REPLACE FUNCTION ch_udf(x NUMBER) RETURN VARCHAR2 IS "
+                    "v VARCHAR2(20); BEGIN SELECT ssn INTO v FROM ch_secret WHERE ROWNUM = 1; "
+                    "RETURN v; END;")
+        cur.execute("CREATE SYNONYM hop_mid FOR ch_udf")
+        cur.execute("CREATE SYNONYM add_days FOR hop_mid")
+        cur.execute("CREATE SYNONYM loop_a FOR loop_b")
+        cur.execute("CREATE SYNONYM loop_b FOR loop_a")
+        con.commit()
+
+        cur.execute("SELECT add_days(1) FROM dual")
+        assert cur.fetchone()[0] == "123-45-6789", "two hops must reach the UDF, or this proves nothing"
+
+        names = set(adapter.user_functions())
+        assert "add_days" in names, "the chained alias is what the query spells"
+        assert "hop_mid" in names
+
+        refused = decide("SELECT add_days(1) AS x FROM ch_claim", {"ch_claim": {"id"}},
+                         adapter=adapter, dialect="oracle", target="oracle")
+        assert refused.code.value == "unmodelled_call"
+        assert "defined by this source itself" in refused.message
+    finally:
+        for ddl in drops:
+            with contextlib.suppress(Exception):
+                cur.execute(ddl)
+        con.commit()
+        adapter._pool.release(con)
         adapter.close()


### PR DESCRIPTION
The stop-time review found that #23 left synonym-invoked UDFs approvable. It was
right, and closing it took four attempts because Oracle's name resolution is not
what I kept assuming.

### The leak

`CREATE SYNONYM add_days FOR real_udf` over a function reading an ungranted
table. `decide` **approved** `SELECT add_days(1)` — the inventory held the
target's name and the query spells the alias. It matters only for an alias
sqlglot models; one it does not know is refused by the allowlist anyway, which is
why my first demonstration (`syn_leak`) proved nothing and its test passed with
the fix reverted.

### Four attempts, each wrong in a way the next one measured

| attempt | what broke |
|---|---|
| join on the immediate target | a chain `a → b → udf` was missed; Oracle resolves all three |
| walk keyed on the bare **name** | a private/PUBLIC collision resolved by set iteration order — reached under `PYTHONHASHSEED` 0, 1, 4, 7 and missed under 2, 3, 5, 6 |
| keyed by identity, PUBLIC-by-name as the only fallback | read `PUBLIC add_days FOR app2.add_days` — the commonest shape — as a link from the synonym to itself, and dropped it |
| exact lookup only, "a target names one object" | wrong, and measured wrong: with no `APPUSER.DBMS_RANDOM`, `SELECT zz.value` resolved through `PUBLIC.DBMS_RANDOM` |

**Both links are followed now and neither is preferred.** Which one Oracle takes
depends on whether the named object exists — the very list this walk feeds — so
the order is not modelled at all. An alias counts if *any* object its chain can
name is a function. Over-inclusion costs a refusal; under-inclusion costs an
approval.

### Cost

Walked in Python, not SQL: the recursive `WITH ... CYCLE` form is **141 ms** a
call (116 ms even restricted to one schema) because each iteration rejoins a
7,869-row view. Reading the view once is 23.8 ms and `user_functions` settles at
**32 ms** against DuckDB's 13. A PUBLIC alias enters the walk only when its
immediate target already leaves Oracle's own furniture — without that the walk
runs from ~7,800 synonyms and costs 167 ms.

A planted `loop_a → loop_b → loop_a` raised **ORA-32044** from the recursive
form, so the cycle guard is not decoration. The hop cap is gone: `seen` already
terminates, and a cap of 8 silently dropped a nine-hop chain.

### Pinned where it can be

Over a stubbed data dictionary, because `CREATE PUBLIC SYNONYM` is ORA-01031 for
the app user and a hash-order bug is not something an integration test catches
reliably. Stable across the five seeds that used to disagree. Seven mutations
fail, including one that hangs.

**Filed, not fixed: M101.** Both figures are this container's. An EBS-shaped
dictionary runs to six figures of synonyms and is unmeasured — and a timeout
there makes the inventory `unavailable`, which refuses every statement on the
source, including ones that call nothing.

`1980 passed`; Oracle integration `56 passed, 7 skipped` live.