### PR TITLE
A column can be the call (M100), and a join key can be one too (M103)

### DIFF
--- a/src/mnemiq/adapters/base.py
+++ b/src/mnemiq/adapters/base.py
@@ -45,6 +45,17 @@ class SourceAdapter(Protocol):
     # off the rendered statement is what catches that. A failure RAISES.
     def reachable_user_functions(self) -> list[str]: ...
 
+    # (table, column, stored expression) for every VIRTUAL column -- one whose expression runs
+    # on read, so the statement never names the call. Read through `hasattr`; an adapter that
+    # omits it reports nothing and the decider learns nothing, which is where every adapter
+    # shipped. The EXPRESSION comes back rather than a verdict: whether it is opaque depends on
+    # this source's function inventory, and that judgement belongs in the decider. A failure
+    # RAISES, and `opaque_columns` reads a raise as "nothing known" rather than "none exist" --
+    # the one place in this family where the permissive reading is right, because `check_access`
+    # still stands over the same column. DuckDB needs none: a generated column whose expression
+    # holds a subquery is refused at bind time, so a macro reachable there cannot read a table.
+    def virtual_columns(self) -> list[tuple[str, str, str]]: ...
+
     # Whether `user_functions()` also answers for a VIEW BODY on this source. Read through
     # `getattr(adapter, ..., False)`, so an adapter that says nothing is taken not to cover them
     # -- forgetting yields the conservative answer. Deliberately NOT declared as a member here:

--- a/src/mnemiq/adapters/oracle.py
+++ b/src/mnemiq/adapters/oracle.py
@@ -890,6 +890,35 @@ class OracleAdapter:
             or (owner == "public" and target in reaches_free)
         }
 
