### PR TITLE
The synonym walk goes backwards, and stops asking SYS

### DIFF
--- a/src/mnemiq/adapters/oracle.py
+++ b/src/mnemiq/adapters/oracle.py
@@ -749,10 +749,14 @@ class OracleAdapter:
         worth: `WITH ... UNION ALL ... CYCLE` over `ALL_SYNONYMS` measured **141 ms** a call, and
         116 ms even restricted to this schema, since each iteration rejoins a 7,869-row view with
         no useful access path. Reading that view once is 23.8 ms, and `user_functions` as a
-        whole -- this read, the walk, and three other dictionary queries through `_rows` --
-        settles at 32 ms against DuckDB's 13. Both figures are on the container's stock
-        dictionary of 7,869 synonyms; see the note on the prefilter for what a much larger
-        one is not known to cost.
+        whole -- these reads, the walks, and two other dictionary queries through `_rows` --
+        settles around 40 ms against DuckDB's 13, on this container's 7,869 synonyms.
+
+        The WALK is linear in the graph and no longer the thing to worry about: the first
+        version stored a reachable set per alias and was quadratic, measured on a synthetic
+        chain at 3.6 ms for 200 synonyms, 63.2 for 800 and 239.3 for 1,600. Backwards from the
+        functions it is 33.9 ms at 40,000. What remains unmeasured is the dictionary READ on an
+        instance that size (M101), not the resolution.
 
         **Keyed by (owner, name), not by name.** The first version keyed the walk on the target's
         bare name, so when a private and a PUBLIC synonym shared one, which link the walk took
@@ -766,13 +770,18 @@ class OracleAdapter:
         that was wrong too, and measured wrong: Oracle takes the PUBLIC synonym when the named
         schema holds no such object. Both links are followed now and neither is preferred.
 
-        The WHOLE graph is read, and only the REPORTING is filtered. A chain may hop through a
-        schema this connection does not own, and an edge set narrowed first cannot follow it.
-        What comes back is an alias this schema owns, or a PUBLIC one whose ULTIMATE target
-        belongs to an owner Oracle does not maintain -- every PUBLIC synonym reaching a function
-        on this container is Oracle's own, 368 of them, and putting those in the inventory turns
-        `calls_are_confirmable` false for every Oracle source, which is issue #5 on a schema that
-        defines nothing.
+        The WHOLE graph is read and walked, and only the REPORTING is filtered. A chain may hop
+        through a schema this connection does not own, and an edge set narrowed first cannot
+        follow it. What comes back is an alias this schema owns, or a PUBLIC one whose chain ends
+        outside Oracle's own schemas -- every PUBLIC synonym reaching a function on this
+        container is Oracle's own, 368 of them, and reporting those turns `calls_are_confirmable`
+        false for every Oracle source, which is issue #5 on a schema that defines nothing.
+
+        That filter is asked as its own reverse walk rather than applied afterwards, which is
+        also why no candidate prefilter is needed: an earlier version skipped PUBLIC aliases
+        whose IMMEDIATE target was Oracle-maintained, purely to bound a quadratic walk, and gave
+        up a chain that leaves Oracle's schemas on a later hop. A fuzz over random graphs found
+        68 differences between the two and every one was that gain.
 
         Termination is `seen` over a set of visited objects, not a hop count. A planted `loop_a -> loop_b -> loop_a` raised
         ORA-32044 from the recursive query, so a cycle is a real shape; a depth cap on top of
@@ -795,54 +804,44 @@ class OracleAdapter:
         }
         mine = self._schema.lower()
 
