### PR TITLE
Scan the commits a push adds, not only the tree it leaves (M97)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,13 @@ jobs:
       - run: bash scripts/test-pre-commit-hook.sh
         env:
           REPO_GUARD_NAME_PATTERNS: zzz_placeholder_matches_nothing_zzz
+      # Runs on the CI awk, which is the point: `--range` matches in awk, and its secret pattern
+      # needs interval expressions this machine has and mawk historically did not. The suite's
+      # cases that EXPECT a catch are what turn red there: on such a runner they get the
+      # control's exit 2 instead of 1 or 0. (The control case itself still passes -- it expects
+      # 2 and gets 2 -- so it is not the one that reports the problem.) No env: `--range` skips the
+      # name check by design, and the one case that uses `--all` sets the value inline.
+      - run: bash scripts/test-repo-guard-range.sh
 
   workbench:
     runs-on: ubuntu-latest

--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -14,7 +14,9 @@ on:
   # that fix look like the same subject and are not.
   #
   # Scope worth knowing: `--all` scans the checked-out tree, not the history behind it, so a
-  # secret added and then removed within a branch passes. See M97.
+  # secret added and then removed within a branch passes it. The step below closes that (M97) by
+  # scanning the commits a push adds; `--all` is kept beside it because the two see different
+  # things -- the tree as it stands, and everything that was ever introduced to reach it.
   push:
   pull_request:
 
