### PR TITLE
A synonym over a database link is a route this walk cannot follow

### DIFF
--- a/src/mnemiq/adapters/oracle.py
+++ b/src/mnemiq/adapters/oracle.py
@@ -828,7 +828,7 @@ class OracleAdapter:
             # honest label on an answer, and the alternative is handing back an ungranted SSN.
             # Narrowing it means separating "must refuse a call" from "is evidence this source
             # defines functions", which is a third category `FunctionInventory` does not model
-            # -- filed rather than built here, so this diff stays the security fix.
+            # -- M104, filed rather than built here so this stays the security fix.
             #
             # `may_shadow_a_builtin` IS inert here (`binder_prefers_builtins`), so no coarse
             # whole-source refusal follows from a wider `names`.

--- a/src/mnemiq/adapters/oracle.py
+++ b/src/mnemiq/adapters/oracle.py
@@ -750,7 +750,9 @@ class OracleAdapter:
         116 ms even restricted to this schema, since each iteration rejoins a 7,869-row view with
         no useful access path. Reading that view once is 23.8 ms, and `user_functions` as a
         whole -- these reads, the walks, and two other dictionary queries through `_rows` --
-        settles around 40 ms against DuckDB's 13, on this container's 7,869 synonyms.
+        settles around 40 ms against DuckDB's 13, on this container's 7,869 synonyms. Selecting
+        `db_link` alongside is free: 53.8 ms median against 52.1 reverted, over 15 runs on the
+        same 7,869 rows, which is inside the spread of either.
 
         The WALK is linear in the graph and no longer the thing to worry about: the first
         version stored a reachable set per alias and was quadratic, measured on a synthetic
@@ -787,27 +789,45 @@ class OracleAdapter:
         ORA-32044 from the recursive query, so a cycle is a real shape; a depth cap on top of
         `seen` adds nothing to termination and silently drops a chain longer than the cap.
 