-        def reachable_from(start: tuple[str, str]) -> set[tuple[str, str]]:
-            """Every object a chain from `start` can name.
+        # Forward and backward both, because each answers a question the other cannot.
+        nodes = set(edges) | set(edges.values())
+        forward: dict[tuple[str, str], list[tuple[str, str]]] = {}
+        backwards: dict[tuple[str, str], list[tuple[str, str]]] = {}
+        for at in nodes:
+            for step in (edges.get(at), edges.get(("public", at[1]))):
+                if step is not None:
+                    forward.setdefault(at, []).append(step)
+                    backwards.setdefault(step, []).append(at)
 
-            BOTH links are followed -- the exact one and PUBLIC-by-name -- because Oracle takes
-            the PUBLIC one when the named schema holds no such object. Measured:
-            `CREATE SYNONYM zz FOR appuser.dbms_random` with no `APPUSER.DBMS_RANDOM` present,
-            and `SELECT zz.value FROM dual` returned 0.41 through `PUBLIC.DBMS_RANDOM`.
-
-            Which link applies depends on whether the named object exists, and that is the very
-            list this walk is computing an input to. So the order is not modelled at all: both
-            are collected and the alias counts if ANY of them is a function. Over-inclusive, and
-            over-inclusion here costs a refusal while under-inclusion costs an approval.
-            """
-            seen: set[tuple[str, str]] = set()
-            stack = [start]
+        def spread(seeds, adjacency) -> set[tuple[str, str]]:
+            """Everything `seeds` reaches. `seen` is what makes a cycle terminate."""
+            seen = set(seeds)
+            stack = list(seen)
             while stack:
-                at = stack.pop()
-                if at in seen:
-                    continue
-                seen.add(at)
-                for step in (edges.get(at), edges.get(("public", at[1]))):
-                    if step is not None and step not in seen:
-                        stack.append(step)
+                for nxt in adjacency.get(stack.pop(), ()):
+                    if nxt not in seen:
+                        seen.add(nxt)
+                        stack.append(nxt)
             return seen
 
-        # A PUBLIC alias is a candidate only when its IMMEDIATE target already leaves Oracle's
-        # own furniture, which is the same test the reporting filter applies at the end. Without
-        # it the walk runs from all ~7,800 PUBLIC synonyms on a stock instance and
-        # `user_functions` costs 167 ms instead of 32; with it, every one that survives is a
-        # route a deployment created. What it gives up is a PUBLIC alias whose chain leaves an
-        # Oracle-maintained schema on a LATER hop -- an Oracle synonym pointing into a user
-        # schema, which none of the 7,869 here does.
+        # WHICH OWNERS TO ASK ABOUT, and this is where the cost lives rather than in the walk.
+        # Taking every owner named by an edge pulls SYS in, and `all_objects` for SYS alone is
+        # 107 ms against 3.5 ms for the app schema -- `user_functions` went from 30 ms to 157 ms
+        # that way, which is the same regression the removed prefilter had been hiding, moved
+        # from the walk into the read.
         #
-        # Both figures are this container's. A dictionary two orders larger -- an EBS-shaped
-        # instance runs to six figures of synonyms -- has not been measured, and the read is
-        # bounded only by the probe timeout: if it expires the inventory is `unavailable` and
-        # every statement on the source is refused, including ones that call nothing. Recorded
-        # as M101 rather than guessed at, because a number nobody ran is what this file keeps
-        # being wrong about.
-        candidates = {
-            (o, n): reachable_from(edges[(o, n)])
-            for (o, n) in edges
-            if o == mine or (o == "public" and edges[(o, n)][0] not in oracle_owned)
-        }
-        ends = {end for reached in candidates.values() for end in reached}
-        if not ends:
+        # Only two sets can matter. What THIS schema's aliases reach, which is a small forward
+        # walk. And every non-Oracle-maintained owner named anywhere, since a PUBLIC alias counts
+        # only where its chain ends outside Oracle's own schemas, so SYS functions can never
+        # decide that arm.
+        mine_reaches = spread({t for (o, _), t in edges.items() if o == mine}, forward)
+        owners = sorted(
+            {owner for owner, _ in mine_reaches}
+            | {owner for owner, _ in edges.values() if owner not in oracle_owned}
+        )
+        if not owners:
             return set()
