### PR TITLE
Two fail-opens in the virtual-column guard

### DIFF
--- a/src/mnemiq/adapters/base.py
+++ b/src/mnemiq/adapters/base.py
@@ -50,9 +50,12 @@ class SourceAdapter(Protocol):
     # omits it reports nothing and the decider learns nothing, which is where every adapter
     # shipped. The EXPRESSION comes back rather than a verdict: whether it is opaque depends on
     # this source's function inventory, and that judgement belongs in the decider. A failure
-    # RAISES, and `opaque_columns` reads a raise as "nothing known" rather than "none exist" --
-    # the one place in this family where the permissive reading is right, because `check_access`
-    # still stands over the same column. DuckDB needs none: a generated column whose expression
+    # RAISES, and `opaque_columns` turns that into None -- asked and could not answer -- which
+    # the guard REFUSES on. It read a raise as "none exist" for one commit, on the argument that
+    # `check_access` still stands over the same column; that is backwards, since `check_access`
+    # passes a column the snapshot lists and that is the whole reason the guard exists. Measured
+    # on that version: with the method raising, `SELECT leaked FROM vc_t` was approved.
+    # DuckDB needs none: a generated column whose expression
     # holds a subquery is refused at bind time, so a macro reachable there cannot read a table.
     def virtual_columns(self) -> list[tuple[str, str, str]]: ...
 