-        What this still does not reach is a synonym over a DB-LINK object: it has no local
-        `all_objects` row, so no walk from here can tell whether it ends at a function.
+        A synonym over a DB-LINK object has no local `all_objects` row, so no walk from here
+        can tell whether it ends at a function -- and it is REPORTED for exactly that reason
+        rather than dropped. Skipping it was a measured fail-open (M102): a call through such
+        an alias returned an ungranted SSN and `decide` approved the statement.
         """
         edges: dict[tuple[str, str], tuple[str, str]] = {}
-        for owner, name, target_owner, target_name in self._rows(
+        over_a_link: set[tuple[str, str]] = set()
+        for owner, name, target_owner, target_name, db_link in self._rows(
             "SELECT lower(s.owner), lower(s.synonym_name), "
-            "       lower(s.table_owner), lower(s.table_name) FROM all_synonyms s"
+            "       lower(s.table_owner), lower(s.table_name), s.db_link FROM all_synonyms s"
         ):
-            # A NULL target owner is real -- an unqualified DB-link synonym has one -- and it
-            # used to reach `sorted()` and raise TypeError, which `inventory_from` turns into
-            # `unavailable` and the guard turns into refusing EVERY statement on the source. One
-            # such synonym anywhere in the dictionary would have stopped the whole deployment.
-            # Skipped rather than resolved, and that trades an outage for a FAIL-OPEN (M102):
-            # Oracle resolves a call through such a synonym to the remote function, and an alias
-            # absent from `names` is cleared. Bounded by the same allowlist as everything else --
-            # only an alias sqlglot MODELS gets that far -- and there is no local answer, since a
-            # DB-link target has no `all_objects` row to resolve against.
+            # A DB-LINK target cannot be resolved from here at all, so the alias is assumed to
+            # reach a function rather than dropped (M102). Dropping it was a MEASURED fail-open:
+            # `CREATE SYNONYM add_days FOR m102_udf@zz_loop` over a function reading an
+            # ungranted table, `SELECT add_days(1)` returned the SSN through the link, and
+            # `decide` APPROVED `SELECT add_days(1) FROM m102_claim` because the alias was
+            # missing from `names`.
+            #
+            # BOTH remote shapes are wrong to follow, which is why this branches on the link and
+            # not on the NULL owner it used to test. `ADD_DAYS -> (None, M102_UDF, ZZ_LOOP)` is
+            # the unqualified one and has no owner to join on; `ZZ_LINK_SYN2 -> (APPUSER,
+            # WEST_F, ZZ_LOOP)` names an owner, and joining on it resolves against the LOCAL
+            # `appuser.west_f`, a different object in a different database -- right by accident
+            # when a local function shares the name, fail-open when none does.
+            #
+            # The cost is a refusal for any query spelling such an alias, and only such a query:
+            # `may_shadow_a_builtin` is already inert here (`binder_prefers_builtins`), so no
+            # coarse whole-source refusal follows from a wider `names`.
+            if db_link is not None:
+                over_a_link.add((owner, name))
+                continue
+            # Defensive, and no longer the DB-link case above. A NULL here used to reach
+            # `sorted()` and raise TypeError, which `inventory_from` turns into `unavailable`
+            # and the guard turns into refusing EVERY statement on the source -- one such row
+            # anywhere in the dictionary would have stopped the whole deployment.
             if target_owner is None or target_name is None:
                 continue
             edges[(owner, name)] = (target_owner, target_name)
-        if not edges:
+        if not edges and not over_a_link:
             return set()
         oracle_owned = {
             r[0] for r in self._rows(
@@ -851,8 +871,8 @@ class OracleAdapter:
             {owner for owner, _ in mine_reaches}
             | {owner for owner, _ in edges.values() if owner not in oracle_owned}
         )
-        if not owners:
-            return set()
+        # No early-out on an empty `owners`: the chunked loop below simply does not run, and
+        # the link aliases still have to be reported without any `all_objects` read at all.
         # Chunked, because an Oracle IN list is capped at 1,000 items (ORA-01795) and this one
         # grows with every non-Oracle owner any synonym targets -- a schema-per-tenant instance
         # passes that mark. 900 leaves room without needing a second measurement.
@@ -870,24 +890,34 @@ class OracleAdapter:
                     **binds,
                 )
             )
-        if not functions:
-            return set()
-
         # BACKWARDS from the functions, instead of forwards from every alias. An earlier version
         # stored a reachable set per candidate and was quadratic: measured on a synthetic
         # chain, 3.6 ms at 200 synonyms, 63.2 at 800 and 239.3 at 1,600, which is the wrong shape
         # for the dictionaries M101 is about. Each node is visited once here.
-        reaches_any = spread(functions & nodes, backwards)
+        #
+        # A link alias seeds the walk as ITSELF, since there is no local node standing for its
+        # target: unprovable, therefore assumed to reach a function. `via_public_link` is the
+        # same assumption one hop earlier -- `a -> b` where this schema holds no `b` and the
+        # PUBLIC `b` is a link alias, which the `forward`/`backwards` fallback below cannot
+        # carry because a link alias contributes no edge to follow.
+        unprovable = over_a_link | {at for at in nodes if ("public", at[1]) in over_a_link}
+        reaches_any = spread((functions & nodes) | unprovable, backwards)
         # PUBLIC aliases count only where the chain ends outside Oracle's own schemas, so that
-        # question is asked of its own smaller target set rather than filtered afterwards.
-        reaches_free = spread({f for f in functions & nodes if f[0] not in oracle_owned},
-                              backwards)
+        # question is asked of its own smaller target set rather than filtered afterwards. A
+        # link alias counts for this arm too: a remote target cannot sit in an Oracle-maintained
+        # schema of THIS database, which is the only thing the arm excludes.
+        reaches_free = spread(
+            {f for f in functions & nodes if f[0] not in oracle_owned} | unprovable, backwards)
 
+        # Keyed on the ALIAS rather than on its target, because a link alias has no target node
+        # to test. Equivalent for every other row: an alias reaches a function exactly when its
+        # target does, and a synonym cannot share owner-and-name with a function -- Oracle puts
+        # both in one namespace.
         return {
             name
-            for (owner, name), target in edges.items()
-            if (owner == mine and target in reaches_any)
-            or (owner == "public" and target in reaches_free)
+            for owner, name in set(edges) | over_a_link
+            if (owner == mine and (owner, name) in reaches_any)
+            or (owner == "public" and (owner, name) in reaches_free)
         }
 
     def virtual_columns(self) -> list[tuple[str, str, str]]:

--- a/src/mnemiq/adapters/oracle.py
+++ b/src/mnemiq/adapters/oracle.py
@@ -814,9 +814,24 @@ class OracleAdapter:
             # `appuser.west_f`, a different object in a different database -- right by accident
             # when a local function shares the name, fail-open when none does.
             #
-            # The cost is a refusal for any query spelling such an alias, and only such a query:
-            # `may_shadow_a_builtin` is already inert here (`binder_prefers_builtins`), so no
-            # coarse whole-source refusal follows from a wider `names`.
+            # THE COST IS NOT ONLY A REFUSAL ON QUERIES SPELLING THE ALIAS. An earlier version
+            # of this comment claimed that, reasoning that `calls_are_confirmable` is already
+            # false wherever a schema defines a function -- true, and irrelevant to the schema
+            # that defines NONE. Measured: a schema defining nothing, plus one
+            # `PUBLIC orders FOR orders@ERP_LINK` over a remote TABLE, gives
+            # `user_functions() == ['orders']` and flips `calls_are_confirmable` from True to
+            # False, so every answer carrying any call is labelled `completeness='unknown'`.
+            # A link to a table is the COMMON enterprise shape, and this is the same issue-#5
+            # downgrade the PUBLIC/Oracle-maintained filter below exists to avoid.
+            #
+            # Taken anyway, because the two costs are not comparable: the downgrade is an
+            # honest label on an answer, and the alternative is handing back an ungranted SSN.
+            # Narrowing it means separating "must refuse a call" from "is evidence this source
+            # defines functions", which is a third category `FunctionInventory` does not model
+            # -- filed rather than built here, so this diff stays the security fix.
+            #
+            # `may_shadow_a_builtin` IS inert here (`binder_prefers_builtins`), so no coarse
+            # whole-source refusal follows from a wider `names`.
             if db_link is not None:
                 over_a_link.add((owner, name))
                 continue
@@ -910,9 +925,18 @@ class OracleAdapter:
             {f for f in functions & nodes if f[0] not in oracle_owned} | unprovable, backwards)
 
         # Keyed on the ALIAS rather than on its target, because a link alias has no target node
-        # to test. Equivalent for every other row: an alias reaches a function exactly when its
-        # target does, and a synonym cannot share owner-and-name with a function -- Oracle puts
-        # both in one namespace.
+        # to test. NOT equivalent for every other row, which an earlier version of this comment
+        # claimed: `backwards` also carries the PUBLIC same-bare-name fallback, so an alias can
+        # land in `reaches_any` by a link its own target does not have. Measured on
+        # `[("app","d","sys","c"), ("public","d","sys","sys_udf")]` with `sys_udf` a function --
+        # target-keyed returns `set()`, alias-keyed returns `{"d"}`, because `app.d` collects
+        # the PUBLIC `d`'s edge even though Oracle would resolve `d` through the private synonym
+        # and never consult the PUBLIC one.
+        #
+        # Over-reporting, so fail-closed, and a 6,000-graph randomised comparison found 9
+        # divergences all in that direction. Kept because the alternative is special-casing the
+        # link aliases at the return, and a second code path for the shape this function most
+        # recently got wrong is the worse trade.
         return {
             name
             for owner, name in set(edges) | over_a_link

--- a/src/mnemiq/adapters/oracle.py
+++ b/src/mnemiq/adapters/oracle.py
@@ -814,21 +814,29 @@ class OracleAdapter:
             # `appuser.west_f`, a different object in a different database -- right by accident
             # when a local function shares the name, fail-open when none does.
             #
-            # WHAT REPORTING AN ALIAS COSTS, in the two places `names` is read:
+            # WHAT REPORTING AN ALIAS COSTS, in the three places a non-empty `names` is read:
             #
             #   the refusal -- `may_shadow_a_builtin` is inert on this adapter
-            #     (`binder_prefers_builtins`), so `called & names` is the only rule left, and
+            #     (`binder_prefers_builtins`), so `called & names` is the rule that fires, and
             #     `called` is a LEXICAL scan for an identifier before an open paren. So
             #     `SELECT * FROM orders` through `PUBLIC orders FOR orders@ERP_LINK` is still
             #     answered and only `orders(...)` is refused. A scan, not a parse: it
             #     over-collects on purpose, and `FROM customer AS c(id, name)` yields `c`.
             #
-            #   the label -- `calls_are_confirmable` is `not names`, so ONE alias downgrades
-            #     the whole source. Measured on that same `orders` row against a schema
-            #     defining nothing of its own: `user_functions() == ['orders']` and the flag
-            #     goes True -> False, `completeness='unknown'` on every answer carrying a call.
-            #     A link to a TABLE is the common enterprise shape and nothing local tells it
-            #     from a link to a function, so this is the issue-#5 blanket downgrade that the
+            #   the gate in front of it -- `check_unmodelled_calls` returns early while `names`
+            #     is EMPTY, so a first alias also switches on the arm behind that gate: a
+            #     statement the scan cannot read at all (`UnreadableCalls`) is now refused
+            #     whole, not just one whose text spells the alias. Fail-closed and arguably
+            #     right -- an unreadable statement against unknown functions cannot be cleared
+            #     -- but it is not bounded by the scan, and an earlier note here said it was.
+            #
+            #   the label -- `calls_are_confirmable` is `licensed and not names`, so where
+            #     `licensed` holds ONE alias downgrades the whole source. Measured on that same
+            #     `orders` row against a schema defining nothing of its own:
+            #     `user_functions() == ['orders']` and the flag goes True -> False,
+            #     `completeness='unknown'` on every answer carrying a call. A link to a TABLE is
+            #     the common enterprise shape and nothing local tells it from a link to a
+            #     function, so this is the issue-#5 blanket downgrade that the
             #     PUBLIC/Oracle-maintained filter below exists to avoid, by another route.
             #
             # The second is the one worth arguing about, and it is taken anyway: a downgraded

--- a/src/mnemiq/adapters/oracle.py
+++ b/src/mnemiq/adapters/oracle.py
@@ -814,30 +814,28 @@ class OracleAdapter:
             # `appuser.west_f`, a different object in a different database -- right by accident
             # when a local function shares the name, fail-open when none does.
             #
-            # THE COST IS NOT ONLY A REFUSAL ON STATEMENTS THAT SPELL THE ALIAS BEFORE AN OPEN
-            # PAREN -- which is the whole refusal, since `may_shadow_a_builtin` is inert here
-            # and the remaining rule intersects `names` with exactly that lexical scan. Reading
-            # the remote table by name is untouched: for the `orders` example a few lines down,
-            # `SELECT * FROM orders` is still answered and only `orders(...)` is refused. Said
-            # as a scan rather than as "a call" because it IS a scan, and over-collects on
-            # purpose -- `FROM customer AS c(id, name)` yields `c`. An earlier version
-            # of this comment claimed that, reasoning that `calls_are_confirmable` is already
-            # false wherever a schema defines a function -- true, and irrelevant to the schema
-            # that defines NONE. Measured: a schema defining nothing, plus one
-            # `PUBLIC orders FOR orders@ERP_LINK` over a remote TABLE, gives
-            # `user_functions() == ['orders']` and flips `calls_are_confirmable` from True to
-            # False, so every answer carrying any call is labelled `completeness='unknown'`.
-            # A link to a table is the COMMON enterprise shape, and this is the same issue-#5
-            # downgrade the PUBLIC/Oracle-maintained filter below exists to avoid.
+            # WHAT REPORTING AN ALIAS COSTS, in the two places `names` is read:
             #
-            # Taken anyway, because the two costs are not comparable: the downgrade is an
-            # honest label on an answer, and the alternative is handing back an ungranted SSN.
-            # Narrowing it means separating "must refuse a call" from "is evidence this source
-            # defines functions", which is a third category `FunctionInventory` does not model
-            # -- M104, filed rather than built here so this stays the security fix.
+            #   the refusal -- `may_shadow_a_builtin` is inert on this adapter
+            #     (`binder_prefers_builtins`), so `called & names` is the only rule left, and
+            #     `called` is a LEXICAL scan for an identifier before an open paren. So
+            #     `SELECT * FROM orders` through `PUBLIC orders FOR orders@ERP_LINK` is still
+            #     answered and only `orders(...)` is refused. A scan, not a parse: it
+            #     over-collects on purpose, and `FROM customer AS c(id, name)` yields `c`.
             #
-            # That inertness is `binder_prefers_builtins`, and it is why no coarse
-            # whole-source refusal follows from a wider `names`.
+            #   the label -- `calls_are_confirmable` is `not names`, so ONE alias downgrades
+            #     the whole source. Measured on that same `orders` row against a schema
+            #     defining nothing of its own: `user_functions() == ['orders']` and the flag
+            #     goes True -> False, `completeness='unknown'` on every answer carrying a call.
+            #     A link to a TABLE is the common enterprise shape and nothing local tells it
+            #     from a link to a function, so this is the issue-#5 blanket downgrade that the
+            #     PUBLIC/Oracle-maintained filter below exists to avoid, by another route.
+            #
+            # The second is the one worth arguing about, and it is taken anyway: a downgraded
+            # label is honest about an answer, and the alternative is handing back an ungranted
+            # SSN. Narrowing it means a name that must refuse without being evidence the source
+            # defines functions -- a third category `FunctionInventory` does not model, filed
+            # as M104 so this stays the security fix.
             if db_link is not None:
                 over_a_link.add((owner, name))
                 continue

--- a/src/mnemiq/adapters/oracle.py
+++ b/src/mnemiq/adapters/oracle.py
@@ -814,7 +814,13 @@ class OracleAdapter:
             # `appuser.west_f`, a different object in a different database -- right by accident
             # when a local function shares the name, fail-open when none does.
             #
-            # THE COST IS NOT ONLY A REFUSAL ON QUERIES SPELLING THE ALIAS. An earlier version
+            # THE COST IS NOT ONLY A REFUSAL ON STATEMENTS THAT SPELL THE ALIAS BEFORE AN OPEN
+            # PAREN -- which is the whole refusal, since `may_shadow_a_builtin` is inert here
+            # and the remaining rule intersects `names` with exactly that lexical scan. Reading
+            # the remote table by name is untouched: for the `orders` example a few lines down,
+            # `SELECT * FROM orders` is still answered and only `orders(...)` is refused. Said
+            # as a scan rather than as "a call" because it IS a scan, and over-collects on
+            # purpose -- `FROM customer AS c(id, name)` yields `c`. An earlier version
             # of this comment claimed that, reasoning that `calls_are_confirmable` is already
             # false wherever a schema defines a function -- true, and irrelevant to the schema
             # that defines NONE. Measured: a schema defining nothing, plus one
@@ -830,7 +836,7 @@ class OracleAdapter:
             # defines functions", which is a third category `FunctionInventory` does not model
             # -- M104, filed rather than built here so this stays the security fix.
             #
-            # `may_shadow_a_builtin` IS inert here (`binder_prefers_builtins`), so no coarse
+            # That inertness is `binder_prefers_builtins`, and it is why no coarse
             # whole-source refusal follows from a wider `names`.
             if db_link is not None:
                 over_a_link.add((owner, name))

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -170,15 +170,17 @@ def check_unmodelled_calls(
     allowlist alone, which is where it started.
 
     **WHICH SOURCES THAT ACTUALLY COVERS, because the paragraphs above read as if it were all of
-    them.** Only an adapter implementing `user_functions` is asked, and today that is the DuckDB
-    family alone -- `resolve.py` hands out one other live adapter, `OracleAdapter`, which
-    implements neither method and therefore gets `never_asked` and the bare allowlist. So an
-    Oracle schema function named `median` still passes here, exactly as every source did before
-    the inventory existed. Nothing regressed; one adapter moved and the rest did not, and an
-    asymmetry nobody wrote down is one a reader assumes away (M99). The Oracle exposure itself
-    is older and filed as deployment preconditions M66 and M71, which `adapters/oracle.py`
-    documents at length; closing it wants Oracle-side catalogue discovery, not a fail-closed
-    default here, which would refuse every call-bearing query on the adapters that cannot answer.
+    them.** Only an adapter implementing `user_functions` is asked. When this paragraph was
+    written that was the DuckDB family alone, and it named `OracleAdapter` as the live adapter
+    implementing neither method, so an Oracle schema function called `median` passed here
+    exactly as every source did before the inventory existed (M99). **That stopped being true
+    at `ce4e16a`**: Oracle answers `user_functions` now, and `virtual_columns` too, so every
+    `names`-driven rule below applies to it -- and since `binder_prefers_builtins` is True
+    there, `called & names` is the arm that fires rather than the coarse shadow rule. An
+    adapter still implementing neither gets `never_asked` and the bare allowlist, which remains
+    the reason this is not fail-closed by default: that would refuse every call-bearing query
+    on the adapters that cannot answer. The older Oracle exposure is filed as deployment
+    preconditions M66 and M71, which `adapters/oracle.py` documents at length.
     """
     for call in ast.find_all(exp.Anonymous):
         name = str(call.this)

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -170,17 +170,26 @@ def check_unmodelled_calls(
     allowlist alone, which is where it started.
 
     **WHICH SOURCES THAT ACTUALLY COVERS, because the paragraphs above read as if it were all of
-    them.** Only an adapter implementing `user_functions` is asked. When this paragraph was
-    written that was the DuckDB family alone, and it named `OracleAdapter` as the live adapter
-    implementing neither method, so an Oracle schema function called `median` passed here
-    exactly as every source did before the inventory existed (M99). **That stopped being true
-    at `ce4e16a`**: Oracle answers `user_functions` now, and `virtual_columns` too, so every
-    `names`-driven rule below applies to it -- and since `binder_prefers_builtins` is True
-    there, `called & names` is the arm that fires rather than the coarse shadow rule. An
-    adapter still implementing neither gets `never_asked` and the bare allowlist, which remains
-    the reason this is not fail-closed by default: that would refuse every call-bearing query
-    on the adapters that cannot answer. The older Oracle exposure is filed as deployment
-    preconditions M66 and M71, which `adapters/oracle.py` documents at length.
+    them.** Only an adapter implementing `user_functions` is asked -- that method alone decides
+    `never_asked`; `virtual_columns` is a separate path, and an adapter missing it yields an
+    empty opaque set rather than landing here. When this paragraph was written the DuckDB
+    family was the only one asked, and it named `OracleAdapter` as the live adapter
+    implementing neither, so an Oracle schema function called `median` passed here exactly as
+    every source did before the inventory existed (M99).
+
+    **Oracle answers both now**, at different times: `user_functions` at `ce4e16a`,
+    `virtual_columns` three commits later at `77d24b0`. So every `names`-driven rule below
+    applies to it. `binder_prefers_builtins` is True there, which rules out the coarse shadow
+    arm and leaves two: `called & names`, and -- for any statement the scan cannot read at all
+    -- the `UnreadableCalls` refusal, which fires whatever the scan returns. `adapters/oracle.py`
+    records that second arm as the correction to a note of its own that framed the first as the
+    only one.
+
+    An adapter still implementing `user_functions` gets asked; one that does not gets
+    `never_asked` and the bare allowlist, which remains the reason this is not fail-closed by
+    default: that would refuse every call-bearing query on the adapters that cannot answer. The
+    older Oracle exposure is filed as deployment preconditions M66 and M71, which
+    `adapters/oracle.py` documents at length.
     """
     for call in ast.find_all(exp.Anonymous):
         name = str(call.this)

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -1034,8 +1034,10 @@ def test_a_synonym_over_a_db_link_is_reported_rather_than_dropped():
 
     A remote target cannot be resolved from here at all, so the alias is ASSUMED to reach a
     function. Dropping one that turns out to be a function costs the row; reporting one that
-    turns out to be a table costs a refusal on any query spelling it AND, on a schema that
-    defines nothing else, the source's whole completeness label -- which is M104, and which
+    turns out to be a table costs a refusal on a query CALLING it -- `SELECT * FROM orders`
+    still reads the remote table, since the refusal path scans for an identifier before an open
+    paren -- AND, on a schema that defines nothing else, the source's whole completeness
+    label, which is M104 and which
     `test_reporting_a_link_alias_downgrades_completeness_on_a_schema_that_defines_nothing`
     measures. An earlier version of this docstring claimed the refusal was the whole cost.
     """

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -1033,8 +1033,11 @@ def test_a_synonym_over_a_db_link_is_reported_rather_than_dropped():
     cross-dialect allowlist waves it through and only the inventory can catch it.
 
     A remote target cannot be resolved from here at all, so the alias is ASSUMED to reach a
-    function. Reporting a name that turns out to be a table costs one refusal on a query
-    spelling it; dropping one that turns out to be a function costs the row.
+    function. Dropping one that turns out to be a function costs the row; reporting one that
+    turns out to be a table costs a refusal on any query spelling it AND, on a schema that
+    defines nothing else, the source's whole completeness label -- which is M104, and which
+    `test_reporting_a_link_alias_downgrades_completeness_on_a_schema_that_defines_nothing`
+    measures. An earlier version of this docstring claimed the refusal was the whole cost.
     """
     assert _oracle_walk([("app", "add_days", None, "m102_udf", "DBL_LOOP")], []) == {"add_days"}
 

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -839,7 +839,12 @@ def _oracle_walk(synonyms, functions, oracle_owned=("sys",), schema="APP", asked
             # would silently pass a version that narrowed the read before walking it -- which is
             # the bug that stopped a chain at the first hop into another schema.
             assert "where" not in sql.lower(), "the synonym graph must be read unfiltered"
-            return list(synonyms)
+            # `db_link` is the fifth column and defaults to None, so every 4-tuple case above
+            # keeps its shape and only a DB-link case has to spell it. The 4-column slice is
+            # what the walk asked for before M102, and answering what was ASKED is what makes a
+            # revert of that fix fail the link tests on BEHAVIOUR rather than on unpacking.
+            padded = [tuple(r) + (None,) * (5 - len(r)) for r in synonyms]
+            return padded if "db_link" in sql else [r[:4] for r in padded]
         if "oracle_maintained" in sql:
             return [(o,) for o in oracle_owned]
         wanted = set(binds.values())
@@ -1014,6 +1019,81 @@ def test_a_synonym_with_no_target_owner_does_not_take_the_source_down():
     assert _oracle_walk(synonyms, [("app", "udf")]) == {"x"}
 
 
+def test_a_synonym_over_a_db_link_is_reported_rather_than_dropped():
+    """M102, the fail-open this closes, measured live before it was written.
+
+    `CREATE SYNONYM add_days FOR m102_udf@zz_loop` over a function reading an ungranted table:
+    `SELECT add_days(1)` returned `'123-45-6789'` through a loopback link and `decide` APPROVED
+    `SELECT add_days(1) FROM m102_claim`, because the walk dropped every row whose `table_owner`
+    was NULL and the alias never reached `names`. The register had this shape down as "not
+    reproducible here: 0 `db_link` synonyms out of 7,869", so it was documented rather than
+    measured; a loopback link into the same PDB reproduces it exactly.
+
+    `add_days` for the same reason the other synonym tests use it -- sqlglot models it, so the
+    cross-dialect allowlist waves it through and only the inventory can catch it.
+
+    A remote target cannot be resolved from here at all, so the alias is ASSUMED to reach a
+    function. Reporting a name that turns out to be a table costs one refusal on a query
+    spelling it; dropping one that turns out to be a function costs the row.
+    """
+    assert _oracle_walk([("app", "add_days", None, "m102_udf", "DBL_LOOP")], []) == {"add_days"}
+
+
+def test_a_QUALIFIED_db_link_synonym_is_not_resolved_against_the_local_object_of_that_name():
+    """The second remote shape, and why the branch tests the link and not the NULL owner.
+
+    Both were read off the container: `(None, 'WEST_F', 'ZZ_LOOP')` for `west_f@zz_loop` and
+    `('APPUSER', 'WEST_F', 'ZZ_LOOP')` for `appuser.west_f@zz_loop`. The second names an owner,
+    so the old code joined on it and answered from the LOCAL `app.west_f` -- a different object
+    in a different database. Right by accident whenever a local function shares the name, and
+    fail-open whenever none does, which is what this asserts: `functions` is empty here.
+    """
+    assert _oracle_walk([("app", "qual_syn", "app", "west_f", "DBL_LOOP")], []) == {"qual_syn"}
+
+
+def test_a_chain_ENDING_at_a_db_link_synonym_reports_every_hop():
+    """Oracle resolves `hop -> add_days -> m102_udf@zz_loop` at call time, so `hop(1)` runs the
+    remote function too. A link alias contributes no edge to follow, so it has to seed the
+    backward walk as ITSELF or every hop in front of it is lost with it."""
+    assert _oracle_walk([
+        ("app", "hop", "app", "add_days"),
+        ("app", "add_days", None, "m102_udf", "DBL_LOOP"),
+    ], []) == {"hop", "add_days"}
+
+
+def test_a_chain_reaching_a_PUBLIC_db_link_synonym_reports_both():
+    """`via_pub -> pub_link` where this schema holds no `pub_link` and the PUBLIC one is a link
+    alias. The `forward`/`backwards` PUBLIC fallback cannot carry that hop, because a link alias
+    contributes no edge for the fallback to find -- which is what `via_public_link` is for.
+
+    The PUBLIC arm normally excludes chains ending in Oracle's own schemas; a remote target
+    cannot be in one of THIS database's, so a link alias counts for it.
+    """
+    assert _oracle_walk([
+        ("app", "via_pub", "app", "pub_link"),
+        ("public", "pub_link", None, "remote_f", "DBL_LOOP"),
+    ], []) == {"via_pub", "pub_link"}
+
+
+def test_a_synonym_over_a_LOCAL_non_function_is_still_not_reported():
+    """The control. Without it every DB-link assertion above passes on a walk that reports every
+    synonym it sees, which is a different bug rather than a fix -- and it has to pass with the
+    fix REVERTED too, which is why the stub answers the four columns the old query asked for."""
+    assert _oracle_walk([("app", "tbl_syn", "app", "some_table")],
+                        [("app", "a_real_function")]) == set()
+
+
+def test_a_NULL_target_with_no_db_link_is_skipped_without_raising():
+    """The defensive arm the DB-link branch left behind. A NULL reaching `sorted()` raised
+    TypeError, which `inventory_from` turns into `unavailable` and the guard turns into refusing
+    EVERY statement on the source -- one such row anywhere in the dictionary, a whole deployment
+    stopped."""
+    assert _oracle_walk([
+        ("app", "odd", None, None),
+        ("app", "good", "app", "a_real_function"),
+    ], [("app", "a_real_function")]) == {"good"}
+
+
 def test_the_owner_read_is_chunked_under_oracles_in_list_cap():
     """An Oracle IN list is capped at 1,000 items (ORA-01795), and this one grows with every
     non-Oracle owner any synonym targets -- a schema-per-tenant instance passes that mark.
@@ -1031,7 +1111,12 @@ def test_the_owner_read_is_chunked_under_oracles_in_list_cap():
 
     def rows(sql, **binds):
         if "all_synonyms" in sql:
-            return list(synonyms)
+            # Padded to the walk's five columns, as in `_oracle_walk`; none of these 2,500
+            # rows is over a link, so the column is None throughout. Answering what the query
+            # ASKED for keeps this test out of the M102 revert control -- returning 5-tuples
+            # unconditionally made it fail on unpacking, which reads as collateral damage from
+            # a fix it has nothing to do with.
+            return [tuple(r) + (None,) if "db_link" in sql else tuple(r) for r in synonyms]
         if "oracle_maintained" in sql:
             return [("sys",)]
         reads.append(len(binds))

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -13,7 +13,7 @@ import duckdb
 import pytest
 
 from mnemiq.adapters.duckdb import DuckDBAdapter
-from mnemiq.sql.functions import FunctionInventory
+from mnemiq.sql.functions import FunctionInventory, calls_are_confirmable
 
 
 def test_an_empty_answer_is_not_a_failed_lookup():
@@ -1073,6 +1073,45 @@ def test_a_chain_reaching_a_PUBLIC_db_link_synonym_reports_both():
         ("app", "via_pub", "app", "pub_link"),
         ("public", "pub_link", None, "remote_f", "DBL_LOOP"),
     ], []) == {"via_pub", "pub_link"}