-        owners = sorted({owner for owner, _ in ends})
         binds = {f"o{i}": owner for i, owner in enumerate(owners)}
         placeholders = ", ".join(f":{k}" for k in binds)
         functions = {
@@ -854,11 +853,24 @@ class OracleAdapter:
                 **binds,
             )
         }
+        if not functions:
+            return set()
+
+        # BACKWARDS from the functions, instead of forwards from every alias. The forward
+        # version stored a reachable set per candidate and was quadratic: measured on a synthetic
+        # chain, 3.6 ms at 200 synonyms, 63.2 at 800 and 239.3 at 1,600, which is the wrong shape
+        # for the dictionaries M101 is about. Each node is visited once here.
+        reaches_any = spread(functions & nodes, backwards)
+        # PUBLIC aliases count only where the chain ends outside Oracle's own schemas, so that
+        # question is asked of its own smaller target set rather than filtered afterwards.
+        reaches_free = spread({f for f in functions & nodes if f[0] not in oracle_owned},
+                              backwards)
+
         return {
             name
-            for (owner, name), reached in candidates.items()
-            if any(end in functions and (owner == mine or end[0] not in oracle_owned)
-                   for end in reached)
+            for (owner, name), target in edges.items()
+            if (owner == mine and target in reaches_any)
+            or (owner == "public" and target in reaches_free)
         }
 
     def foreign_keys(self) -> list[tuple[str, str, str, str, str]]:

--- a/src/mnemiq/adapters/oracle.py
+++ b/src/mnemiq/adapters/oracle.py
@@ -795,6 +795,14 @@ class OracleAdapter:
             "SELECT lower(s.owner), lower(s.synonym_name), "
             "       lower(s.table_owner), lower(s.table_name) FROM all_synonyms s"
         ):
+            # A NULL target owner is real -- an unqualified DB-link synonym has one -- and it
+            # used to reach `sorted()` and raise TypeError, which `inventory_from` turns into
+            # `unavailable` and the guard turns into refusing EVERY statement on the source. One
+            # such synonym anywhere in the dictionary would have stopped the whole deployment.
+            # Skipped rather than resolved: the docstring already says a DB-link target has no
+            # local `all_objects` row to resolve against.
+            if target_owner is None or target_name is None:
+                continue
             edges[(owner, name)] = (target_owner, target_name)
         if not edges:
             return set()
@@ -842,22 +850,28 @@ class OracleAdapter:
         )
         if not owners:
             return set()
