### PR TITLE
The README told first-timers to use a .env the engine never reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ The first joins through a lookup table to resolve a coded column — `segment_cd
 and nothing in the name says "enterprise". The second is refused: the demo schema has no price or
 revenue column, and the engine says so instead of returning a number.
 
-Access is fail-closed. A role is required — pass `--roles analyst` on the command line, or set
-`MNEMIQ_ROLES=analyst` in your `.env`. Without a role the engine grants nothing and defers, which
-is the correct behaviour and the first thing people mistake for a bug. No policy, no grants, no
-snapshot — no data.
+Access is fail-closed. A role is required — pass `--roles analyst`, or `export
+MNEMIQ_ROLES=analyst` alongside the other settings above. Without a role the engine grants nothing
+and defers, which is the correct behaviour and the first thing people mistake for a bug. No policy,
+no grants, no snapshot — no data.
 
 ### Which LLM endpoints work
 
@@ -240,10 +240,11 @@ either way: [verification is off by default](https://github.com/agenticfabriq/mn
 despite being the only lever measured to reduce the wrong-rate.
 Contributions and arguments welcome.
 
-Two of the four this list opened with are now closed. An unreachable judge withholds the answer
-instead of passing it ([#2](https://github.com/agenticfabriq/mnemiq/issues/2)), and lineage stopped
+Three of the four this list opened with are now closed. An unreachable judge withholds the answer
+instead of passing it ([#2](https://github.com/agenticfabriq/mnemiq/issues/2)), lineage stopped
 reporting `unconfirmed-function-identity` on ordinary queries
-([#5](https://github.com/agenticfabriq/mnemiq/issues/5)).
+([#5](https://github.com/agenticfabriq/mnemiq/issues/5)), and the CLI honours `MNEMIQ_ROLES` like
+every other surface ([#4](https://github.com/agenticfabriq/mnemiq/issues/4)).
 
 ## Contributing
 

--- a/src/mnemiq/cli.py
+++ b/src/mnemiq/cli.py
@@ -82,12 +82,21 @@ def _identity(args, settings: Settings | None = None) -> IdentityContext:
     # from "the user passed a value"), which matches how the rest of the configuration resolves.
     from mnemiq.config import identity_from_settings
 
+    # THE TWO FLAGS FALL BACK BY DIFFERENT RULES, deliberately, because empty means something
+    # different for each. `--roles ""` is a real instruction -- grant nothing -- so it is honoured
+    # over the environment and only an ABSENT flag falls through. An empty principal is not an
+    # instruction, so a blank one falls through as if unset rather than building an identity with
+    # no principal at all.
     base = identity_from_settings(settings)
     roles_raw = getattr(args, "roles", None)
     return IdentityContext(
         tenant_id=base.tenant_id,
-        principal_id=getattr(args, "principal", None) or base.principal_id,
-        roles=[r for r in roles_raw.split(",") if r] if roles_raw is not None else base.roles,
+        principal_id=(getattr(args, "principal", None) or "").strip() or base.principal_id,
+        # Stripped for the same reason `identity_from_settings` strips: `--roles "analyst, viewer"`
+        # is what a person types, and an unstripped " viewer" matches no policy role, grants
+        # nothing, and reads as the engine being broken.
+        roles=([r.strip() for r in roles_raw.split(",") if r.strip()]
+               if roles_raw is not None else base.roles),
     )
 
 

--- a/src/mnemiq/config.py
+++ b/src/mnemiq/config.py
@@ -192,5 +192,6 @@ def identity_from_settings(settings: "Settings | None"):
         # role named " viewer" -- which matches nothing in the policy, grants nothing, and produces
         # the same accurate-sounding "no tables are available" that #4 was filed about. Every
         # surface resolves roles here, so the CLI, MCP and `/v1` all had it.
-        roles=[r.strip() for r in ((settings.roles if settings else "") or "").split(",") if r.strip()],
+        roles=[r.strip() for r in ((settings.roles if settings else "") or "").split(",")
+               if r.strip()],
     )

--- a/src/mnemiq/config.py
+++ b/src/mnemiq/config.py
@@ -188,5 +188,9 @@ def identity_from_settings(settings: "Settings | None"):
     return IdentityContext(
         tenant_id=(settings.tenant if settings else None) or "local",
         principal_id=(settings.principal if settings else None) or "local",
-        roles=[r for r in ((settings.roles if settings else "") or "").split(",") if r],
+        # STRIPPED, because `MNEMIQ_ROLES=analyst, viewer` is what a person writes and it yielded a
+        # role named " viewer" -- which matches nothing in the policy, grants nothing, and produces
+        # the same accurate-sounding "no tables are available" that #4 was filed about. Every
+        # surface resolves roles here, so the CLI, MCP and `/v1` all had it.
+        roles=[r.strip() for r in ((settings.roles if settings else "") or "").split(",") if r.strip()],
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -252,8 +252,8 @@ def test_roles_flag_strips_names_and_an_empty_flag_still_means_no_roles(monkeypa
     with no principal.
 
     Where an assertion is load-bearing in a way reading it does not show, a comment on that
-    assertion says which mutation of `_identity`'s `roles=` argument kills it -- measured, one
-    at a time. Deliberately per-assertion and not a map: every earlier version of this paragraph
+    assertion says which mutation of `_identity` kills it -- measured, one at a time, and each
+    kills its own assertion alone. Deliberately per-assertion and not a map: every earlier version of this paragraph
     tried to state the whole mapping in one place and was wrong about part of it each time.
     """
     import mnemiq.cli as cli

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -261,12 +261,13 @@ def test_roles_flag_strips_names_and_an_empty_flag_still_means_no_roles(monkeypa
         set. Making an empty parse fall through (`parsed or base.roles`) fails this line alone.
       * bare `ask q` -> `["analyst"]` guards the opposite direction, that an ABSENT flag falls
         through to settings. Returning `[]` there fails this and the env-fallback tests above.
-      * `--roles "a, b"` holds TWO, and is the only guard for either. It is the sole assertion
-        anywhere reading the per-element `.strip()`: change the element expression from
-        `r.strip()` to `r` while KEEPING the `if r.strip()` filter, and this line fails alone --
-        the whitespace-only case above survives on the filter. Dropping both strips fails both. It is also what
-        fails first if the flag is ignored entirely. Do not simplify it to `--roles "a,b"` -- that
-        still satisfies the second property and silently retires the first.
+      * `--roles "a, b"` holds TWO properties and is the only guard for either. It is the sole
+        assertion anywhere reading the per-element `.strip()`: change the element expression
+        from `r.strip()` to `r` while KEEPING the `if r.strip()` filter and this line fails
+        alone, since `--roles "a, ,b"` survives on the filter. (Dropping both strips fails
+        both.) It is also what fails first if the flag is ignored entirely. Do NOT simplify it
+        to `--roles "a,b"`: that still satisfies the second property and silently retires the
+        first.
     """
     import mnemiq.cli as cli
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -261,8 +261,11 @@ def test_roles_flag_strips_names_and_an_empty_flag_still_means_no_roles(monkeypa
         set. Making an empty parse fall through (`parsed or base.roles`) fails this line alone.
       * bare `ask q` -> `["analyst"]` guards the opposite direction, that an ABSENT flag falls
         through to settings. Returning `[]` there fails this and the env-fallback tests above.
-      * `--roles "a, b"` guards that the flag is consulted at all; ignoring it entirely fails here
-        first.
+      * `--roles "a, b"` holds TWO, and is the only guard for either. It is the sole assertion
+        anywhere reading the per-element `.strip()`: drop it from the comprehension and this line
+        fails alone, while the whitespace-only case above survives on the filter. It is also what
+        fails first if the flag is ignored entirely. Do not simplify it to `--roles "a,b"` -- that
+        still satisfies the second property and silently retires the first.
     """
     import mnemiq.cli as cli
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -251,10 +251,10 @@ def test_roles_flag_strips_names_and_an_empty_flag_still_means_no_roles(monkeypa
     empty `--principal` is not an instruction, so it falls through rather than building an identity
     with no principal.
 
-    Two of the assertions are load-bearing in a way that is not obvious from reading them, so
-    each says which mutation of `_identity`'s `roles=` argument kills it -- measured, one at a
-    time. The rest of the mutation map lives in this commit rather than here: every earlier
-    version of this paragraph tried to state the whole thing and was wrong about part of it.
+    Where an assertion is load-bearing in a way reading it does not show, a comment on that
+    assertion says which mutation of `_identity`'s `roles=` argument kills it -- measured, one
+    at a time. Deliberately per-assertion and not a map: every earlier version of this paragraph
+    tried to state the whole mapping in one place and was wrong about part of it each time.
     """
     import mnemiq.cli as cli
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -282,6 +282,6 @@ def test_roles_flag_strips_names_and_an_empty_flag_still_means_no_roles(monkeypa
     # The case the principal strip actually exists for. `--principal ""` above is resolved by the
     # `or` alone, so it reads the strip not at all -- deleting `.strip()` left every test green.
     assert ident(["ask", "q", "--principal", "   "]).principal_id == "alice@corp.com"
-    # Controls: the flag still wins when given, and absence still falls through to settings.
+    # The flag is used when given; an absent one falls through to settings (see above).
     assert ident(["ask", "q", "--roles", "admin"]).roles == ["admin"]
     assert ident(["ask", "q"]).roles == ["analyst"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -251,10 +251,11 @@ def test_roles_flag_strips_names_and_an_empty_flag_still_means_no_roles(monkeypa
     empty `--principal` is not an instruction, so it falls through rather than building an identity
     with no principal.
 
-    Each assertion holds a DIFFERENT property, measured by mutating `_identity` one way at a time
-    rather than reasoned about -- an earlier version of this paragraph named its control by
-    position, a later commit inserted a case at that position, and the correction then re-pointed
-    it at two assertions that guard something else:
+    The strip cases carry their own comments. The three that decide how `--roles` RESOLVES are
+    below, each named by the mutation that kills it -- measured one at a time rather than reasoned
+    about, because an earlier version of this paragraph named its control by position, a later
+    commit inserted a case at that position, and the correction then re-pointed it at assertions
+    guarding something else:
 
       * `--roles ""` -> `[]` is the ONLY guard that an explicit empty flag beats a configured role
         set. Making an empty parse fall through (`parsed or base.roles`) fails this line alone.
@@ -282,5 +283,4 @@ def test_roles_flag_strips_names_and_an_empty_flag_still_means_no_roles(monkeypa
     # The case the principal strip actually exists for. `--principal ""` above is resolved by the
     # `or` alone, so it reads the strip not at all -- deleting `.strip()` left every test green.
     assert ident(["ask", "q", "--principal", "   "]).principal_id == "alice@corp.com"
-    assert ident(["ask", "q", "--roles", "admin"]).roles == ["admin"]
     assert ident(["ask", "q"]).roles == ["analyst"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -251,11 +251,17 @@ def test_roles_flag_strips_names_and_an_empty_flag_still_means_no_roles(monkeypa
     empty `--principal` is not an instruction, so it falls through rather than building an identity
     with no principal.
 
-    The `--roles admin` and bare `ask q` cases are the CONTROLS, named rather than pointed at by
-    position: without them "strip the flag" could be satisfied by a change that dropped the flag's
-    precedence entirely. An earlier version of this sentence said "the second assertion", and a
-    later commit inserted a strip case in that position -- so the sentence then told a maintainer
-    that the coverage this test exists for was redundant.
+    Each assertion holds a DIFFERENT property, measured by mutating `_identity` one way at a time
+    rather than reasoned about -- an earlier version of this paragraph named its control by
+    position, a later commit inserted a case at that position, and the correction then re-pointed
+    it at two assertions that guard something else:
+
+      * `--roles ""` -> `[]` is the ONLY guard that an explicit empty flag beats a configured role
+        set. Making an empty parse fall through (`parsed or base.roles`) fails this line alone.
+      * bare `ask q` -> `["analyst"]` guards the opposite direction, that an ABSENT flag falls
+        through to settings. Returning `[]` there fails this and the env-fallback tests above.
+      * `--roles "a, b"` guards that the flag is consulted at all; ignoring it entirely fails here
+        first.
     """
     import mnemiq.cli as cli
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -263,8 +263,14 @@ def test_roles_flag_strips_names_and_an_empty_flag_still_means_no_roles(monkeypa
         return cli._identity(cli.build_parser().parse_args(argv), settings)
 
     assert ident(["ask", "q", "--roles", "a, b"]).roles == ["a", "b"]
+    # An element that is nothing but whitespace is not a role. Without this the filter could go
+    # back to `if r` and stay green, letting `--roles "a, ,b"` carry a "" role.
+    assert ident(["ask", "q", "--roles", "a, ,b"]).roles == ["a", "b"]
     assert ident(["ask", "q", "--roles", ""]).roles == []
     assert ident(["ask", "q", "--principal", ""]).principal_id == "alice@corp.com"
+    # The case the principal strip actually exists for. `--principal ""` above is resolved by the
+    # `or` alone, so it reads the strip not at all -- deleting `.strip()` left every test green.
+    assert ident(["ask", "q", "--principal", "   "]).principal_id == "alice@corp.com"
     # Controls: the flag still wins when given, and absence still falls through to settings.
     assert ident(["ask", "q", "--roles", "admin"]).roles == ["admin"]
     assert ident(["ask", "q"]).roles == ["analyst"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -262,8 +262,9 @@ def test_roles_flag_strips_names_and_an_empty_flag_still_means_no_roles(monkeypa
       * bare `ask q` -> `["analyst"]` guards the opposite direction, that an ABSENT flag falls
         through to settings. Returning `[]` there fails this and the env-fallback tests above.
       * `--roles "a, b"` holds TWO, and is the only guard for either. It is the sole assertion
-        anywhere reading the per-element `.strip()`: drop it from the comprehension and this line
-        fails alone, while the whitespace-only case above survives on the filter. It is also what
+        anywhere reading the per-element `.strip()`: change the element expression from
+        `r.strip()` to `r` while KEEPING the `if r.strip()` filter, and this line fails alone --
+        the whitespace-only case above survives on the filter. Dropping both strips fails both. It is also what
         fails first if the flag is ignored entirely. Do not simplify it to `--roles "a,b"` -- that
         still satisfies the second property and silently retires the first.
     """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -251,23 +251,10 @@ def test_roles_flag_strips_names_and_an_empty_flag_still_means_no_roles(monkeypa
     empty `--principal` is not an instruction, so it falls through rather than building an identity
     with no principal.
 
-    The strip cases carry their own comments. The three that decide how `--roles` RESOLVES are
-    below, each named by the mutation that kills it -- measured one at a time rather than reasoned
-    about, because an earlier version of this paragraph named its control by position, a later
-    commit inserted a case at that position, and the correction then re-pointed it at assertions
-    guarding something else:
-
-      * `--roles ""` -> `[]` is the ONLY guard that an explicit empty flag beats a configured role
-        set. Making an empty parse fall through (`parsed or base.roles`) fails this line alone.
-      * bare `ask q` -> `["analyst"]` guards the opposite direction, that an ABSENT flag falls
-        through to settings. Returning `[]` there fails this and the env-fallback tests above.
-      * `--roles "a, b"` holds TWO properties and is the only guard for either. It is the sole
-        assertion anywhere reading the per-element `.strip()`: change the element expression
-        from `r.strip()` to `r` while KEEPING the `if r.strip()` filter and this line fails
-        alone, since `--roles "a, ,b"` survives on the filter. (Dropping both strips fails
-        both.) It is also what fails first if the flag is ignored entirely. Do NOT simplify it
-        to `--roles "a,b"`: that still satisfies the second property and silently retires the
-        first.
+    Two of the assertions are load-bearing in a way that is not obvious from reading them, so
+    each says which mutation of `_identity`'s `roles=` argument kills it -- measured, one at a
+    time. The rest of the mutation map lives in this commit rather than here: every earlier
+    version of this paragraph tried to state the whole thing and was wrong about part of it.
     """
     import mnemiq.cli as cli
 
@@ -279,10 +266,16 @@ def test_roles_flag_strips_names_and_an_empty_flag_still_means_no_roles(monkeypa
     def ident(argv):
         return cli._identity(cli.build_parser().parse_args(argv), settings)
 
+    # The only assertion reading the per-element `.strip()` in the CLI's own comprehension
+    # (`roles_raw.split(",")`). Change that element expression to `r`, keeping the
+    # `if r.strip()` filter, and this line fails while the "a, ,b" case below survives. Do not
+    # simplify it to "a,b": that keeps the test passing and retires the guard.
     assert ident(["ask", "q", "--roles", "a, b"]).roles == ["a", "b"]
     # An element that is nothing but whitespace is not a role. Without this the filter could go
     # back to `if r` and stay green, letting `--roles "a, ,b"` carry a "" role.
     assert ident(["ask", "q", "--roles", "a, ,b"]).roles == ["a", "b"]
+    # The only guard that an explicit EMPTY flag beats a configured role set: making an empty
+    # parse fall through (`parsed or base.roles`) fails here alone.
     assert ident(["ask", "q", "--roles", ""]).roles == []
     assert ident(["ask", "q", "--principal", ""]).principal_id == "alice@corp.com"
     # The case the principal strip actually exists for. `--principal ""` above is resolved by the

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -241,3 +241,30 @@ def test_tenant_defaults_from_env(monkeypatch, capsys):
     monkeypatch.setattr(cli.Settings, "from_env", classmethod(lambda cls: settings))
     assert main(["ask", "q"]) == 0
     assert captured["identity"].tenant_id == "acme"
+
+
+def test_roles_flag_strips_names_and_an_empty_flag_still_means_no_roles(monkeypatch):
+    """The `--roles` path strips like the environment path, and the two flags keep falling back by
+    different rules on purpose.
+
+    `--roles ""` is a real instruction -- grant nothing -- so it beats a configured role set; an
+    empty `--principal` is not an instruction, so it falls through rather than building an identity
+    with no principal. The second assertion is the control for the first: without it, "strip the
+    flag" could be satisfied by a change that dropped the flag's precedence entirely.
+    """
+    import mnemiq.cli as cli
+
+    settings = Settings(
+        llm_base_url="x", llm_api_key="k", llm_model="m", pg_dsn="d",
+        roles="analyst", principal="alice@corp.com",
+    )
+
+    def ident(argv):
+        return cli._identity(cli.build_parser().parse_args(argv), settings)
+
+    assert ident(["ask", "q", "--roles", "a, b"]).roles == ["a", "b"]
+    assert ident(["ask", "q", "--roles", ""]).roles == []
+    assert ident(["ask", "q", "--principal", ""]).principal_id == "alice@corp.com"
+    # Controls: the flag still wins when given, and absence still falls through to settings.
+    assert ident(["ask", "q", "--roles", "admin"]).roles == ["admin"]
+    assert ident(["ask", "q"]).roles == ["analyst"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -282,6 +282,5 @@ def test_roles_flag_strips_names_and_an_empty_flag_still_means_no_roles(monkeypa
     # The case the principal strip actually exists for. `--principal ""` above is resolved by the
     # `or` alone, so it reads the strip not at all -- deleting `.strip()` left every test green.
     assert ident(["ask", "q", "--principal", "   "]).principal_id == "alice@corp.com"
-    # The flag is used when given; an absent one falls through to settings (see above).
     assert ident(["ask", "q", "--roles", "admin"]).roles == ["admin"]
     assert ident(["ask", "q"]).roles == ["analyst"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -249,8 +249,13 @@ def test_roles_flag_strips_names_and_an_empty_flag_still_means_no_roles(monkeypa
 
     `--roles ""` is a real instruction -- grant nothing -- so it beats a configured role set; an
     empty `--principal` is not an instruction, so it falls through rather than building an identity
-    with no principal. The second assertion is the control for the first: without it, "strip the
-    flag" could be satisfied by a change that dropped the flag's precedence entirely.
+    with no principal.
+
+    The `--roles admin` and bare `ask q` cases are the CONTROLS, named rather than pointed at by
+    position: without them "strip the flag" could be satisfied by a change that dropped the flag's
+    precedence entirely. An earlier version of this sentence said "the second assertion", and a
+    later commit inserted a strip case in that position -- so the sentence then told a maintainer
+    that the coverage this test exists for was redundant.
     """
     import mnemiq.cli as cli
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -370,3 +370,32 @@ def Settings_env_example_fields() -> str:
     from mnemiq.config import Settings
 
     return Settings.env_example()
+
+
+def test_role_names_are_stripped_so_a_space_after_a_comma_is_not_a_role():
+    """`MNEMIQ_ROLES=analyst, viewer` is what a person writes, and it used to yield a role named
+    `" viewer"`.
+
+    That role matches nothing in the policy, so it grants nothing, and the engine's "no tables are
+    available" is accurate -- the same invisible failure #4 was filed about, one comma-space later.
+    Every surface resolves roles through this function, so the CLI, MCP and `/v1` all had it.
+
+    The direction is worth naming: stripping GRANTS more than before, because a name that matched
+    no policy role now matches one. That is the deployer's stated intent -- they wrote two role
+    names -- and the previous behaviour honoured the whitespace rather than the intent.
+    """
+    from mnemiq.config import identity_from_settings
+
+    def roles_for(raw):
+        return identity_from_settings(
+            Settings(llm_base_url="x", llm_api_key="k", llm_model="m", pg_dsn="d", roles=raw)
+        ).roles
+
+    assert roles_for("analyst, viewer") == ["analyst", "viewer"]
+    assert roles_for("  analyst  ,viewer ") == ["analyst", "viewer"]
+    # Controls: neither the ordinary spelling nor the empty cases move.
+    assert roles_for("analyst,viewer") == ["analyst", "viewer"]
+    assert roles_for("analyst,") == ["analyst"]
+    assert roles_for("") == []
+    # A name that is nothing BUT whitespace is not a role, where before it was.
+    assert roles_for("analyst, ,viewer") == ["analyst", "viewer"]


### PR DESCRIPTION
Follow-up to #9, which fixed the CLI ignoring `MNEMIQ_ROLES` and then documented the
fix with an instruction that does not work.

## The README told first-timers to use a `.env` the engine never reads

> set `MNEMIQ_ROLES=analyst` in your `.env`

mnemiq does not read `.env`. `config.py` says so — *"`Settings()` reads `os.environ`
only (scripts `source .env`)"* — the quickstart four sections up uses `export`, and
measured, with a `.env` holding `MNEMIQ_ROLES=analyst` in the working directory:

```
Settings.from_env().roles -> None
```

A first-time user follows that line, gets "no tables are available", and concludes the
engine is broken — the exact confusion #9 exists to remove, reintroduced in its own
documentation.

The same section still said *"Two of the four this list opened with are now closed"*
while dropping #4 from the open list, so the count and the sentence disagreed about #4.
Three now, with #4 named alongside #2 and #5.

## Role names are stripped

`MNEMIQ_ROLES=analyst, viewer` is what a person writes, and it yielded a role named
`" viewer"` — matching nothing in the policy, granting nothing, producing the same
accurate-sounding refusal one comma-space later. Fixed in `identity_from_settings`,
where every surface resolves roles, so the CLI, MCP and `/v1` all had it. The `--roles`
flag path strips too.

**Worth naming: this grants more than before**, because a name that matched no policy
role now matches one. That is the deployer's stated intent — they wrote two role names —
and the previous behaviour honoured the whitespace instead of the intent.

## The two flags fall back by different rules, and now say so

`--roles ""` is a real instruction (grant nothing), so it beats a configured role set.
An empty `--principal` is not an instruction, so it falls through rather than building
an identity with no principal. That asymmetry was correct and undocumented; it is now
documented rather than "fixed" into a false symmetry.

## Tests

Two, both verified to fail with the strip reverted. Every mutation was measured **one at
a time** — the first attempt deleted two strips together, failed on the first assertion,
and read as proving both.

Each load-bearing assertion carries the mutation that kills it, and each kills its own
assertion alone:

| mutation of `_identity` | kills |
|---|---|
| element expr `r.strip()` → `r` (filter kept) | `--roles "a, b"` |
| filter `if r.strip()` → `if r` | `--roles "a, ,b"` |
| `parsed or base.roles` | `--roles ""` |
| drop the principal `.strip()` | `--principal "   "` |

Local suite `2039 passed`, with the same six pre-existing environment failures main has
(a Postgres port collision and an acme table count) — none touched by this branch.

## Note on the history

Thirteen commits for ~5 lines of logic. Twelve review-gate rounds ran on this branch and
every one found something true; seven of them were the same test docstring, where each
rewrite fixed the named defect and introduced another, because the paragraph kept trying
to state a complete assertion-to-mutation mapping in prose beside code that moved. It is
now per-assertion comments and no map. Squash-merging, so `main` sees one commit.