+
+
+def test_reporting_a_link_alias_downgrades_completeness_on_a_schema_that_defines_nothing():
+    """The COST of the M102 fix, pinned rather than described, because the comment describing
+    it was wrong twice.
+
+    `calls_are_confirmable` is `licensed and not inventory.names`, so any name at all makes it
+    false. The first note on the fix argued the cost was bounded to queries spelling the alias,
+    on the grounds that a schema defining a function is already downgraded -- true, and silent
+    about the schema that defines NONE, which is the case this measures. A link over a remote
+    TABLE is the common enterprise shape and produces a name here regardless, because nothing
+    local can tell a remote table from a remote function.
+
+    Same issue-#5 downgrade the PUBLIC/Oracle-maintained filter exists to avoid, accepted here
+    because the alternative is approving a call that returns an ungranted row.
+    """
+    names = _oracle_walk([("public", "orders", None, "orders", "ERP_LINK")], [])
+    assert names == {"orders"}, "a remote table is indistinguishable from a remote function"
+
+    downgraded = FunctionInventory(names=frozenset(names))
+    assert calls_are_confirmable(downgraded, in_view_body=False) is False
+    # The control: without the link alias this source certifies, so the flip is the alias's.
+    assert calls_are_confirmable(FunctionInventory(names=frozenset()), in_view_body=False) is True
+
+
+def test_keying_the_report_on_the_alias_over_reports_through_the_public_fallback():
+    """Keying the return on the ALIAS rather than its target is not equivalent, and the comment
+    that said it was has been corrected.
+
+    `backwards` carries the PUBLIC same-bare-name fallback, so `app.d` collects the PUBLIC `d`'s
+    edge to a function even though Oracle resolves `d` through the private synonym and never
+    consults the PUBLIC one. Target-keyed this was `set()`.
+
+    Asserted because it is OVER-reporting -- fail-closed -- and an assertion is what would catch
+    it turning into the other direction. Nothing here is over a link: the divergence is in the
+    keying, not in M102.
+    """
+    assert _oracle_walk([("app", "d", "sys", "c"), ("public", "d", "sys", "sys_udf")],
+                        [("sys", "sys_udf")]) == {"d"}
 
 
 def test_a_synonym_over_a_LOCAL_non_function_is_still_not_reported():

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -1034,9 +1034,10 @@ def test_a_synonym_over_a_db_link_is_reported_rather_than_dropped():
 
     A remote target cannot be resolved from here at all, so the alias is ASSUMED to reach a
     function. Dropping one that turns out to be a function costs the row; reporting one that