-        binds = {f"o{i}": owner for i, owner in enumerate(owners)}
-        placeholders = ", ".join(f":{k}" for k in binds)
-        functions = {
-            (owner, name)
-            for owner, name in self._rows(
-                "SELECT lower(owner), lower(object_name) FROM all_objects "
-                "WHERE object_type IN ('FUNCTION', 'PACKAGE') "
-                f"  AND lower(owner) IN ({placeholders})",
-                **binds,
+        # Chunked, because an Oracle IN list is capped at 1,000 items (ORA-01795) and this one
+        # grows with every non-Oracle owner any synonym targets -- a schema-per-tenant instance
+        # passes that mark. 900 leaves room without needing a second measurement.
+        functions: set[tuple[str, str]] = set()
+        for start in range(0, len(owners), 900):
+            chunk = owners[start:start + 900]
+            binds = {f"o{i}": owner for i, owner in enumerate(chunk)}
+            placeholders = ", ".join(f":{k}" for k in binds)
+            functions.update(
+                (owner, name)
+                for owner, name in self._rows(
+                    "SELECT lower(owner), lower(object_name) FROM all_objects "
+                    "WHERE object_type IN ('FUNCTION', 'PACKAGE') "
+                    f"  AND lower(owner) IN ({placeholders})",
+                    **binds,
+                )
             )
-        }
         if not functions:
             return set()
 
-        # BACKWARDS from the functions, instead of forwards from every alias. The forward
-        # version stored a reachable set per candidate and was quadratic: measured on a synthetic
+        # BACKWARDS from the functions, instead of forwards from every alias. An earlier version
+        # stored a reachable set per candidate and was quadratic: measured on a synthetic
         # chain, 3.6 ms at 200 synonyms, 63.2 at 800 and 239.3 at 1,600, which is the wrong shape
         # for the dictionaries M101 is about. Each node is visited once here.
         reaches_any = spread(functions & nodes, backwards)

--- a/src/mnemiq/adapters/oracle.py
+++ b/src/mnemiq/adapters/oracle.py
@@ -799,8 +799,11 @@ class OracleAdapter:
             # used to reach `sorted()` and raise TypeError, which `inventory_from` turns into
             # `unavailable` and the guard turns into refusing EVERY statement on the source. One
             # such synonym anywhere in the dictionary would have stopped the whole deployment.
-            # Skipped rather than resolved: the docstring already says a DB-link target has no
-            # local `all_objects` row to resolve against.
+            # Skipped rather than resolved, and that trades an outage for a FAIL-OPEN (M102):
+            # Oracle resolves a call through such a synonym to the remote function, and an alias
+            # absent from `names` is cleared. Bounded by the same allowlist as everything else --
+            # only an alias sqlglot MODELS gets that far -- and there is no local answer, since a
+            # DB-link target has no `all_objects` row to resolve against.
             if target_owner is None or target_name is None:
                 continue
             edges[(owner, name)] = (target_owner, target_name)

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -999,3 +999,45 @@ def test_the_object_read_does_not_ask_about_oracles_own_schemas():
 
     assert "app2" in asked, "this schema's chain endpoints have to be resolved"
     assert "sys" not in asked, "SYS cannot decide either arm, and asking costs 107 ms"
+
+
+def test_a_synonym_with_no_target_owner_does_not_take_the_source_down():
+    """An unqualified DB-link synonym has a NULL `TABLE_OWNER`, and it used to reach `sorted()`
+    and raise TypeError. `inventory_from` turns a raise into `unavailable`, which the guard turns
+    into refusing EVERY statement on the source -- so one such row anywhere in the dictionary
+    would have stopped the deployment, including queries that call nothing.
+
+    Skipped, not resolved: a DB-link target has no local `all_objects` row to resolve against,
+    which the adapter's docstring already names as the limit.
+    """
+    synonyms = [("other", "remote_s", None, "emp"), ("app", "x", "app", "udf")]
+    assert _oracle_walk(synonyms, [("app", "udf")]) == {"x"}
+
+
+def test_the_owner_read_is_chunked_under_oracles_in_list_cap():
+    """An Oracle IN list is capped at 1,000 items (ORA-01795), and this one grows with every
+    non-Oracle owner any synonym targets -- a schema-per-tenant instance passes that mark.
+
+    The stub counts the reads rather than the binds, because the cap is on one statement.
+    """
+    synonyms = [("app", f"a{i}", f"own{i}", "udf") for i in range(2500)]
+    reads: list[int] = []
+
+    from mnemiq.adapters.oracle import OracleAdapter
+
+    adapter = OracleAdapter.__new__(OracleAdapter)
+    adapter._schema = "APP"
+
+    def rows(sql, **binds):
+        if "all_synonyms" in sql:
+            return list(synonyms)
+        if "oracle_maintained" in sql:
+            return [("sys",)]
+        reads.append(len(binds))
+        return [(o, "udf") for o in binds.values()]
+
+    adapter._rows = rows
+    got = adapter._synonyms_reaching_functions()
+
+    assert len(got) == 2500
+    assert reads and max(reads) <= 900, f"one read bound {max(reads)} owners"

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -1018,7 +1018,8 @@ def test_the_owner_read_is_chunked_under_oracles_in_list_cap():
     """An Oracle IN list is capped at 1,000 items (ORA-01795), and this one grows with every
     non-Oracle owner any synonym targets -- a schema-per-tenant instance passes that mark.
 
-    The stub counts the reads rather than the binds, because the cap is on one statement.
+    The stub records how many owners each READ binds and asserts on the largest, because the cap
+    is per statement rather than per call.
     """
     synonyms = [("app", f"a{i}", f"own{i}", "udf") for i in range(2500)]
     reads: list[int] = []

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -819,14 +819,21 @@ def test_every_adapter_the_resolver_hands_out_can_answer_the_inventory():
 # --------------------------------------------------------------------------------------------
 
 
-def _oracle_walk(synonyms, functions, oracle_owned=("sys",), schema="APP"):
-    """`_synonyms_reaching_functions` over a stubbed data dictionary."""
+def _oracle_walk(synonyms, functions, oracle_owned=("sys",), schema="APP", asked=None):
+    """`_synonyms_reaching_functions` over a stubbed data dictionary.
+
+    `asked` collects the owners the object read binds, because WHICH owners it asks about is
+    where the cost lives and no stub can time it.
+    """
     from mnemiq.adapters.oracle import OracleAdapter
 
+    asked = set() if asked is None else asked
     adapter = OracleAdapter.__new__(OracleAdapter)
     adapter._schema = schema
 
     def rows(sql, **binds):
+        if "all_objects" in sql:
+            asked.update(binds.values())
         if "all_synonyms" in sql:
             # The WHOLE graph, asserted here because a stub cannot honour a WHERE clause and
             # would silently pass a version that narrowed the read before walking it -- which is
@@ -930,3 +937,65 @@ def test_the_public_link_is_followed_when_the_named_schema_has_no_such_object():
         ("public", "calc", "app2", "calc"),   # ...so Oracle takes the PUBLIC link
     ]
     assert "add_days" in _oracle_walk(synonyms, [("app2", "calc")])