+    def virtual_columns(self) -> list[tuple[str, str, str]]:
+        """(table, column, expression) for every VIRTUAL column in this schema.
+
+        A virtual column runs its expression on read, so it is a route to user code the
+        statement never names. MEASURED: `leaked AS (vc_udf(id))` over a function reading
+        another table, and `SELECT id, leaked FROM vc_t` returned an SSN with no function named
+        anywhere in the SQL (M100). `check_unmodelled_calls` walks call nodes, `called_names`
+        reads the rendered text, and `check_access` sees a column the snapshot lists -- all
+        three pass it.
+
+        The EXPRESSION comes back, not a verdict, because which of them is opaque is a question
+        about this source's function inventory and that belongs in the decider rather than here.
+        `ALL_TAB_COLS.DATA_DEFAULT` is a LONG and arrives quoted: `"APPUSER"."VC_UDF"("ID")` for
+        the dangerous one, `"QTY"*"PRICE"` for arithmetic, which is exactly the distinction the
+        caller needs to draw.
+
+        0.5 ms on this container, and scoped to `self._schema` for the reason `list_columns` is.
+
+        A failure RAISES, like its siblings.
+        """
+        return [
+            (table, column, expression or "")
+            for table, column, expression in self._rows(
+                "SELECT lower(table_name), lower(column_name), data_default "
+                "FROM all_tab_cols WHERE owner = :owner AND virtual_column = 'YES'",
+                owner=self._schema,
+            )
+        ]
+
     def foreign_keys(self) -> list[tuple[str, str, str, str, str]]:
         """Declared FKs: (from_table, from_col, to_table, to_col, constraint_id).
 

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -260,13 +260,12 @@ def check_opaque_columns(ast: exp.Expression, opaque, dialect: str | None = None
     referenced = {object_key(t): t.alias_or_name for t in base_tables(ast, dialect)}
     by_alias = {alias: table for table, alias in referenced.items()}
 
-    def refuse(name: str, why: str) -> Refusal:
+    def refuse(name: str, why: str, repair: str) -> Refusal:
         return Refusal(
             code=RefusalCode.UNRESOLVABLE_CALLS,
             message=(
                 f"{name!r} is computed by an expression this source stores and this engine "
-                f"cannot attribute, so it cannot confirm what {why} executes. Answer without "
-                "that column."
+                f"cannot attribute, so it cannot confirm what {why} executes. {repair}"
             ),
             subject=name,
             repairable_override=True,
@@ -282,13 +281,14 @@ def check_opaque_columns(ast: exp.Expression, opaque, dialect: str | None = None
             name = key.name.lower() if hasattr(key, "name") else str(key).lower()
             for table in referenced:
                 if (table.lower(), name) in opaque:
-                    return refuse(name, "joining on it")
+                    return refuse(name, "joining on it", "Join on a different column.")
         if (join.args.get("method") or "").upper() == "NATURAL":
             # It names no column, so there is nothing to check against: the keys are whatever the
             # two tables share. Any opaque column on a table in this statement could be one.
             for table, column in sorted(opaque):
                 if table in referenced:
-                    return refuse(column, "a NATURAL join on this table")
+                    return refuse(column, "a NATURAL join on this table",
+                                  "Join with an explicit ON or USING naming the columns.")
 
     for column in ast.find_all(exp.Column):
         name = column.name.lower()
@@ -300,7 +300,7 @@ def check_opaque_columns(ast: exp.Expression, opaque, dialect: str | None = None
             owners = list(referenced)
         for table in owners:
             if (table.lower(), name) in opaque:
-                return refuse(name, "reading it")
+                return refuse(name, "reading it", "Answer without that column.")
     return None
 
 

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -285,8 +285,13 @@ def check_opaque_columns(ast: exp.Expression, opaque, dialect: str | None = None
         if (join.args.get("method") or "").upper() == "NATURAL":
             # It names no column, so there is nothing to check against: the keys are whatever the
             # two tables share. Any opaque column on a table in this statement could be one.
+            # Lowercased, like the USING arm and the column loop. `opaque` keys arrive
+            # lowercase from the adapter and an Oracle query naturally writes `FROM VC_T`, so
+            # comparing raw let the uppercase spelling through -- the case that source actually
+            # produces, while the lowercase one was refused.
+            lowered = {t.lower() for t in referenced}
             for table, column in sorted(opaque):
-                if table in referenced:
+                if table.lower() in lowered:
                     return refuse(column, "a NATURAL join on this table",
                                   "Join with an explicit ON or USING naming the columns.")
 

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -238,6 +238,50 @@ def check_unmodelled_calls(
     return None
 
 
+def check_opaque_columns(ast: exp.Expression, opaque, dialect: str | None = None) -> Refusal | None:
+    """Refuse a column whose stored expression this engine cannot attribute.
+
+    A virtual column runs user code on read, and the statement never names it. MEASURED on
+    Oracle: `leaked AS (vc_udf(id))` over a function reading another table, and
+    `SELECT id, leaked FROM vc_t` returned an SSN from a table the identity was never granted.
+    `check_unmodelled_calls` walks call nodes and sees none; `called_names` reads the rendered
+    text and sees none; `check_access` sees a column the snapshot lists and passes it.
+
+    Third time this codebase has met code reached with no call in the text -- after `count(*)`
+    binding a macro named `count_star`, and `SELECT id + 1` binding one named `+`. The first two
+    were answered by asking the source a different question rather than enumerating shapes, and
+    so is this: `opaque` comes from the source's own dictionary.
+
+    REPAIRABLE, unlike the other arrivals at this code. Selecting a different column is a real
+    rewrite, and the message names the one to avoid.
+    """
+    if not opaque:
+        return None
+    referenced = {object_key(t): t.alias_or_name for t in base_tables(ast, dialect)}
+    by_alias = {alias: table for table, alias in referenced.items()}
+    for column in ast.find_all(exp.Column):
+        name = column.name.lower()
+        # A qualifier names the table directly; without one, any table in scope could own it,
+        # and an opaque column anywhere in scope is one this statement may be reading.
+        if column.table:
+            owners = [by_alias.get(column.table.lower(), column.table.lower())]
+        else:
+            owners = list(referenced)
+        for table in owners:
+            if (table.lower(), name) in opaque:
+                return Refusal(
+                    code=RefusalCode.UNRESOLVABLE_CALLS,
+                    message=(
+                        f"{name!r} is computed by an expression this source stores and this "
+                        "engine cannot attribute, so it cannot confirm what reading it "
+                        "executes. Answer without that column."
+                    ),
+                    subject=name,
+                    repairable_override=True,
+                )
+    return None
+
+
 def _cannot_resolve(inventory: FunctionInventory, *, unreadable: bool = False) -> Refusal:
     """Nothing here can be attributed, so nothing here can be decided.
 

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -259,6 +259,37 @@ def check_opaque_columns(ast: exp.Expression, opaque, dialect: str | None = None
         return None
     referenced = {object_key(t): t.alias_or_name for t in base_tables(ast, dialect)}
     by_alias = {alias: table for table, alias in referenced.items()}
+
+    def refuse(name: str, why: str) -> Refusal:
+        return Refusal(
+            code=RefusalCode.UNRESOLVABLE_CALLS,
+            message=(
+                f"{name!r} is computed by an expression this source stores and this engine "
+                f"cannot attribute, so it cannot confirm what {why} executes. Answer without "
+                "that column."
+            ),
+            subject=name,
+            repairable_override=True,
+        )
+
+    # A JOIN KEY is not an `exp.Column`, and it reads the column all the same. `USING (leaked)`
+    # names it as a bare identifier, and a NATURAL join names nothing at all -- both evaluate the
+    # expression per row, and whether rows match leaks its value a bit at a time. Measured: both
+    # passed a guard that walked only column nodes, while `WHERE leaked = 'x'` was refused, which
+    # is the same channel one syntax over.
+    for join in ast.find_all(exp.Join):
+        for key in join.args.get("using") or ():
+            name = key.name.lower() if hasattr(key, "name") else str(key).lower()
+            for table in referenced:
+                if (table.lower(), name) in opaque:
+                    return refuse(name, "joining on it")
+        if (join.args.get("method") or "").upper() == "NATURAL":
+            # It names no column, so there is nothing to check against: the keys are whatever the
+            # two tables share. Any opaque column on a table in this statement could be one.
+            for table, column in sorted(opaque):
+                if table in referenced:
+                    return refuse(column, "a NATURAL join on this table")
+
     for column in ast.find_all(exp.Column):
         name = column.name.lower()
         # A qualifier names the table directly; without one, any table in scope could own it,
@@ -269,16 +300,7 @@ def check_opaque_columns(ast: exp.Expression, opaque, dialect: str | None = None
             owners = list(referenced)
         for table in owners:
             if (table.lower(), name) in opaque:
-                return Refusal(
-                    code=RefusalCode.UNRESOLVABLE_CALLS,
-                    message=(
-                        f"{name!r} is computed by an expression this source stores and this "
-                        "engine cannot attribute, so it cannot confirm what reading it "
-                        "executes. Answer without that column."
-                    ),
-                    subject=name,
-                    repairable_override=True,
-                )
+                return refuse(name, "reading it")
     return None
 
 

--- a/src/mnemiq/sql/cls.py
+++ b/src/mnemiq/sql/cls.py
@@ -66,22 +66,26 @@ def check_cls(ast: exp.Expression, policy: AccessPolicy,
     for join in ast.find_all(exp.Join):
         for key in join.args.get("using") or ():
             name = key.name if hasattr(key, "name") else str(key)
-            for table in referenced:
-                if policy.denies(table, name):
-                    return Refusal(
-                        code=RefusalCode.UNAUTHORIZED_COLUMN,
-                        message=f"You may not read the column {name!r}.",
-                        subject=name,
-                    )
-                if policy.masks(table, name):
-                    return Refusal(
-                        code=RefusalCode.MASKED_COLUMN_IN_PREDICATE,
-                        message=(
-                            f"{name!r} is masked for you; joining on it is a filter, so it may "
-                            "only be selected."
-                        ),
-                        subject=name,
-                    )
+            # DENY across every candidate table before MASK, the order the column loop below
+            # uses. Asking both per table inside one loop made the verdict depend on set
+            # iteration order: with one table masking `ssn` and another denying it, the same
+            # query returned the repairable `masked_column_in_predicate` in some processes and
+            # the unrepairable `unauthorized_column` in others.
+            if any(policy.denies(table, name) for table in referenced):
+                return Refusal(
+                    code=RefusalCode.UNAUTHORIZED_COLUMN,
+                    message=f"You may not read the column {name!r}.",
+                    subject=name,
+                )
+            if any(policy.masks(table, name) for table in referenced):
+                return Refusal(
+                    code=RefusalCode.MASKED_COLUMN_IN_PREDICATE,
+                    message=(
+                        f"{name!r} is masked for you; joining on it is a filter, so it may "
+                        "only be selected."
+                    ),
+                    subject=name,
+                )
         if (join.args.get("method") or "").upper() == "NATURAL":
             # It names no column: the keys are whatever the tables share, so any denied or
             # masked column on a referenced table could be one. The repair is an explicit ON.

--- a/src/mnemiq/sql/cls.py
+++ b/src/mnemiq/sql/cls.py
@@ -58,6 +58,46 @@ def check_cls(ast: exp.Expression, policy: AccessPolicy,
     local = {cte.alias_or_name for cte in ast.find_all(exp.CTE)}
     aliased = local | {s.alias_or_name for s in ast.find_all(exp.Subquery) if s.alias_or_name}
 
+    # A JOIN KEY is not an `exp.Column`, and it reads the column all the same. Measured with
+    # `denied={("claim","ssn")}`: `ON c.ssn = p.ssn` was refused and both `USING (ssn)` and
+    # `NATURAL JOIN person` were APPROVED -- a denied column used as a join key, and a masked one
+    # filtered through one, where whether rows match leaks the value a row at a time. The same
+    # hole `check_opaque_columns` was written around; found there and then looked for here.
+    for join in ast.find_all(exp.Join):
+        for key in join.args.get("using") or ():
+            name = key.name if hasattr(key, "name") else str(key)
+            for table in referenced:
+                if policy.denies(table, name):
+                    return Refusal(
+                        code=RefusalCode.UNAUTHORIZED_COLUMN,
+                        message=f"You may not read the column {name!r}.",
+                        subject=name,
+                    )
+                if policy.masks(table, name):
+                    return Refusal(
+                        code=RefusalCode.MASKED_COLUMN_IN_PREDICATE,
+                        message=(
+                            f"{name!r} is masked for you; joining on it is a filter, so it may "
+                            "only be selected."
+                        ),
+                        subject=name,
+                    )
+        if (join.args.get("method") or "").upper() == "NATURAL":
+            # It names no column: the keys are whatever the tables share, so any denied or
+            # masked column on a referenced table could be one. The repair is an explicit ON.
+            for table in sorted(referenced):
+                for owner, name in sorted(policy.denied | policy.masked):
+                    if owner == table:
+                        return Refusal(
+                            code=RefusalCode.UNAUTHORIZED_COLUMN,
+                            message=(
+                                "A NATURAL join reads whatever columns these tables share, and "
+                                f"{table!r} has one this identity may not read that way. Join "
+                                "with an explicit ON or USING naming the columns."
+                            ),
+                            subject=table,
+                        )
+
     for column in ast.find_all(exp.Column):
         cands = _candidate_tables(column, resolved, referenced, aliased)
         name = column.name

--- a/src/mnemiq/sql/decide.py
+++ b/src/mnemiq/sql/decide.py
@@ -4,8 +4,8 @@ import sqlglot
 from sqlglot import exp
 
 from mnemiq.contract import ViewDefinition
-from mnemiq.sql.functions import inventory_from
-from mnemiq.sql.authz_guard import check_access, check_unmodelled_calls
+from mnemiq.sql.functions import inventory_from, opaque_columns
+from mnemiq.sql.authz_guard import check_access, check_opaque_columns, check_unmodelled_calls
 from mnemiq.sql.cls import check_cls
 from mnemiq.sql.guard import MAX_ROWS, check_shape
 from mnemiq.sql.lint import lint
@@ -67,6 +67,15 @@ def decide(
     opaque = check_unmodelled_calls(shaped, functions, dialect, target)
     if opaque is not None:
         return opaque
+
+    # A COLUMN can be the call. A virtual column runs its stored expression on read, so
+    # `SELECT id, leaked FROM t` executes a UDF that the statement never names -- measured on
+    # Oracle, returning an SSN from an ungranted table while every check above passed it (M100).
+    # Third shape of the same thing, after `count(*)` reaching `count_star` and `id + 1`
+    # reaching a macro named `+`, and answered the same way: ask the source, do not enumerate.
+    computed = check_opaque_columns(shaped, opaque_columns(adapter, functions), target)
+    if computed is not None:
+        return computed
 
     cls = check_cls(shaped, policy, target)  # column deny / mask-in-predicate
     if cls is not None:

--- a/src/mnemiq/sql/decide_write.py
+++ b/src/mnemiq/sql/decide_write.py
@@ -5,8 +5,8 @@ from sqlglot import exp
 
 from mnemiq.authz.grants import GrantSet
 from mnemiq.contract import ViewDefinition
-from mnemiq.sql.authz_guard import check_access, check_unmodelled_calls
-from mnemiq.sql.functions import inventory_from
+from mnemiq.sql.authz_guard import check_access, check_opaque_columns, check_unmodelled_calls
+from mnemiq.sql.functions import inventory_from, opaque_columns
 from mnemiq.sql.cls import check_cls
 from mnemiq.sql.policy import AccessPolicy
 from mnemiq.sql.prove import prove
@@ -223,9 +223,17 @@ def decide_write(
     # that stores what it read into a granted table. Both dialects, as on the read path: the
     # guard renders to find the names the source will be asked for, and `target` has already
     # been defaulted to `dialect` at the top of this function.
-    opaque = check_unmodelled_calls(shaped, inventory_from(adapter), dialect, target)
+    functions = inventory_from(adapter)
+    opaque = check_unmodelled_calls(shaped, functions, dialect, target)
     if opaque is not None:
         return opaque
+
+    # And the column form, for the reason above stated once more: a write is the worse place to
+    # lose it. `INSERT INTO notes SELECT id, leaked FROM vc_t` stores what the virtual column's
+    # expression returned into a table the caller may read forever (M100, the M30 shape).
+    computed = check_opaque_columns(shaped, opaque_columns(adapter, functions), target)
+    if computed is not None:
+        return computed
 
     # A write needs RAW access: a masked column is treated as denied for writes.
     write_cls = check_cls(shaped, AccessPolicy(denied=policy.denied | policy.masked), target)

--- a/src/mnemiq/sql/functions.py
+++ b/src/mnemiq/sql/functions.py
@@ -299,6 +299,40 @@ def _builtins_from(adapter) -> tuple[frozenset[str] | None, bool]:
         return None, True
 
 
+def opaque_columns(adapter, inventory: FunctionInventory) -> frozenset[tuple[str, str]]:
+    """(table, column) pairs whose stored expression this engine cannot attribute.
+
+    A virtual column is a route to user code with no call in the statement, which is the third
+    shape of that this codebase has found -- after `count(*)` binding a macro named `count_star`
+    and `SELECT id + 1` binding one named `+`. Each time the answer was to stop enumerating
+    shapes and ask the source a different question; this is that question for columns.
+
+    Opaque means the expression NAMES something this source defines. Arithmetic does not --
+    `"QTY"*"PRICE"` calls nothing -- and refusing every virtual column would cost a legitimate
+    modelling feature to close a route that needs a function to be a route at all.
+
+    An adapter that cannot report virtual columns yields nothing, which is the state every
+    adapter shipped in, and an inventory that is not `certain` yields every virtual column,
+    because then no name in an expression can be cleared.
+    """
+    if adapter is None or not hasattr(adapter, "virtual_columns"):
+        return frozenset()
+    try:
+        columns = adapter.virtual_columns()
+    except Exception:
+        # The same reading `inventory_from` gives a failed lookup: asked and could not answer is
+        # not "there are none". Every virtual column would be unknown, and none is known, so the
+        # honest answer is that the caller learns nothing here -- `check_access` still stands.
+        return frozenset()
+    if not inventory.certain:
+        return frozenset((t, c) for t, c, _ in columns)
+    return frozenset(
+        (table, column)
+        for table, column, expression in columns
+        if names_called_in(expression) & inventory.names
+    )
+
+
 def calls_are_confirmable(inventory: FunctionInventory, *, in_view_body: bool) -> bool:
     """Whether a call in this statement can be taken for a builtin.
 
@@ -339,6 +373,18 @@ _CALLED = re.compile(r"([A-Za-z_][A-Za-z_0-9$]*)\s*\(")
 
 class UnreadableCalls(Exception):
     """The statement could not be rendered, so its call names could not be enumerated."""
+
+
+def names_called_in(expression: str) -> frozenset[str]:
+    """Every name called in a stored expression, over-collected on purpose.
+
+    The same crude scan `called_names` runs over a rendered statement, on a fragment the source
+    stored rather than one this engine rendered -- a virtual column's `DATA_DEFAULT`, which
+    arrives quoted: `"APPUSER"."VC_UDF"("ID")`. The quotes are stripped first, because an
+    identifier followed by `"` followed by `(` matches nothing otherwise, and a scan that
+    silently finds no calls in a fragment full of them is worse than no scan.
+    """
+    return frozenset(m.lower() for m in _CALLED.findall(expression.replace('"', "")))
 
 
 def called_names(ast: exp.Expression, *dialects: str) -> frozenset[str]:

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -1042,3 +1042,86 @@ def test_the_owner_read_is_chunked_under_oracles_in_list_cap():
 
     assert len(got) == 2500
     assert reads and max(reads) <= 900, f"one read bound {max(reads)} owners"
+
+
+# --------------------------------------------------------------------------------------------
+# M100. A virtual column runs its stored expression on read, so the statement never names the
+# call. Third shape of that here, after `count(*)` reaching a macro named `count_star` and
+# `SELECT id + 1` reaching one named `+`.
+# --------------------------------------------------------------------------------------------
+
+
+def _opaque(virtual, defines, certain=True):
+    from mnemiq.sql.functions import FunctionInventory, opaque_columns
+
+    class Source:
+        def virtual_columns(self):
+            return list(virtual)
+
+    inventory = (FunctionInventory.of(defines) if certain
+                 else FunctionInventory.unavailable("RuntimeError"))
+    return opaque_columns(Source(), inventory)
+
+
+def test_only_a_virtual_column_that_names_a_user_function_is_opaque():
+    """Arithmetic calls nothing. Refusing every virtual column would cost a legitimate modelling
+    feature to close a route that needs a function to be a route at all -- measured on the
+    container, `total AS (qty * price)` stores `"QTY"*"PRICE"` and `leaked AS (vc_udf(id))`
+    stores `"APPUSER"."VC_UDF"("ID")`.
+    """
+    virtual = [("vc_t", "total", '"QTY"*"PRICE"'),
+               ("vc_t", "leaked", '"APPUSER"."VC_UDF"("ID")')]
+    assert _opaque(virtual, ["vc_udf"]) == frozenset({("vc_t", "leaked")})
+
+
+def test_a_virtual_column_calling_something_this_source_does_not_define_is_left_alone():
+    """A builtin in a virtual column is still a builtin. `UPPER("NAME")` names nothing this
+    source defines, and the name-based question is the same one the call guard asks."""
+    assert _opaque([("t", "shouty", 'UPPER("NAME")')], ["vc_udf"]) == frozenset()
+
+
+def test_an_uncertain_inventory_makes_every_virtual_column_opaque():
+    """If no name in an expression can be cleared, none of them is cleared. The empty `names` an
+    `unavailable` inventory carries would otherwise read as "this source defines nothing", which
+    is the collapse `FunctionInventory` exists to prevent."""
+    virtual = [("t", "a", '"X"*"Y"'), ("t", "b", 'F("X")')]
+    assert _opaque(virtual, [], certain=False) == frozenset({("t", "a"), ("t", "b")})
+
+
+def test_an_adapter_that_cannot_report_virtual_columns_changes_nothing():
+    """Every adapter shipped in that state, so it must stay the permissive one -- the same
+    posture `never_asked` takes for functions."""
+    from mnemiq.sql.functions import FunctionInventory, opaque_columns
+
+    class Silent:
+        pass
+
+    class Angry:
+        def virtual_columns(self):
+            raise RuntimeError("no dictionary for you")
+
+    assert opaque_columns(Silent(), FunctionInventory.of(["f"])) == frozenset()
+    assert opaque_columns(Angry(), FunctionInventory.of(["f"])) == frozenset()
+    assert opaque_columns(None, FunctionInventory.of(["f"])) == frozenset()
+
+
+def test_the_guard_catches_the_column_qualified_or_not():
+    """`check_access` sees a column the snapshot lists and passes it, so this is the only thing
+    between the caller and the expression. A qualifier must not be a way around it."""
+    import sqlglot
+
+    from mnemiq.sql.authz_guard import check_opaque_columns
+
+    opaque = frozenset({("vc_t", "leaked")})
+    for sql in ("SELECT id, leaked FROM vc_t",
+                "SELECT vc_t.leaked FROM vc_t",
+                "SELECT t.leaked FROM vc_t AS t",
+                "SELECT id FROM vc_t WHERE leaked = 'x'"):
+        refusal = check_opaque_columns(sqlglot.parse_one(sql, read="oracle"), opaque, "oracle")
+        assert refusal is not None, sql
+        assert refusal.subject == "leaked"
+        assert refusal.repairable is True, "selecting another column is a real rewrite"
+
+    clean = check_opaque_columns(
+        sqlglot.parse_one("SELECT id, total FROM vc_t", read="oracle"), opaque, "oracle")
+    assert clean is None

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -1125,3 +1125,37 @@ def test_the_guard_catches_the_column_qualified_or_not():
     clean = check_opaque_columns(
         sqlglot.parse_one("SELECT id, total FROM vc_t", read="oracle"), opaque, "oracle")
     assert clean is None
+
+
+@pytest.mark.parametrize("sql, why", [
+    ("SELECT vc_t.id FROM vc_t JOIN other USING (leaked)", "USING names it as a bare identifier"),
+    ("SELECT id FROM vc_t NATURAL JOIN other", "NATURAL names no column at all"),
+])
+def test_a_join_key_reads_the_column_without_being_a_column_node(sql, why):
+    """Both passed a guard that walked only `exp.Column`, while `WHERE leaked = 'x'` was refused
+    -- the same channel one syntax over. A join evaluates the expression per row, and whether
+    rows match leaks its value a bit at a time.
+
+    NATURAL has nothing to check against, since the keys are whatever the two tables share, so
+    any opaque column on a table in the statement is one it could be joining on.
+    """
+    import sqlglot
+
+    from mnemiq.sql.authz_guard import check_opaque_columns
+
+    refusal = check_opaque_columns(sqlglot.parse_one(sql, read="oracle"),
+                                   frozenset({("vc_t", "leaked")}), "oracle")
+    assert refusal is not None, why
+    assert refusal.subject == "leaked"
+
+
+def test_a_join_on_an_ordinary_column_still_answers():
+    """The control. Without it the pair above is satisfied by refusing every join."""
+    import sqlglot
+
+    from mnemiq.sql.authz_guard import check_opaque_columns
+
+    clean = check_opaque_columns(
+        sqlglot.parse_one("SELECT vc_t.id FROM vc_t JOIN other USING (id)", read="oracle"),
+        frozenset({("vc_t", "leaked")}), "oracle")
+    assert clean is None

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -1170,3 +1170,18 @@ def test_a_join_that_cannot_touch_the_opaque_column_still_answers():
         sqlglot.parse_one("SELECT id FROM vc_t NATURAL JOIN other", read="oracle"),
         opaque, "oracle")
     assert "explicit ON or USING" in natural.message
+
+
+def test_the_natural_arm_matches_the_case_an_oracle_query_actually_writes():
+    """`opaque` keys arrive lowercase from the adapter and an Oracle query naturally writes
+    `FROM VC_T`, so an un-lowercased comparison let the uppercase spelling through while
+    refusing the lowercase one -- the wrong way round from what the source produces."""
+    import sqlglot
+
+    from mnemiq.sql.authz_guard import check_opaque_columns
+
+    opaque = frozenset({("vc_t", "leaked")})
+    for sql in ("SELECT id FROM VC_T NATURAL JOIN other",
+                "SELECT id FROM vc_t NATURAL JOIN other"):
+        assert check_opaque_columns(sqlglot.parse_one(sql, read="oracle"),
+                                    opaque, "oracle") is not None, sql

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -1149,13 +1149,24 @@ def test_a_join_key_reads_the_column_without_being_a_column_node(sql, why):
     assert refusal.subject == "leaked"
 
 
-def test_a_join_on_an_ordinary_column_still_answers():
-    """The control. Without it the pair above is satisfied by refusing every join."""
+def test_a_join_that_cannot_touch_the_opaque_column_still_answers():
+    """The control, and it has to cover BOTH arms: the pair above is satisfied by refusing every
+    join, and the NATURAL arm specifically by refusing every natural join on any source that has
+    an opaque column anywhere."""
     import sqlglot
 
     from mnemiq.sql.authz_guard import check_opaque_columns
 
-    clean = check_opaque_columns(
-        sqlglot.parse_one("SELECT vc_t.id FROM vc_t JOIN other USING (id)", read="oracle"),
-        frozenset({("vc_t", "leaked")}), "oracle")
-    assert clean is None
+    opaque = frozenset({("vc_t", "leaked")})
+    for sql in ("SELECT vc_t.id FROM vc_t JOIN other USING (id)",
+                # NATURAL over tables that do NOT include the opaque column's table.
+                "SELECT id FROM other NATURAL JOIN third"):
+        assert check_opaque_columns(sqlglot.parse_one(sql, read="oracle"),
+                                    opaque, "oracle") is None, sql
+
+    # ...and the message tells the caller something they can act on. "Answer without that
+    # column" is useless for a NATURAL join, which never names one.
+    natural = check_opaque_columns(
+        sqlglot.parse_one("SELECT id FROM vc_t NATURAL JOIN other", read="oracle"),
+        opaque, "oracle")
+    assert "explicit ON or USING" in natural.message

--- a/tests/test_oracle_adapter.py
+++ b/tests/test_oracle_adapter.py
@@ -1879,3 +1879,61 @@ def test_a_synonym_chain_is_followed_and_a_cycle_does_not_stop_it():
         con.commit()
         adapter._pool.release(con)
         adapter.close()
+
+
+def test_a_virtual_column_runs_a_udf_the_statement_never_names():
+    """M100, end to end. `SELECT id, leaked FROM vc_t` returned an SSN from a table the identity
+    was never granted, with no function named anywhere in the SQL: `check_unmodelled_calls`
+    walks call nodes and sees none, `called_names` reads the rendered text and sees none, and
+    `check_access` sees a column the snapshot lists and passes it.
+
+    The arithmetic virtual column beside it is the control. Refusing every virtual column would
+    close the route by removing a legitimate modelling feature, and would also pass this test.
+    """
+    from mnemiq.sql.decide import decide
+
+    adapter = OracleAdapter(dsn=DSN, user=USER, password=PASSWORD, schema=USER.upper())
+    con = adapter._pool.acquire()
+    cur = con.cursor()
+    drops = ("DROP TABLE vc_t", "DROP FUNCTION vc_udf", "DROP TABLE vc_sec")
+    try:
+        for ddl in drops:
+            with contextlib.suppress(Exception):
+                cur.execute(ddl)
+        cur.execute("CREATE TABLE vc_sec(ssn VARCHAR2(20))")
+        cur.execute("INSERT INTO vc_sec VALUES ('123-45-6789')")
+        cur.execute("CREATE OR REPLACE FUNCTION vc_udf(x NUMBER) RETURN VARCHAR2 DETERMINISTIC "
+                    "IS v VARCHAR2(20); BEGIN SELECT ssn INTO v FROM vc_sec WHERE ROWNUM = 1; "
+                    "RETURN v; END;")
+        cur.execute("CREATE TABLE vc_t(id NUMBER, qty NUMBER, price NUMBER, "
+                    "total AS (qty * price), leaked AS (vc_udf(id)))")
+        cur.execute("INSERT INTO vc_t(id, qty, price) VALUES (1, 2, 3)")
+        con.commit()
+
+        cur.execute("SELECT id, leaked FROM vc_t")
+        assert cur.fetchone()[1] == "123-45-6789", "no leak, so nothing below proves anything"
+
+        # The dictionary draws the distinction; this engine does not have to parse Oracle SQL.
+        stored = {c: expr for t, c, expr in adapter.virtual_columns() if t == "vc_t"}
+        assert stored["total"] == '"QTY"*"PRICE"'
+        assert "VC_UDF" in stored["leaked"]
+
+        visible = {"vc_t": {"id", "qty", "price", "total", "leaked"}}
+
+        def verdict(sql):
+            return decide(sql, visible, adapter=adapter, dialect="oracle", target="oracle")
+
+        for spelling in ("SELECT id, leaked FROM vc_t", "SELECT vc_t.leaked FROM vc_t"):
+            refused = verdict(spelling)
+            assert refused.code.value == "unresolvable_calls", spelling
+            assert refused.subject == "leaked"
+
+        for clean in ("SELECT id, total FROM vc_t", "SELECT id, qty FROM vc_t"):
+            assert not hasattr(verdict(clean), "code"), clean
+    finally:
+        for ddl in drops:
+            with contextlib.suppress(Exception):
+                cur.execute(ddl)
+        con.commit()
+        adapter._pool.release(con)
+        adapter.close()

--- a/tests/test_oracle_adapter.py
+++ b/tests/test_oracle_adapter.py
@@ -1937,3 +1937,58 @@ def test_a_virtual_column_runs_a_udf_the_statement_never_names():
         con.commit()
         adapter._pool.release(con)
         adapter.close()
+
+
+def test_a_write_cannot_store_what_a_virtual_column_computed():
+    """The M98 divergence, recreated for columns and caught by review before it shipped: the
+    read path got the guard and the write path did not.
+
+    A write is the worse place to lose it. `INSERT INTO notes SELECT id, leaked FROM vc_t`
+    stores the UDF's output -- an SSN, here -- into a table the caller may read forever, which
+    is the M30 shape. The ordinary insert beside it is the control: without one this passes by
+    refusing every write.
+    """
+    from mnemiq.authz.grants import GrantSet
+    from mnemiq.sql.decide_write import decide_write
+    from mnemiq.sql.policy import AccessPolicy
+
+    adapter = OracleAdapter(dsn=DSN, user=USER, password=PASSWORD,
+                            schema=USER.upper(), read_only=False)
+    con = adapter._pool.acquire()
+    cur = con.cursor()
+    drops = ("DROP TABLE vc_notes", "DROP TABLE vc_t", "DROP FUNCTION vc_udf",
+             "DROP TABLE vc_sec")
+    try:
+        for ddl in drops:
+            with contextlib.suppress(Exception):
+                cur.execute(ddl)
+        cur.execute("CREATE TABLE vc_sec(ssn VARCHAR2(20))")
+        cur.execute("INSERT INTO vc_sec VALUES ('123-45-6789')")
+        cur.execute("CREATE OR REPLACE FUNCTION vc_udf(x NUMBER) RETURN VARCHAR2 DETERMINISTIC "
+                    "IS v VARCHAR2(20); BEGIN SELECT ssn INTO v FROM vc_sec WHERE ROWNUM = 1; "
+                    "RETURN v; END;")
+        cur.execute("CREATE TABLE vc_t(id NUMBER, leaked AS (vc_udf(id)))")
+        cur.execute("INSERT INTO vc_t(id) VALUES (1)")
+        cur.execute("CREATE TABLE vc_notes(id NUMBER, note VARCHAR2(40))")
+        con.commit()
+
+        visible = {"vc_t": {"id", "leaked"}, "vc_notes": {"id", "note"}}
+        grants = GrantSet(frozenset({"vc_t", "vc_notes"}), writable=frozenset({"vc_notes"}))
+
+        def write(sql):
+            return decide_write(sql, visible, grants, policy=AccessPolicy(), adapter=adapter,
+                                dialect="oracle", target="oracle", writes_enabled=True)
+
+        refused = write("INSERT INTO vc_notes (id, note) SELECT id, leaked FROM vc_t")
+        assert refused.code.value == "unresolvable_calls", refused
+        assert refused.subject == "leaked"
+
+        ordinary = write("INSERT INTO vc_notes (id, note) SELECT id, 'ok' FROM vc_t")
+        assert not hasattr(ordinary, "code"), ordinary
+    finally:
+        for ddl in drops:
+            with contextlib.suppress(Exception):
+                cur.execute(ddl)
+        con.commit()
+        adapter._pool.release(con)
+        adapter.close()

--- a/tests/test_sql_authz_guard.py
+++ b/tests/test_sql_authz_guard.py
@@ -453,3 +453,58 @@ def test_one_code_two_answers_about_whether_to_try_again():
         assert refusal.repairable is False, inventory
         assert "No query can be decided against this source." in refusal.message, inventory
         assert "Try again." not in refusal.message, inventory
+
+
+@pytest.mark.parametrize("sql, code", [
+    ("SELECT c.id FROM claim c JOIN person p USING (ssn)", "unauthorized_column"),
+    ("SELECT c.id FROM claim c NATURAL JOIN person p", "unauthorized_column"),
+])
+def test_a_denied_column_cannot_be_used_as_a_join_key(sql, code):
+    """Pre-existing, and found only because the same hole had just been closed one guard over.
+
+    Measured with `denied={("claim","ssn")}`: `ON c.ssn = p.ssn` was refused and both of these
+    were APPROVED. A join key is not an `exp.Column` -- `USING` names it as a bare identifier
+    and NATURAL names nothing -- and the join reads the column all the same, leaking whether
+    rows match a row at a time.
+    """
+    from mnemiq.sql.cls import check_cls
+    from mnemiq.sql.policy import AccessPolicy
+
+    refusal = check_cls(sqlglot.parse_one(sql, read="duckdb"),
+                        AccessPolicy(denied={("claim", "ssn")}), "duckdb")
+    assert refusal is not None and refusal.code.value == code, sql
+
+
+def test_a_masked_column_cannot_be_joined_on_either():
+    """Joining on a masked column is a filter on it, which is what
+    `masked_column_in_predicate` exists to refuse -- the mask would silently change the answer.
+    """
+    from mnemiq.sql.cls import check_cls
+    from mnemiq.sql.policy import AccessPolicy
+
+    policy = AccessPolicy(masked={("claim", "ssn")})
+    joined = check_cls(sqlglot.parse_one(
+        "SELECT c.id FROM claim c JOIN person p USING (ssn)", read="duckdb"), policy, "duckdb")
+    assert joined.code.value == "masked_column_in_predicate"
+
+    # ...and a bare projection of the same column is still fine, which is the whole point of
+    # masking rather than denying it.
+    assert check_cls(sqlglot.parse_one("SELECT ssn FROM claim", read="duckdb"),
+                     policy, "duckdb") is None
+
+
+def test_an_ordinary_join_key_is_untouched():
+    """The control, and it covers BOTH arms: the tests above are satisfied by refusing every
+    join, and the NATURAL arm specifically by refusing every natural join whatever the policy
+    covers."""
+    from mnemiq.sql.cls import check_cls
+    from mnemiq.sql.policy import AccessPolicy
+
+    policy = AccessPolicy(denied={("claim", "ssn")})
+    assert check_cls(
+        sqlglot.parse_one("SELECT c.id FROM claim c JOIN person p USING (id)", read="duckdb"),
+        policy, "duckdb") is None
+    # A NATURAL join between tables the policy says nothing about is an ordinary join.
+    assert check_cls(
+        sqlglot.parse_one("SELECT p.id FROM person p NATURAL JOIN policy q", read="duckdb"),
+        policy, "duckdb") is None

--- a/tests/test_sql_authz_guard.py
+++ b/tests/test_sql_authz_guard.py
@@ -508,3 +508,19 @@ def test_an_ordinary_join_key_is_untouched():
     assert check_cls(
         sqlglot.parse_one("SELECT p.id FROM person p NATURAL JOIN policy q", read="duckdb"),
         policy, "duckdb") is None
+
+
+def test_a_join_key_that_is_denied_on_one_table_and_masked_on_another_is_not_a_coin_flip():
+    """Asking deny and mask per table inside one loop over a SET made the verdict depend on
+    iteration order: the repairable `masked_column_in_predicate` in some processes and the
+    unrepairable `unauthorized_column` in others, for the same query.
+
+    Deny is checked across every candidate first, which is the order the column loop already
+    used -- and the stricter of the two is the right answer when both apply.
+    """
+    from mnemiq.sql.cls import check_cls
+    from mnemiq.sql.policy import AccessPolicy
+
+    policy = AccessPolicy(denied={("claim", "ssn")}, masked={("person", "ssn")})
+    ast = sqlglot.parse_one("SELECT c.id FROM claim c JOIN person p USING (ssn)", read="duckdb")
+    assert check_cls(ast, policy, "duckdb").code.value == "unauthorized_column"


### PR DESCRIPTION
A virtual column runs its stored expression on read, so the statement never
names the call. Measured on the live Oracle:

```
CREATE TABLE vc_t(id NUMBER, total AS (qty*price), leaked AS (vc_udf(id)))
SELECT id, leaked FROM vc_t   →   (1, '123-45-6789')
```

An SSN from a table the identity was never granted. `check_unmodelled_calls`
walks call nodes and sees none; `called_names` reads the rendered text and sees
none; `check_access` sees a column the snapshot lists and passes it.

Third shape of this after `count(*)` reaching a macro named `count_star` and
`SELECT id + 1` reaching one named `+`. Each time the answer was to stop
enumerating shapes and ask the source a different question — and the source
answers this one directly. `ALL_TAB_COLS` marks the column virtual and stores its
expression: `"QTY"*"PRICE"` against `"APPUSER"."VC_UDF"("ID")`, in **0.5 ms**.

Only a column whose expression *names* something this source defines is refused.
Arithmetic calls nothing, and refusing every virtual column would cost a
legitimate modelling feature to close a route that needs a function to be a route
at all — `SELECT id, total FROM vc_t` still answers.

### Three more routes to the same column, found by review

- **The write path had lost the guard.** `INSERT INTO notes SELECT id, leaked
  FROM vc_t` came back `ApprovedWrite`, storing the SSN where a later plain
  SELECT returns it. That is M98's divergence recreated one guard over, in a file
  whose own comment warns against exactly that.
- **A join key is not an `exp.Column`.** `USING (leaked)` names it as a bare
  identifier and `NATURAL` names nothing; both evaluate the expression per row,
  and whether rows match leaks its value a bit at a time. The test one line above
  already refused `WHERE leaked = 'x'` — the same channel in different syntax.
- **The uppercase spelling passed.** The NATURAL arm compared table names raw
  while the adapter's keys are lowercase, so `FROM VC_T` — what an Oracle query
  naturally writes — went through while the lowercase form was refused.

### M103: the same shape, pre-existing, in `check_cls`

Asking *where else does a guard walk only `exp.Column`* produced a live bypass:

| policy | `ON c.ssn = p.ssn` | `USING (ssn)` | `NATURAL JOIN` |
|---|---|---|---|
| `denied` | refused | **approved** | **approved** |
| `masked` | refused (`WHERE`) | **approved** | — |

A denied column worked as a join key and a masked one was filterable through
one, disclosing its value a row at a time without ever appearing in a result set.
Fixed in the same change, with controls on both arms — without the NATURAL
control, refusing *every* natural join passed every test.

### Also

A deny/mask check per table inside a loop over a set made the refusal **code**
depend on hash order: `unauthorized_column` in some processes,
`masked_column_in_predicate` in others. Second hash-order defect I have written
in this area, both the same shape — a per-item loop deciding something that has
to be decided once over the whole set.

`1999 passed`; Oracle integration `58 passed, 7 skipped` live. Eleven mutations
fail across the two guards.