@@ -27,10 +29,36 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Full history, though the scan reads only the tree (see the scope note above and
-          # M97). Kept because the fix for M97 needs the commits a push adds; today it fetches
-          # what nothing opens, which is precisely the mismatch that finding is about.
+          # Full history, and now something reads it: the range step below scans the commits a
+          # push adds. This fetch predated that step and existed for it -- for a while it fetched
+          # what nothing opened, which was precisely the mismatch M97 named.
           fetch-depth: 0
+      - name: Scan the commits this push ADDS, not just the tree it leaves
+        # M97: `--all` resolves to `git ls-files`, so a branch whose commit N adds a secret and
+        # commit N+1 removes it scans clean while the secret stays permanently readable in the
+        # pushed public history. This is what the `fetch-depth: 0` above was always for; until now
+        # it fetched what nothing opened, which is precisely the mismatch that finding names.
+        #
+        # `github.event.before` is all-zeros for a new branch and absent on a pull_request, so the
+        # fallback is every commit this ref adds to main. Broader than the push, never narrower --
+        # re-scanning a commit costs seconds and missing one cannot be taken back.
+        run: |
+          before="${{ github.event.before }}"
+          if [ -z "$before" ] || [ "$before" = "0000000000000000000000000000000000000000" ] \
+             || ! git cat-file -e "${before}^{commit}" 2>/dev/null; then
+            git fetch -q --no-tags origin main || true
+            range="origin/main..HEAD"
+          else
+            range="${before}..${{ github.sha }}"
+          fi
+          if [ -z "$(git rev-list --count "$range" 2>/dev/null || echo 0)" ] \
+             || [ "$(git rev-list --count "$range" 2>/dev/null || echo 0)" = "0" ]; then
+            echo "repo-guard: no new commits in $range -- nothing to scan."
+            exit 0
+          fi
+          echo "repo-guard: scanning $(git rev-list --count "$range") commit(s) in $range"
+          bash scripts/repo-guard.sh --range "$range"
+
       - name: Scan for secret shapes and machine home paths
         # Not proprietary names. That check is local-only and `--all` refuses to run it,
         # so this job needs no repository secret. Supplying one would leak the list by

--- a/scripts/repo-guard.sh
+++ b/scripts/repo-guard.sh
@@ -22,8 +22,8 @@
 # name they have never heard.
 #
 # So the list comes from REPO_GUARD_NAME_PATTERNS (environment, or the gitignored
-# .env), the check fails closed without it under --staged, and --all skips it and says
-# so. Install the hook or the local half never runs:
+# .env), the check fails closed without it under --staged, and the two CI modes -- --all and
+# --range -- skip it and say so. Install the hook or the local half never runs:
 #
 #     git config core.hooksPath .githooks
 set -uo pipefail

--- a/scripts/repo-guard.sh
+++ b/scripts/repo-guard.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # repo-guard: block commits that leak proprietary names, personal identity, or
-# secrets into this repo. Pre-commit hook (--staged) and CI (--all).
+# secrets into this repo. Pre-commit hook (--staged), CI over the tree (--all), and CI over
+# the commits a push adds (--range <rev-range>), which is the only one that sees a secret
+# added and removed within a branch (M97).
 #
 # THREE CHECKS, TWO AUDIENCES, and the split is deliberate.
 #
@@ -27,13 +29,41 @@
 set -uo pipefail
 
 MODE="${1:---staged}"
+RANGE="${2:-}"
+if [ "$MODE" = "--range" ] && [ -z "$RANGE" ]; then
+  echo "repo-guard: --range needs a rev-range, e.g. --range origin/main..HEAD" >&2
+  exit 2
+fi
 
 list_files() {
   if [ "$MODE" = "--all" ]; then
     git ls-files
+  elif [ "$MODE" = "--range" ]; then
+    :   # --range does not scan paths; see scan_range
   else
     git diff --cached --name-only --diff-filter=ACM
   fi
+}
+
+# `--range <rev-range>`: content INTRODUCED by the commits a push adds, which is the one thing
+# neither other mode can see. `--all` resolves to `git ls-files` -- the working TREE -- so a branch
+# whose commit N adds a secret and commit N+1 removes it scans clean, while the secret stays
+# permanently readable in the pushed public history, recoverable from the commit object long after
+# the tip looks fine (M97). `--staged` has the same blind spot from the other end: it sees each
+# commit as it is made, and a `--no-verify` or an amend-and-force skips it entirely.
+#
+# Reads ADDED LINES from a patch rather than each commit's whole tree. `git grep` over every
+# commit is O(commits x tree) and re-reads unchanged files thousands of times; a secret has to
+# arrive as an added line at some commit, so one pass over the patches sees every introduction and
+# nothing twice.
+#
+# The scanner excludes ITSELF by pathspec, for the reason the tree scan does: its patterns can
+# match their own spelling. Measured on mnemiq's history -- 1,399 commits -- the only file that
+# ever matched a secret shape was this one, 1,089 times, matching the literal `AF_SECRET_KEY` in
+# its own pattern list.
+scan_range() {
+  git log -p -U0 --no-color --diff-filter=AMR --format='__COMMIT__ %H' "$RANGE" \
+      -- . ":(exclude)$EXCLUDE_PATH"
 }
 
 # Resolve the blocklist: environment first (CI), then the gitignored .env.
@@ -66,7 +96,11 @@ fi
 NAMES_SETTING="$(printf '%s' "${REPO_GUARD_NAME_PATTERNS:-}" \
   | tr '[:upper:]' '[:lower:]' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
 CHECK_NAMES=1
-if [ "$MODE" = "--all" ]; then
+# `--range` joins `--all` here, and for the identical reason rather than by analogy: both run in
+# CI, whose log is public on a public repo, and enforcing the list there would LEAK it -- a
+# flagged word in a public log tells every reader that word is on the blocklist. A fork's pull
+# request could not receive the secret that carries it anyway.
+if [ "$MODE" = "--all" ] || [ "$MODE" = "--range" ]; then
   CHECK_NAMES=0
   echo "repo-guard: proprietary-name check SKIPPED -- it runs locally only, by design."
   echo "  Secret shapes and home paths are checked below; neither needs configuration."
@@ -95,9 +129,62 @@ HOME_PATH_PATTERNS='/(Users|home)/[A-Za-z0-9._-]+'
 
 # The scanner itself: free of name tokens now, but its secret-shape patterns
 # can match their own spelling. Never scan it.
-EXCLUDE_REGEX='^scripts/repo-guard\.sh$'
+EXCLUDE_PATH='scripts/repo-guard.sh'
+EXCLUDE_REGEX="^$(printf '%s' "$EXCLUDE_PATH" | sed 's/\./\\./g')\$"
 
 fail=0
+
+if [ "$MODE" = "--range" ]; then
+  # POSITIVE CONTROL, before trusting a clean result. The matching below runs in `awk`, and the
+  # secret pattern leans on interval expressions (`{16,}`) that not every awk implements -- BSD
+  # awk here, mawk on the CI runner. An awk that ignores intervals reports every range clean and
+  # says nothing, which is the failure mode this whole finding is about: a scanner that passes
+  # because it cannot see. So prove the engine matches a known sample and REFUSE if it cannot,
+  # rather than emit a green tick a reader would trust.
+  control='+KEY = "sk-abcdefghijklmnopqrstuvwx"'
+  if ! printf '%s\n' "$control" \
+       | awk -v secret="$SECRET_PATTERNS" '/^\+/ { if (substr($0,2) ~ secret) found=1 }
+                                           END { exit found ? 0 : 1 }'; then
+    echo "repo-guard: BLOCKED [instrument]: this awk does not match the secret pattern" >&2
+    echo "  (interval expressions such as {16,} are the usual cause). A scanner that cannot" >&2
+    echo "  detect its own positive control must not report a range clean." >&2
+    exit 2
+  fi
+
+  # ONE awk pass, not a shell loop. The first version ran two `grep`s per added line through a
+  # `printf` pipe -- two process spawns per line -- and measured 45s for 50 commits and 293s for
+  # 300, about a second each. A CI step that costs a second per commit is one somebody narrows
+  # later for speed, which is how the tree-only scan got here. This is the same matching in one
+  # process.
+  #
+  # The matched TEXT is never printed: this mode runs in CI, whose log is public on a public repo,
+  # so the shape and its location are the finding and the value is not.
+  # git's own failure must not read as "nothing found". Sending stderr to /dev/null and taking
+  # the empty output made an unresolvable range -- a typo, a missing object, a shallow clone --
+  # exit 0 and report the push clean. CI builds this range from `github.event.before`, which is
+  # exactly where an unresolvable ref comes from.
+  if ! range_raw="$(scan_range)"; then
+    echo "repo-guard: BLOCKED [instrument]: git could not read the range '$RANGE'." >&2
+    echo "  A range this scanner cannot walk is not a range with nothing in it." >&2
+    exit 2
+  fi
+  range_out="$(printf '%s\n' "$range_raw" | awk -v secret="$SECRET_PATTERNS" -v home="$HOME_PATH_PATTERNS" '
+    # 12, not 13. `__COMMIT__` is ten characters and the space is the eleventh, so 13 dropped
+    # the first hex digit and every SHA this printed was one an operator could not look up.
+    /^__COMMIT__ / { commit = substr($0, 12, 12); next }
+    /^\+\+\+ b\// { file = substr($0, 7); next }
+    /^\+/ {
+      body = substr($0, 2)
+      if (body ~ secret) print "BLOCKED [secret]: " file " introduced at " commit " (matched a secret pattern)"
+      else if (body ~ home) print "BLOCKED [home-path]: " file " introduced at " commit
+    }
+  ' | sort -u)"
+  if [ -n "$range_out" ]; then
+    printf '%s\n' "$range_out"
+    fail=1
+  fi
+fi
+
 while IFS= read -r f; do
   [ -z "$f" ] && continue
   if printf '%s\n' "$f" | grep -qE "$EXCLUDE_REGEX"; then continue; fi

--- a/scripts/test-repo-guard-range.sh
+++ b/scripts/test-repo-guard-range.sh
@@ -68,8 +68,10 @@ cd / || exit 1; rm -rf "$REPO"
 #    a shape, so its source matches it -- on mnemiq's real history that token in this scanner was
 #    1,089 of the only matches there were. Naming the token here would trip the guard on THIS
 #    file, which is the same lesson one level down.
+#    The edit has to ADD A MATCHING LINE. The first version appended `# touched`, which matches
+#    nothing, so the case passed with the exclusion removed and guarded it not at all.
 scratch
-sed -i.bak 's/^set -uo pipefail/set -uo pipefail\n# touched/' scripts/repo-guard.sh && rm -f scripts/repo-guard.sh.bak
+printf '# sample for the exclusion test: %s\n' "$FAKE_KEY" >> scripts/repo-guard.sh
 git add scripts/repo-guard.sh && git commit -qm "edit the guard"
 bash scripts/repo-guard.sh --range "$BASE..HEAD" >/dev/null 2>&1
 check "the scanner does not flag its own pattern list" 0 "$?"

--- a/scripts/test-repo-guard-range.sh
+++ b/scripts/test-repo-guard-range.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Exercises `scripts/repo-guard.sh --range`. Run it after touching that file:
+#
+#     bash scripts/test-repo-guard-range.sh
+#
+# `--range` exists because `--all` resolves to `git ls-files` -- the working TREE -- so a branch
+# whose commit N adds a secret and commit N+1 removes it scans clean while the secret stays
+# permanently readable in the pushed public history (M97). Every case below builds a throwaway
+# repo and asserts an EXIT CODE, because the mode that matters here is the one that reports
+# "clean": a scanner that passes for the wrong reason looks exactly like one that works.
+set -uo pipefail
+
+GUARD="$(cd "$(dirname "$0")" && pwd)/repo-guard.sh"
+
+# ASSEMBLED, never written literally, so this file does not trip the very scan it tests --
+# `scripts/test-pre-commit-hook.sh` builds its sample the same way and for the same reason. The
+# alternative is adding this path to the guard's exclusion list, which buys a blind spot in a
+# real file to avoid one in a fixture.
+FAKE_KEY="sk-$(printf 'a%.0s' $(seq 1 24))"
+FAKE_HOME="/$(printf 'U')sers/someone/data"
+pass=0; fail=0
+
+check() {  # check <label> <expected-exit> <actual-exit>
+  if [ "$2" = "$3" ]; then pass=$((pass+1)); printf '  ok   %-52s exit %s\n' "$1" "$3"
+  else fail=$((fail+1)); printf '  FAIL %-52s expected %s, got %s\n' "$1" "$2" "$3"; fi
+}
+
+# EVERY `cd` is guarded, and that is not defensive style. Unguarded, a failed `mktemp -d` or
+# `git init` leaves the shell in the operator's own checkout, where `git config user.name`
+# rewrites their identity and the case commits land on their branch -- including `leak.py`, which
+# carries a working key shape. A test for a secret scanner must not be able to commit a secret.
+scratch() {  # a repo with the guard in it, one clean commit, and $BASE set
+  REPO="$(mktemp -d)" || exit 1
+  git init -q "$REPO" || exit 1
+  cd "$REPO" || exit 1
+  git config user.email t@t; git config user.name t
+  mkdir -p scripts && cp "$GUARD" scripts/repo-guard.sh
+  git add scripts/repo-guard.sh && git commit -qm base
+  echo hello > app.py && git add app.py && git commit -qm clean
+  BASE="$(git rev-parse HEAD)"
+}
+
+# 1. THE FINDING ITSELF: added then removed, so the tree is clean and the history is not.
+scratch
+printf 'KEY = "%s"\n' "$FAKE_KEY" > leak.py && git add leak.py && git commit -qm oops
+git rm -q leak.py && git commit -qm removed
+bash scripts/repo-guard.sh --range "$BASE..HEAD" >/dev/null 2>&1
+check "add-then-remove is caught by --range" 1 "$?"
+REPO_GUARD_NAME_PATTERNS=off bash scripts/repo-guard.sh --all >/dev/null 2>&1
+check "...and --all still cannot see it (the reason --range exists)" 0 "$?"
+cd / || exit 1; rm -rf "$REPO"
+
+# 2. A range with nothing in it must PASS, or the check is just "always red".
+scratch
+echo "more" >> app.py && git add app.py && git commit -qm ordinary
+bash scripts/repo-guard.sh --range "$BASE..HEAD" >/dev/null 2>&1
+check "an ordinary range passes" 0 "$?"
+cd / || exit 1; rm -rf "$REPO"
+
+# 3. A home path introduced and kept.
+scratch
+printf 'P = "%s"\n' "$FAKE_HOME" > cfg.py && git add cfg.py && git commit -qm paths
+bash scripts/repo-guard.sh --range "$BASE..HEAD" >/dev/null 2>&1
+check "a machine home path is caught" 1 "$?"
+cd / || exit 1; rm -rf "$REPO"
+
+# 4. The scanner must not flag ITSELF. One of its own secret patterns is a bare token rather than
+#    a shape, so its source matches it -- on mnemiq's real history that token in this scanner was
+#    1,089 of the only matches there were. Naming the token here would trip the guard on THIS
+#    file, which is the same lesson one level down.
+scratch
+sed -i.bak 's/^set -uo pipefail/set -uo pipefail\n# touched/' scripts/repo-guard.sh && rm -f scripts/repo-guard.sh.bak
+git add scripts/repo-guard.sh && git commit -qm "edit the guard"
+bash scripts/repo-guard.sh --range "$BASE..HEAD" >/dev/null 2>&1
+check "the scanner does not flag its own pattern list" 0 "$?"
+cd / || exit 1; rm -rf "$REPO"
+
+# 5. No range is a usage error, not a silent pass.
+scratch
+bash scripts/repo-guard.sh --range >/dev/null 2>&1
+check "--range with no rev-range refuses" 2 "$?"
+
+# 6. THE INSTRUMENT CHECK. An awk without interval expressions matches nothing and would report
+#    every range clean; the guard must refuse instead. Simulated by blinding the pattern.
+# The replacement must not itself be a key shape -- the first one was `sk-` plus twenty
+# alphanumerics, which is precisely what the pattern it replaced matches, and the guard blocked
+# this file for containing it.
+sed 's/sk-\[A-Za-z0-9\]{16,}/__no_such_pattern__/' scripts/repo-guard.sh > scripts/blind.sh
+bash scripts/blind.sh --range "$BASE..HEAD" >/dev/null 2>&1
+check "a matcher that fails its own control refuses" 2 "$?"
+cd / || exit 1; rm -rf "$REPO"
+
+# 7. A range git cannot resolve must REFUSE, not report clean. `scan_range` sent stderr to
+#    /dev/null and took the empty output as "nothing found", so a typo'd or missing ref exited 0 --
+#    and CI builds the range from `github.event.before`, which is where an unresolvable ref comes
+#    from.
+scratch
+bash scripts/repo-guard.sh --range "nosuchref..alsonosuch" >/dev/null 2>&1
+check "an unresolvable range refuses rather than passing" 2 "$?"
+
+# 8. The reported SHA must be one an operator can look up. It was read from the wrong offset and
+#    every hash printed was missing its first hex digit.
+printf 'K = "%s"\n' "$FAKE_KEY" > leak.py && git add leak.py && git commit -qm oops
+real="$(git rev-parse HEAD)"
+reported="$(bash scripts/repo-guard.sh --range "$BASE..HEAD" 2>&1 \
+            | grep -oE 'introduced at [0-9a-f]{12}' | head -1 | awk '{print $3}')"
+if [ "$reported" = "${real:0:12}" ]; then
+  pass=$((pass+1)); printf '  ok   %-52s %s\n' "the reported commit is the real one" "$reported"
+else
+  fail=$((fail+1)); printf '  FAIL %-52s got %s, want %s\n' "the reported commit is the real one" "$reported" "${real:0:12}"
+fi
+cd / || exit 1; rm -rf "$REPO"
+
+echo
+if [ "$fail" -ne 0 ]; then echo "repo-guard --range: $fail failed, $pass passed"; exit 1; fi
+echo "repo-guard --range: $pass cases behave as intended"


### PR DESCRIPTION
`--all` resolves to `git ls-files` — the working **tree** — so a branch whose
commit N adds a secret and commit N+1 removes it scans clean, while the secret
stays permanently readable in the pushed public history. `--staged` has the same
blind spot from the other end: `--no-verify` or an amend skips it.

This is what the workflow's `fetch-depth: 0` was always for. Until now it fetched
what nothing opened, which is precisely the mismatch M97 names.

### Measured before building

| | commits | real secrets | real home paths |
|---|---|---|---|
| mnemiq | 1,399 | **0** | **0** |
| beacon | 317 | **0** | **0** |

Every hit was the scanner matching a bare token from its own pattern list (1,089
times) or the placeholder `/Users/user` in four benchmark scripts. **Nothing has
leaked** — the gap was latent, which is why this is a guard fix and not an
incident.

### How `--range` works

It reads **added lines** from a patch rather than each commit's whole tree. A
secret has to arrive as an added line somewhere, so one pass sees every
introduction and nothing twice. `git grep` per commit re-reads unchanged files
thousands of times.

The first version spawned two `grep`s per added line: **45s for 50 commits, 293s
for 300**. One `awk` pass is **1s for 300**. A CI step costing a second per commit
is one somebody narrows later for speed — which is how the tree-only scan got
here.

### Four fail-opens of my own, all found by review

- **The awk may not support interval expressions.** `{16,}` works here (BSD awk)
  and mawk historically did not; an awk that ignores them reports every range
  clean while saying nothing. The scan now proves its own matcher against a known
  sample and exits 2 rather than reporting clean.
- **git's stderr went to `/dev/null`** and the empty output read as "nothing
  found", so an unresolvable range exited **0** — and CI builds that range from
  `github.event.before`, exactly where a bad ref comes from.
- **The SHA was read from the wrong offset**, printing `af3ae83d5632` for
  `baf3ae83d563` — every reported hash missing its first hex digit, so an
  operator could not look up what was flagged.
- **The suite's `cd` was unguarded**, so a failed `mktemp -d` would have left the
  shell in the operator's own checkout, rewriting their git identity and
  committing `leak.py` — a working key shape — onto their branch. A test for a
  secret scanner must not be able to commit a secret. Verified by forcing the
  failure: identity, HEAD and tree untouched.

A fifth: the self-exclusion case appended `# touched`, which matches nothing, so
it passed with the exclusion removed. It appends a key-shaped sample now.

### The guard blocked this commit three times, correctly

The fixtures were a real key shape and a real home path; then my blinding string
was itself `sk-` plus twenty alphanumerics; then a comment named one of the
guard's own tokens. Samples are assembled at runtime, as the sibling suite
already did — excluding this file would have bought a blind spot in a real file
to avoid one in a fixture.

Nine cases, exit codes asserted, wired into `ci.yml` so they run on **the CI awk**
— the half that matters, since this machine's awk is not the one that fails open.