+
+
+def test_the_synonym_walk_is_linear_in_the_graph():
+    """It was quadratic: a reachable set stored per alias, measured on a synthetic chain at
+    3.6 ms for 200 synonyms, 13.9 for 400, 63.2 for 800 and 239.3 for 1,600. A dictionary of the
+    size M101 is about would not have finished.
+
+    Walking BACKWARDS from the functions visits each node once. The assertion is a ratio rather
+    than a wall-clock number, because a timing test pinned to a machine is a flaky test: doubling
+    the graph must not quadruple the work.
+    """
+    import time
+
+    def elapsed(n):
+        synonyms = [("app", f"c{i}", "app", f"c{i + 1}") for i in range(n)]
+        synonyms += [("app", f"a{j}", "app", "c0") for j in range(n)]
+        start = time.perf_counter()
+        _oracle_walk(synonyms, [("app", f"c{n}")])
+        return time.perf_counter() - start
+
+    small = min(elapsed(500) for _ in range(3))
+    large = min(elapsed(2000) for _ in range(3))
+    # Quadratic would be ~16x for a 4x graph. Linear is ~4x; the ceiling leaves room for noise
+    # without leaving room for the defect.
+    assert large < small * 9, f"{small * 1000:.1f} ms -> {large * 1000:.1f} ms looks superlinear"
+
+
+def test_a_public_chain_that_leaves_oracles_schemas_on_a_later_hop_still_counts():
+    """The candidate prefilter skipped a PUBLIC alias whose IMMEDIATE target was
+    Oracle-maintained, purely to bound a quadratic walk. Dropping it is a behaviour change: a
+    fuzz over random graphs found 68 differences and every one was this gain.
+
+    `public.later -> sys.hop -> app2.udf` ends outside Oracle's schemas, so the alias is a route
+    a deployment created and belongs in the inventory -- the first hop passing through SYS says
+    nothing about where it ends.
+    """
+    synonyms = [("public", "later", "sys", "hop"), ("sys", "hop", "app2", "udf")]
+    assert _oracle_walk(synonyms, [("app2", "udf")], oracle_owned=("sys",)) == {"later"}
+
+    # ...and the mirror: a chain that ENDS in an Oracle schema stays out however it got there.
+    ends_inside = [("public", "inside", "app2", "hop2"), ("app2", "hop2", "sys", "dbms_output")]
+    assert _oracle_walk(ends_inside, [("sys", "dbms_output")], oracle_owned=("sys",)) == set()
+
+
+def test_the_object_read_does_not_ask_about_oracles_own_schemas():
+    """Which owners the object read binds is where the cost lives, and no stub can time it.
+
+    Taking every owner named by an edge pulled SYS in, and `all_objects` for SYS alone is 107 ms
+    against 3.5 ms for the app schema -- `user_functions` went from 30 ms to 157 ms that way.
+    Only two sets can decide anything: what THIS schema's aliases reach, and every owner Oracle
+    does not maintain, because a PUBLIC alias counts only where its chain ends outside Oracle's
+    schemas.
+    """
+    asked: set[str] = set()
+    synonyms = [
+        ("public", "dbms_output", "sys", "dbms_output"),   # Oracle's own: cannot decide anything
+        ("app", "mine", "app2", "udf"),                    # this schema's: must be asked about
+    ]
+    _oracle_walk(synonyms, [("app2", "udf")], oracle_owned=("sys",), asked=asked)
+
+    assert "app2" in asked, "this schema's chain endpoints have to be resolved"
+    assert "sys" not in asked, "SYS cannot decide either arm, and asking costs 107 ms"