-    turns out to be a table costs a refusal on a query CALLING it -- `SELECT * FROM orders`
-    still reads the remote table, since the refusal path scans for an identifier before an open
-    paren -- AND, on a schema that defines nothing else, the source's whole completeness
+    turns out to be a table costs a refusal on any statement whose TEXT spells it before an
+    open paren -- `SELECT * FROM orders` is still answered, and the rule is a lexical scan
+    rather than a parse, so it over-collects on purpose -- AND, on a schema that defines
+    nothing else, the source's whole completeness
     label, which is M104 and which
     `test_reporting_a_link_alias_downgrades_completeness_on_a_schema_that_defines_nothing`
     measures. An earlier version of this docstring claimed the refusal was the whole cost.

--- a/tests/test_oracle_adapter.py
+++ b/tests/test_oracle_adapter.py
@@ -20,6 +20,15 @@ Run against the container the spike used:
       -e APP_USER=appuser -e APP_USER_PASSWORD=apppw gvenzl/oracle-free:23-slim-faststart
     MNEMIQ_ORACLE_TEST_DSN=127.0.0.1:1522/FREEPDB1 MNEMIQ_ORACLE_TEST_USER=appuser \\
       MNEMIQ_ORACLE_TEST_PASSWORD=apppw uv run pytest tests/test_oracle_adapter.py -m integration