--- a/src/mnemiq/eval/criterion.py
+++ b/src/mnemiq/eval/criterion.py
@@ -131,7 +131,7 @@ def touched(ast: exp.Expression, policy: AccessPolicy, schema=None, dialect=None
         masked_cols.setdefault(obj.lower(), set()).add(col.lower())
     every_masked_name = {c for cols in masked_cols.values() for c in cols}
 
-    # Attribution is keyed on `column_tables` AND ON NOTHING ELSE. `_candidate_tables` must not be
+    # Attribution is keyed on `column_tables` AND ON NOTHING ELSE. `candidate_tables` must not be
     # the instrument: it is a fail-CLOSED helper built for REFUSING, and fail-closed is the wrong
     # shape for measuring -- refusing wants a superset of what might be touched, measuring wants
     # exactly what was. On `SELECT bogus.ssn FROM claim` it answers `{claim}`, a definite single

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -5,7 +5,7 @@ from sqlglot.dialects.dialect import Dialect
 
 from mnemiq.sql.functions import FunctionInventory, UnreadableCalls, called_names
 from mnemiq.sql.qualify import object_key
-from mnemiq.sql.scope import base_tables, column_tables
+from mnemiq.sql.scope import base_tables, candidate_tables, column_tables
 from mnemiq.sql.verdict import Refusal, RefusalCode
 
 
@@ -255,10 +255,27 @@ def check_opaque_columns(ast: exp.Expression, opaque, dialect: str | None = None
     REPAIRABLE, unlike the other arrivals at this code. Selecting a different column is a real
     rewrite, and the message names the one to avoid.
     """
+    if opaque is None:
+        # ASKED and could not answer. Every column could be computed by an expression nobody can
+        # read, and `check_access` passes a listed column, so there is nothing else looking.
+        # Retried rather than final: `decide` re-reads the catalogue on every attempt.
+        return Refusal(
+            code=RefusalCode.UNRESOLVABLE_CALLS,
+            message=(
+                "This source could not say which of its columns are computed, so this engine "
+                "cannot confirm what reading them executes. Try again."
+            ),
+            repairable_override=True,
+        )
     if not opaque:
         return None
-    referenced = {object_key(t): t.alias_or_name for t in base_tables(ast, dialect)}
-    by_alias = {alias: table for table, alias in referenced.items()}
+    referenced = {object_key(t) for t in base_tables(ast, dialect)}
+    # Scope-aware, like `check_access` and `check_cls`. A flat alias map keyed on the written
+    # case let `SELECT Q.leaked FROM vc_t Q` through while refusing the lowercase spelling, and
+    # one alias meaning two tables across UNION branches changed the verdict with branch order.
+    resolved = column_tables(ast, dialect)
+    local = {cte.alias_or_name for cte in ast.find_all(exp.CTE)}
+    aliased = local | {s.alias_or_name for s in ast.find_all(exp.Subquery) if s.alias_or_name}
 
     def refuse(name: str, why: str, repair: str) -> Refusal:
         return Refusal(
@@ -299,10 +316,7 @@ def check_opaque_columns(ast: exp.Expression, opaque, dialect: str | None = None
         name = column.name.lower()
         # A qualifier names the table directly; without one, any table in scope could own it,
         # and an opaque column anywhere in scope is one this statement may be reading.
-        if column.table:
-            owners = [by_alias.get(column.table.lower(), column.table.lower())]
-        else:
-            owners = list(referenced)
+        owners = candidate_tables(column, resolved, referenced, aliased)
         for table in owners:
             if (table.lower(), name) in opaque:
                 return refuse(name, "reading it", "Answer without that column.")

--- a/src/mnemiq/sql/cls.py
+++ b/src/mnemiq/sql/cls.py
@@ -4,33 +4,8 @@ from sqlglot import exp
 
 from mnemiq.sql.policy import AccessPolicy
 from mnemiq.sql.qualify import object_key
-from mnemiq.sql.scope import base_tables, column_tables
+from mnemiq.sql.scope import base_tables, candidate_tables, column_tables
 from mnemiq.sql.verdict import Refusal, RefusalCode
-
-
-def _candidate_tables(
-    column: exp.Column, resolved: dict[int, str] | None, referenced: set[str], aliased: set[str]
-) -> set[str]:
-    """The base table(s) a column could belong to.
-
-    Qualified -> the table its alias names IN ITS OWN SCOPE, which is why this takes a
-    per-node map rather than a name->table dictionary: one alias can mean two tables in one
-    statement, and a flat map kept whichever was seen last (Codex review, 2026-08-12).
-
-    Unqualified -> every referenced base table, fail-closed. An alias the resolver could not
-    place is treated the same way rather than as "no table": unresolvable is not permission.
-    """
-    if not column.table or resolved is None:
-        # `resolved is None` -> the scopes could not be read, so nothing here is known to be a
-        # local alias. Every referenced base table is a candidate; an unreadable statement is
-        # not an argument for permission.
-        return referenced
-    table = resolved.get(id(column))
-    if table is not None:
-        return {table}
-    # A qualifier naming a CTE or derived table owns no base column -- but only when we are
-    # sure that is what it is. Otherwise fall back to every table.
-    return set() if column.table in aliased else referenced
 
 
 def _is_bare_projection(column: exp.Column) -> bool:
@@ -103,7 +78,7 @@ def check_cls(ast: exp.Expression, policy: AccessPolicy,
                         )
 
     for column in ast.find_all(exp.Column):
-        cands = _candidate_tables(column, resolved, referenced, aliased)
+        cands = candidate_tables(column, resolved, referenced, aliased)
         name = column.name
         if any(policy.denies(t, name) for t in cands):
             return Refusal(

--- a/src/mnemiq/sql/functions.py
+++ b/src/mnemiq/sql/functions.py
@@ -299,7 +299,7 @@ def _builtins_from(adapter) -> tuple[frozenset[str] | None, bool]:
         return None, True
 
 
-def opaque_columns(adapter, inventory: FunctionInventory) -> frozenset[tuple[str, str]]:
+def opaque_columns(adapter, inventory: FunctionInventory) -> frozenset[tuple[str, str]] | None:
     """(table, column) pairs whose stored expression this engine cannot attribute.
 
     A virtual column is a route to user code with no call in the statement, which is the third
@@ -311,19 +311,26 @@ def opaque_columns(adapter, inventory: FunctionInventory) -> frozenset[tuple[str
     `"QTY"*"PRICE"` calls nothing -- and refusing every virtual column would cost a legitimate
     modelling feature to close a route that needs a function to be a route at all.
 
-    An adapter that cannot report virtual columns yields nothing, which is the state every
-    adapter shipped in, and an inventory that is not `certain` yields every virtual column,
-    because then no name in an expression can be cleared.
+    Three answers, not two. An adapter that cannot report virtual columns yields an empty set,
+    which is the state every adapter shipped in. One that was ASKED and could not answer yields
+    **None**, and the guard refuses on it.
+
+    The first version returned an empty set for both, with a comment arguing that the permissive
+    reading was safe because `check_access` still stands. That is exactly backwards:
+    `check_access` sees a column the snapshot lists and passes it, which is the whole reason
+    this function exists. Measured on the first version -- with `virtual_columns()` raising,
+    `SELECT leaked FROM vc_t` was APPROVED, so a catalogue outage switched the control off. The
+    absence-and-failure collapse, argued for in a comment.
+
+    An inventory that is not `certain` yields every virtual column, because then no name in an
+    expression can be cleared.
     """
     if adapter is None or not hasattr(adapter, "virtual_columns"):
         return frozenset()
     try:
         columns = adapter.virtual_columns()
     except Exception:
-        # The same reading `inventory_from` gives a failed lookup: asked and could not answer is
-        # not "there are none". Every virtual column would be unknown, and none is known, so the
-        # honest answer is that the caller learns nothing here -- `check_access` still stands.
-        return frozenset()
+        return None
     if not inventory.certain:
         return frozenset((t, c) for t, c, _ in columns)
     return frozenset(

--- a/src/mnemiq/sql/scope.py
+++ b/src/mnemiq/sql/scope.py
@@ -283,3 +283,33 @@ def column_tables(ast: exp.Expression, dialect: str | None = None) -> dict[int, 
             if column.table == target.alias_or_name and id(column) not in out:
                 out[id(column)] = key
     return out
+
+
+def candidate_tables(
+    column: exp.Column, resolved: dict[int, str] | None, referenced: set[str], aliased: set[str]
+) -> set[str]:
+    """The base table(s) a column could belong to.
+
+    Lives here, with the other scope resolution, because three guards need the same answer:
+    `check_cls`, `check_access`'s column half, and `check_opaque_columns`. The last one had its
+    own flat alias map for one commit, keyed on the written case, and let `SELECT Q.leaked FROM
+    vc_t Q` through while refusing the lowercase spelling.
+
+    Qualified -> the table its alias names IN ITS OWN SCOPE, which is why this takes a
+    per-node map rather than a name->table dictionary: one alias can mean two tables in one
+    statement, and a flat map kept whichever was seen last (Codex review, 2026-08-12).
+
+    Unqualified -> every referenced base table, fail-closed. An alias the resolver could not
+    place is treated the same way rather than as "no table": unresolvable is not permission.
+    """
+    if not column.table or resolved is None:
+        # `resolved is None` -> the scopes could not be read, so nothing here is known to be a
+        # local alias. Every referenced base table is a candidate; an unreadable statement is
+        # not an argument for permission.
+        return referenced
+    table = resolved.get(id(column))
+    if table is not None:
+        return {table}
+    # A qualifier naming a CTE or derived table owns no base column -- but only when we are
+    # sure that is what it is. Otherwise fall back to every table.
+    return set() if column.table in aliased else referenced

--- a/src/mnemiq/sql/scope.py
+++ b/src/mnemiq/sql/scope.py
@@ -290,10 +290,12 @@ def candidate_tables(
 ) -> set[str]:
     """The base table(s) a column could belong to.
 
-    Lives here, with the other scope resolution, because three guards need the same answer:
-    `check_cls`, `check_access`'s column half, and `check_opaque_columns`. The last one had its
-    own flat alias map for one commit, keyed on the written case, and let `SELECT Q.leaked FROM
-    vc_t Q` through while refusing the lowercase spelling.
+    Lives here, with the other scope resolution, because two guards need the same answer --
+    `check_cls` and `check_opaque_columns` -- and the second had its own flat alias map for one
+    commit, keyed on the written case, which let `SELECT Q.leaked FROM vc_t Q` through while
+    refusing the lowercase spelling. `check_access` resolves columns from `column_tables`
+    directly rather than through this, which is a third copy of the same idea and worth knowing
+    about before a fourth is written.
 
     Qualified -> the table its alias names IN ITS OWN SCOPE, which is why this takes a
     per-node map rather than a name->table dictionary: one alias can mean two tables in one

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -1088,9 +1088,16 @@ def test_an_uncertain_inventory_makes_every_virtual_column_opaque():
     assert _opaque(virtual, [], certain=False) == frozenset({("t", "a"), ("t", "b")})
 
 
-def test_an_adapter_that_cannot_report_virtual_columns_changes_nothing():
-    """Every adapter shipped in that state, so it must stay the permissive one -- the same
-    posture `never_asked` takes for functions."""
+def test_never_asked_and_could_not_answer_are_different_answers():
+    """An adapter with no such method is permissive -- every adapter shipped that way. One that
+    was ASKED and RAISED is not, and the first version made them the same.
+
+    Measured on it: with `virtual_columns()` raising, `SELECT leaked FROM vc_t` was APPROVED, so
+    a catalogue outage switched the control off. The comment defending that said `check_access`
+    still stands, which is exactly backwards -- `check_access` passes a column the snapshot
+    lists, and that is the whole reason this function exists.
+    """
+    from mnemiq.sql.authz_guard import check_opaque_columns
     from mnemiq.sql.functions import FunctionInventory, opaque_columns
 
     class Silent:
@@ -1101,8 +1108,17 @@ def test_an_adapter_that_cannot_report_virtual_columns_changes_nothing():
             raise RuntimeError("no dictionary for you")
 
     assert opaque_columns(Silent(), FunctionInventory.of(["f"])) == frozenset()
-    assert opaque_columns(Angry(), FunctionInventory.of(["f"])) == frozenset()
     assert opaque_columns(None, FunctionInventory.of(["f"])) == frozenset()
+    assert opaque_columns(Angry(), FunctionInventory.of(["f"])) is None
+
+    # ...and the guard refuses on that, rather than treating it as "no opaque columns".
+    import sqlglot
+
+    refusal = check_opaque_columns(
+        sqlglot.parse_one("SELECT id FROM vc_t", read="oracle"), None, "oracle")
+    assert refusal is not None and refusal.code.value == "unresolvable_calls"
+    # Retried, because `decide` re-reads the catalogue on every attempt and this may be a blip.
+    assert refusal.repairable is True
 
 
 def test_the_guard_catches_the_column_qualified_or_not():
@@ -1185,3 +1201,23 @@ def test_the_natural_arm_matches_the_case_an_oracle_query_actually_writes():
                 "SELECT id FROM vc_t NATURAL JOIN other"):
         assert check_opaque_columns(sqlglot.parse_one(sql, read="oracle"),
                                     opaque, "oracle") is not None, sql
+
+
+@pytest.mark.parametrize("sql", [
+    "SELECT Q.leaked FROM vc_t Q",                                    # uppercase alias
+    "SELECT q.leaked FROM vc_t q",                                    # lowercase
+    "SELECT x.leaked FROM vc_t x UNION ALL SELECT x.id FROM other x",  # one alias, two tables
+])
+def test_an_alias_cannot_spell_its_way_past_the_guard(sql):
+    """The guard kept its own flat alias map keyed on the WRITTEN case while looking up
+    lowercase, so `SELECT Q.leaked FROM vc_t Q` was APPROVED and the lowercase spelling refused
+    -- and one alias meaning two tables across UNION branches changed the verdict with branch
+    order, which is the flat-map defect `column_tables` already existed to solve.
+    """
+    import sqlglot
+
+    from mnemiq.sql.authz_guard import check_opaque_columns
+
+    refusal = check_opaque_columns(sqlglot.parse_one(sql, read="oracle"),
+                                   frozenset({("vc_t", "leaked")}), "oracle")
+    assert refusal is not None, sql

--- a/tests/test_kill_criterion.py
+++ b/tests/test_kill_criterion.py
@@ -134,20 +134,19 @@ def test_an_UNATTRIBUTABLE_reference_is_unmeasurable_not_green():
 
 
 def test_candidate_tables_would_have_called_that_reference_attributable():
-    """Keying on `_candidate_tables` instead is the mutation the classifier rules out: it is
+    """Keying on `candidate_tables` instead is the mutation the classifier rules out: it is
     fail-CLOSED, built for refusing, and answers with a definite single object here."""
-    from mnemiq.sql.cls import _candidate_tables
-    from mnemiq.sql.scope import column_tables
+    from mnemiq.sql.scope import candidate_tables, column_tables
 
     ast = sqlglot.parse_one("SELECT bogus.ssn FROM claim", read="duckdb")
     column = next(c for c in ast.find_all(sqlglot.exp.Column) if c.name == "ssn")
     # called exactly as `check_cls` calls it, so this measures the real helper
-    cands = _candidate_tables(column, column_tables(ast), {"claim"}, set())
+    cands = candidate_tables(column, column_tables(ast), {"claim"}, set())
 
     assert cands == {"claim"}, "a definite single object -- which is why it looks attributable"
     assert column_tables(ast).get(id(column)) is None, "while the instrument records nothing"
     assert touched(ast, AccessPolicy(masked={("claim", "ssn")})).unattributable, (
-        "so keying on _candidate_tables would score this answer green, unmeasured")
+        "so keying on candidate_tables would score this answer green, unmeasured")
 
 
 def test_an_unmeasurable_answer_does_not_count_as_agreeing():


### PR DESCRIPTION
The stop-time review found both, and both are in the guard #26 added. Reproduced
before changing anything.

### A catalogue outage switched the control off

`opaque_columns` turned a failed `virtual_columns()` lookup into "no opaque
columns". Measured — with the method raising, `SELECT leaked FROM vc_t` was
**approved**.

The absence-and-failure collapse, and this time I had written a comment
defending it: that the permissive reading was safe *because `check_access` still
stands over the same column*. That is exactly backwards. `check_access` passes a
column the snapshot lists, which is the entire reason the guard exists.

Three answers now. No such method is permissive — where every adapter shipped.
Asked and raised is `None`, and the guard refuses on it, **retried** rather than
final, because `decide` re-reads the catalogue on every attempt.

### An alias could spell its way past

The guard kept its own flat alias map keyed on the **written** case while looking
up lowercase:

| query | before |
|---|---|
| `SELECT Q.leaked FROM vc_t Q` | **approved** |
| `SELECT q.leaked FROM vc_t q` | refused |
| `SELECT x.leaked FROM vc_t x UNION ALL SELECT x.id FROM other x` | **approved** |

One alias meaning two tables across UNION branches changed the verdict with
branch order — the flat-map defect `column_tables` already existed to solve, and
which `check_cls` already used.

`candidate_tables` moves to `scope.py` rather than being imported private from
`cls`. Three guards need that answer and the third having its own copy for one
commit is how this happened. `check_access` resolves from `column_tables`
directly, which is a third copy of the same idea — named in the docstring now,
before a fourth appears.

### Also

`base.py`'s Protocol comment still carried the argument for the permissive
reading, unchallenged, where a maintainer reads it first — a standing case for
reverting the fix.

`2002 passed`; Oracle integration `58 passed, 7 skipped` live. Three mutations
fail across the two paths.