### PR DESCRIPTION
The stop-time review called the walk from #24 unbounded quadratic. It
reproduces, and fixing it surfaced three more things the container cannot show.

### Quadratic → linear

Forwards, the walk stored a reachable set per alias:

| synonyms | before | after |
|---|---|---|
| 200 | 3.6 ms | 0.1 ms |
| 800 | 63.2 ms | 0.5 ms |
| 1,600 | 239.3 ms | 2.2 ms |
| 40,000 | — | 33.9 ms |

Backwards from the function nodes, each node is visited once. The reverse edges
are built from the same two links the forward walk followed, so which chains
resolve is unchanged — five existing tests pin that.

### …and the read replaced the walk as the cost

My first attempt at that traded the quadratic walk for an expensive read, caught
before it landed. Taking every owner named by an edge pulls `SYS` in, and
`all_objects` for SYS alone is **107 ms** against 3.5 ms for the app schema, so
`user_functions` went 30 → **157 ms**. Only two owner sets can decide anything:
what *this* schema's aliases reach, and every owner Oracle does not maintain,
since a PUBLIC alias counts only where its chain ends outside Oracle's schemas.
Back to **40 ms**, and the extra ten over the old 30 is what the candidate
prefilter used to cost in correctness — a fuzz over random graphs found 68
differences between prefiltered and not, every one a PUBLIC chain leaving
Oracle's schemas on a later hop.

### Two shapes the container cannot produce

**A NULL `TABLE_OWNER` stopped the source.** An unqualified DB-link synonym has
one; it reached `sorted()` and raised `TypeError`, which becomes `unavailable`
and then a refusal of *every* statement — including queries that call nothing.
One such row anywhere in the dictionary. Skipped now, which trades the outage for
a fail-open recorded as **M102**: bounded to aliases sqlglot models, and with no
local answer, since a DB-link target has no `all_objects` row.

**The owner IN list had no cap**, against Oracle's 1,000-item `ORA-01795`. It
grows with every non-Oracle owner any synonym targets, which a schema-per-tenant
instance passes. Chunked at 900.

Both are pinned by stubs: the container holds 0 NULL-owner synonyms out of 7,869
and nothing near 1,000 owners.

### Tests

Eleven mutations fail, including one that hangs. The scaling test asserts a
*ratio* — quadratic is ~16x for a 4x graph, linear ~4x, so it allows 9x — because
a wall-clock number pinned to a machine is a flaky test. And the owner set has
its own test, since which owners the read binds is where the cost lives and no
stub can time it.

`1985 passed`; Oracle integration `56 passed, 7 skipped` live.