+
+One test needs a privilege that container does not grant, and SKIPS with a reason rather than
+failing without it:
+
+    GRANT CREATE DATABASE LINK TO appuser;   -- as SYSTEM; for the M102 loopback-link test
+
+It is a separate line because it widens what APPUSER can do, which is the container's whole
+point of comparison for the access tests around it. The same assertions run database-free in
+`tests/test_oracle_nodb.py`, so skipping here does not leave the fail-open unguarded.
 """
 
 from __future__ import annotations
@@ -1985,6 +1994,86 @@ def test_a_write_cannot_store_what_a_virtual_column_computed():
 
         ordinary = write("INSERT INTO vc_notes (id, note) SELECT id, 'ok' FROM vc_t")
         assert not hasattr(ordinary, "code"), ordinary
+    finally:
+        for ddl in drops:
+            with contextlib.suppress(Exception):
+                cur.execute(ddl)
+        con.commit()
+        adapter._pool.release(con)
+        adapter.close()
+
+
+def test_a_synonym_over_a_db_link_is_a_route_to_a_udf_this_engine_cannot_resolve():
+    """M102 against a real link, which is how the fail-open was found rather than reasoned about.
+
+    The register row said the shape was "not reproducible here: the container holds 0 `db_link`
+    synonyms out of 7,869", so the behaviour was documented instead of measured. A LOOPBACK link
+    into the same PDB reproduces it exactly, and the measurement contradicted nothing but did
+    settle it: `SELECT add_days(1)` returned `'123-45-6789'` through the link, `add_days` was
+    absent from `user_functions()`, and `decide` APPROVED the statement.
+
+    `add_days` for the same reason the local synonym test uses it -- sqlglot models it, so the
+    cross-dialect allowlist waves it through and only the inventory can catch it. An alias
+    sqlglot does not know is refused as `exp.Anonymous` whatever the inventory holds, which is
+    how an earlier version of that test passed with its fix reverted.
+
+    `tests/test_oracle_nodb.py` carries the same assertions over a fake dictionary, because this
+    one needs a privilege the container does not grant by default and would otherwise be a
+    regression guarded only by a machine that happens to have it.
+    """
+    from mnemiq.sql.decide import decide
+
+    adapter = OracleAdapter(dsn=DSN, user=USER, password=PASSWORD, schema=USER.upper())
+    con = adapter._pool.acquire()
+    cur = con.cursor()
+    have = cur.execute("SELECT COUNT(*) FROM session_privs "
+                       "WHERE privilege = 'CREATE DATABASE LINK'").fetchone()[0]
+    if not have:
+        adapter._pool.release(con)
+        adapter.close()
+        pytest.skip("needs CREATE DATABASE LINK; see this module's docstring for the grant")
+
+    drops = ("DROP SYNONYM add_days", "DROP DATABASE LINK dbl_loop",
+             "DROP FUNCTION dbl_udf", "DROP TABLE dbl_secret", "DROP TABLE dbl_claim")
+    try:
+        for ddl in drops:
+            with contextlib.suppress(Exception):
+                cur.execute(ddl)
+        cur.execute("CREATE TABLE dbl_secret(ssn VARCHAR2(20))")
+        cur.execute("INSERT INTO dbl_secret VALUES ('123-45-6789')")
+        cur.execute("CREATE TABLE dbl_claim(id NUMBER)")
+        cur.execute("INSERT INTO dbl_claim VALUES (1)")
+        cur.execute("CREATE OR REPLACE FUNCTION dbl_udf(x NUMBER) RETURN VARCHAR2 IS "
+                    "v VARCHAR2(20); BEGIN SELECT ssn INTO v FROM dbl_secret WHERE ROWNUM = 1; "
+                    "RETURN v; END;")
+        con.commit()
+        # Back into this same PDB. The link is resolved by the SERVER, so the address is the
+        # container's own listener -- the host-side mapped port is ORA-12541 from in here.
+        cur.execute(f"CREATE DATABASE LINK dbl_loop CONNECT TO {USER} "
+                    f'IDENTIFIED BY "{PASSWORD}" USING \'localhost:1521/FREEPDB1\'')
+        cur.execute("CREATE SYNONYM add_days FOR dbl_udf@dbl_loop")
+        con.commit()
+
+        row = cur.execute("SELECT table_owner, db_link FROM user_synonyms "
+                          "WHERE synonym_name = 'ADD_DAYS'").fetchone()
+        assert row == (None, "DBL_LOOP"), f"not the shape under test: {row}"
+
+        cur.execute("SELECT add_days(1) FROM dual")
+        assert cur.fetchone()[0] == "123-45-6789", "no leak, so nothing below proves anything"
+
+        assert "add_days" in set(adapter.user_functions()), "the alias a query would spell"
+
+        refused = decide("SELECT add_days(1) AS x FROM dbl_claim", {"dbl_claim": {"id"}},
+                         adapter=adapter, dialect="oracle", target="oracle")
+        assert refused.code.value == "unmodelled_call", refused
+        # From the INVENTORY branch, not the allowlist. They share a code and differ in what
+        # they say, and asserting only the code is how the sibling test passed while reverted.
+        assert "defined by this source itself" in refused.message, refused.message
+
+        for clean in ("SELECT count(*) AS n FROM dbl_claim", "SELECT id FROM dbl_claim"):
+            v = decide(clean, {"dbl_claim": {"id"}}, adapter=adapter,
+                       dialect="oracle", target="oracle")
+            assert not hasattr(v, "code"), clean
     finally:
         for ddl in drops:
             with contextlib.suppress(Exception):

--- a/tests/test_oracle_adapter.py
+++ b/tests/test_oracle_adapter.py
@@ -28,7 +28,7 @@ failing without it:
 
 It is a separate line because it widens what APPUSER can do, which is the container's whole
 point of comparison for the access tests around it. The same assertions run database-free in
-`tests/test_oracle_nodb.py`, so skipping here does not leave the fail-open unguarded.
+`tests/test_function_inventory.py`, so skipping here does not leave the fail-open unguarded.
 """
 
 from __future__ import annotations
@@ -2017,7 +2017,7 @@ def test_a_synonym_over_a_db_link_is_a_route_to_a_udf_this_engine_cannot_resolve
     sqlglot does not know is refused as `exp.Anonymous` whatever the inventory holds, which is
     how an earlier version of that test passed with its fix reverted.
 
-    `tests/test_oracle_nodb.py` carries the same assertions over a fake dictionary, because this
+    `tests/test_function_inventory.py` carries the same assertions over a fake dictionary, because this
     one needs a privilege the container does not grant by default and would otherwise be a
     regression guarded only by a machine that happens to have it.
     """


### PR DESCRIPTION
Closes M102, which the register had down as *"not reproducible here: the container
holds 0 `db_link` synonyms out of 7,869, so the shape is pinned by a stub and the
resolution behaviour is documented rather than measured."* A loopback database link
into the same PDB reproduces it exactly, and the fail-open is real.

## The measurement

```sql
CREATE DATABASE LINK zz_loop ... USING 'localhost:1521/FREEPDB1';
CREATE SYNONYM add_days FOR m102_udf@zz_loop;   -- reads an ungranted table
```

| | before |
|---|---|
| `SELECT add_days(1)` | `'123-45-6789'` — through the link |
| `'add_days' in user_functions()` | `False` — the walk dropped the row |
| `decide(SELECT add_days(1) ... )` | **APPROVED** |

The walk skipped every `ALL_SYNONYMS` row with a NULL `table_owner`, which is what an
unqualified DB-link synonym has. `add_days` is the reachable spelling for the same
reason the sibling synonym test uses it: sqlglot models the name, so the cross-dialect
allowlist waves it through and only the inventory can catch it.

## The fix

A remote target cannot be resolved from here at all — there is no `all_objects` row to
join against — so the alias is **assumed** to reach a function rather than dropped.

Both remote shapes were wrong, which is why the branch tests the link and not the NULL
owner. The qualified form `('APPUSER', 'WEST_F', 'ZZ_LOOP')` names an owner, so the old
code joined on it and answered from the *local* `appuser.west_f` — a different object in
a different database. Right by accident when a local function shares the name, fail-open
when none does.

Chains needed the same care: a link alias contributes no edge to follow, so it seeds the
backward walk as itself or every hop in front of it is lost with it.

## What it costs

Three places a non-empty `names` is read, all documented in the adapter and two of them
measured:

- **the refusal** — `called & names` over a lexical scan for an identifier before an open
  paren. `SELECT * FROM orders` through `PUBLIC orders FOR orders@ERP_LINK` is still
  answered; only `orders(...)` is refused.
- **the gate in front of it** — a first alias also switches on the `UnreadableCalls` arm,
  which refuses a statement the scan cannot read at all, whole.
- **the label** — `calls_are_confirmable` is `licensed and not names`, so on a schema that
  defines nothing else, one alias over a remote *table* flips completeness to `unknown`
  for every answer carrying a call. Filed as **M104**; narrowing it needs a third category
  the shared inventory type does not model, so it is not folded in here.

Selecting `db_link` alongside is free: 53.8 ms median against 52.1 reverted, 15 runs on
the same 7,869 rows.

## Tests

Four behavioural regressions plus two controls over the existing fake dictionary in
`test_function_inventory.py`, and a live loopback test in `test_oracle_adapter.py` that
skips without `CREATE DATABASE LINK` (the grant is now in that module's docstring).

The controls have to pass with the fix **reverted**, so the stub answers the four columns
the old query asked for. The first version of these failed as a block on `too many values
to unpack` — including the controls — which measured nothing. Reverted now: exactly the
four link tests go red.

Local suite `2032 passed`; Oracle integration `59 passed, 7 skipped` against a live
container, up one because the new live test runs.

## Deferred

Seven rounds of the review gate ran on this branch. Everything behavioural was taken; what
is left is prose completeness inside one comment block, plus two items called out in the
commits: the `add_days` fixture name is shared with two sibling integration tests (safe
serially, would collide under xdist, and the name is load-bearing), and the M99 paragraph
rewrite is noted as restating a nearby sentence.
