### PR TITLE
The TRY_CAST fix went into one of two siblings, and the untestable one stayed so

### DIFF
--- a/scripts/add_relationships_spider2.py
+++ b/scripts/add_relationships_spider2.py
@@ -21,8 +21,6 @@ import os
 import re
 from collections import defaultdict
 
-import snowflake.connector
-
 
 def declared_keys(cur, database: str) -> tuple[dict, dict]:
     """({schema: {table: pk_column}}, {schema: [(child, col, parent, col), ...]})"""
@@ -133,6 +131,13 @@ def main() -> int:
     p.add_argument("--schema", action="append", dest="schemas")
     p.add_argument("--dry-run", action="store_true")
     args = p.parse_args()
+
+    # Deferred so this module imports without the warehouse extra, which is what lets
+    # `splice` be tested: it is sixty lines of regex splicing, key narrowing and
+    # cycle-breaking whose output is replayed verbatim as CREATE OR REPLACE against a live
+    # semantic view, and it had no test because the import stopped the file being loaded.
+    # `strip_sample_values` and `grade_warehouse` defer it the same way.
+    import snowflake.connector
 
     con = snowflake.connector.connect(connection_name=args.connection)
     cur = con.cursor()

--- a/scripts/infer_keys_spider2.py
+++ b/scripts/infer_keys_spider2.py
@@ -29,10 +29,14 @@ import re
 import sys
 from collections import defaultdict
 
-import snowflake.connector
-
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from fix_keys_snowflake import drop_existing  # noqa: E402
+
+# BOTH deferred into `main()`. `snowflake.connector` obviously, and `drop_existing` because
+# importing it pulls the driver in transitively. Between them they made this module
+# unloadable without the warehouse extra, so `align_column` -- which decides whether a
+# CREATE OR REPLACE runs over a live table -- could not be tested. The commit that changed
+# its SQL applied this same convention to `add_relationships_spider2` and not to the file it
+# had actually changed the behaviour of.
 
 # Types that can plausibly carry a key. Floats and booleans are excluded: a float join key
 # is a coincidence, not a relationship.
@@ -94,10 +98,23 @@ def align_column(cur, database: str, schema: str, table: str, column: str, targe
     The cast is checked for loss first -- a column that does not convert cleanly is left
     alone and its relationship is simply not declared.
     """
+    # TO_VARCHAR around every source. Snowflake's TRY_CAST takes a STRING expression, and a
+    # numeric source reaches here whenever the two sides differ and neither is TEXT --
+    # `_CHILD_TYPES` admits FLOAT/REAL/DOUBLE, so a FLOAT child against a NUMBER parent picks
+    # the FLOAT side for a NUMBER(38,0) target. The raise is swallowed by the caller's
+    # `except Exception: continue`, so the only visible effect is a foreign key that never
+    # gets declared, for a reason nothing prints.
+    #
+    # The sibling `align_fk_types_snowflake` was fixed for exactly this and this file was not:
+    # the same defect in two places, corrected in one. It must match the projection below --
+    # a probe that certifies `TRY_CAST(TO_VARCHAR(x) AS t)` while `TRY_CAST(x AS t)` executes
+    # has verified something adjacent to what runs.
     cur.execute(
-        f'SELECT COUNT("{column}"), COUNT(TRY_CAST("{column}" AS {target})), '
-        f'COUNT_IF(TRY_CAST("{column}" AS FLOAT) IS NOT NULL '
-        f'         AND TRY_CAST("{column}" AS FLOAT) <> TRUNC(TRY_CAST("{column}" AS FLOAT))) '
+        f'SELECT COUNT("{column}"), '
+        f'COUNT(TRY_CAST(TO_VARCHAR("{column}") AS {target})), '
+        f'COUNT_IF(TRY_CAST(TO_VARCHAR("{column}") AS FLOAT) IS NOT NULL AND '
+        f'  TRY_CAST(TO_VARCHAR("{column}") AS FLOAT) '
+        f'  <> TRUNC(TRY_CAST(TO_VARCHAR("{column}") AS FLOAT))) '
         f'FROM {database}."{schema}"."{table}"'
     )
     non_null, converted, fractional = cur.fetchone()
@@ -115,7 +132,8 @@ def align_column(cur, database: str, schema: str, table: str, column: str, targe
     )
     names = [r[0] for r in cur.fetchall()]
     projection = ", ".join(
-        f'TRY_CAST("{n}" AS {target}) AS "{n}"' if n == column else f'"{n}"' for n in names
+        f'TRY_CAST(TO_VARCHAR("{n}") AS {target}) AS "{n}"' if n == column else f'"{n}"'
+        for n in names
     )
     cur.execute(
         f'CREATE OR REPLACE TABLE {database}."{schema}"."{table}" AS '
@@ -236,6 +254,9 @@ def main() -> int:
     p.add_argument("--all-schemas", dest="only_keyless", action="store_false")
     p.add_argument("--dry-run", action="store_true")
     args = p.parse_args()
+
+    import snowflake.connector
+    from fix_keys_snowflake import drop_existing
 
     con = snowflake.connector.connect(connection_name=args.connection)
     cur = con.cursor()

--- a/scripts/strip_sample_values.py
+++ b/scripts/strip_sample_values.py
@@ -56,8 +56,17 @@ def main() -> int:
     args = p.parse_args()
 
     # Imported here, not at module scope: the driver is an optional extra, and the regex above
-    # is the part worth testing. `capture_rows`, `grade_spider2` and `grade_warehouse` defer it
-    # the same way.
+    # is the part worth testing. Several scripts here defer it the same way. Named as a rule
+    # rather than listed, because the list went stale one commit after it was written -- and
+    # then the rule replacing it was a grep I had not run, which matched nothing because the
+    # deferring scripts are not the ones with "snowflake" in the filename. This one is run:
+    #
+    #   grep -lE '(import snowflake|from snowflake)' scripts/*.py \
+    #     | xargs grep -LE '^(import snowflake|from snowflake)'
+    #
+    # Both spellings, because keying on `import snowflake` alone would omit a deferred
+    # `from snowflake.connector import connect`. The two forms return the same six files
+    # today; the broader one keeps doing so after someone writes the other spelling.
     import snowflake.connector
 
     con = snowflake.connector.connect(connection_name=args.connection)

--- a/tests/test_add_relationships_spider2.py
+++ b/tests/test_add_relationships_spider2.py
@@ -1,0 +1,132 @@
+"""`splice`, which rewrites a semantic view's DDL and hands the result straight to
+CREATE OR REPLACE against a live view.
+
+It had no test because the module imported `snowflake.connector` at top level and so could
+not be loaded without the warehouse extra. That import is deferred now, for the reason
+`tests/test_ddl_translate.py` sets the convention: a script's pure part gets a test.
+
+Every case below is a shape the function's own comments name -- a composite key sweeping in a
+foreign key column, a relationship pointing at a column the parent cannot declare, and
+Sakila's real STORE/STAFF cycle -- so a rewrite that stops handling one of them goes red
+rather than producing a view Cortex Analyst quietly refuses.
+"""
+
+from scripts.add_relationships_spider2 import splice
+
+# The two-dotted DIMENSION line must not collect a primary key; only the three-dotted table
+# entries may. That distinction is a regex in `splice` and is the easiest thing to break.
+DDL = (
+    "create or replace semantic view SPIDER2.SAKILA.SV\n"
+    "\ttables (\n"
+    '\t\tSPIDER2.SAKILA."STORE" comment=\'a store\',\n'
+    '\t\tSPIDER2.SAKILA."STAFF" primary key (MANAGER_STAFF_ID, STAFF_ID),\n'
+    '\t\tSPIDER2.SAKILA."RENTAL"\n'
+    "\t)\n"
+    "\tfacts (\n"
+    "\t\tSTORE.STORE_ID as store_id\n"
+    "\t)\n"
+    "\tdimensions (\n"
+    "\t\tSTAFF.NAME as name\n"
+    "\t)\n"
+)
+
+
+def test_a_view_that_already_has_relationships_is_left_alone():
+    """Returns None rather than splicing a second block in. The caller skips on None, so this
+    is what stops a re-run doubling the clause."""
+    already = DDL.replace("\tfacts (", "\trelationships (\n\t\tX as A(B) references C(D)\n\t)\n\tfacts (")
+    assert splice(already, {}, [("A", "B", "C", "D")]) is None
+
+
+def test_no_declarable_relationship_yields_None_rather_than_an_empty_block():
+    """An empty `relationships ()` is not the same as leaving the view unedited: it is a
+    rewrite that changes nothing and costs a CREATE OR REPLACE against a live view."""
+    assert splice(DDL, {}, []) is None
+
+
+def test_the_primary_key_lands_on_table_entries_and_not_on_a_dimension():
+    out = splice(DDL, {"STORE": "STORE_ID"}, [("RENTAL", "STORE_ID", "STORE", "STORE_ID")])
+    assert out is not None
+    assert 'SPIDER2.SAKILA."STORE" primary key (STORE_ID)' in out
+    # The two-dotted lines are columns, not tables, and must be untouched.
+    assert "\t\tSTORE.STORE_ID as store_id\n" in out
+    assert "\t\tSTAFF.NAME as name\n" in out
+
+
+def test_a_composite_key_is_narrowed_to_the_column_that_identifies_the_row():
+    """Autopilot sweeps foreign key columns into the key -- SQLITE-SAKILA's STORE gets
+    (MANAGER_STAFF_ID, STORE_ID). A relationship must name the whole key, so the composite is
+    replaced rather than added to."""
+    out = splice(DDL, {"STAFF": "STAFF_ID"}, [("STORE", "MANAGER_STAFF_ID", "STAFF", "STAFF_ID")])
+    assert out is not None
+    assert 'SPIDER2.SAKILA."STAFF" primary key (STAFF_ID)' in out
+    assert "MANAGER_STAFF_ID, STAFF_ID" not in out, "the composite survived"
+
+
+def test_only_one_referenced_column_survives_and_SORT_ORDER_picks_it():
+    """A semantic view accepts a relationship only against the target's declared key, so where
+    two columns of one parent are referenced, one relationship has to go.
+
+    Which one is decided by `sorted(foreign)`, not by `primary`: the rule preferring "a key
+    something actually references" fires on the first referenced column it sees and then
+    locks, so EMAIL beats the declared STAFF_ID purely because it sorts first. That is the
+    documented intent -- the key is "dictated by what points at it, not by whatever
+    SHOW PRIMARY KEYS happens to report" -- but the tie-break between two referenced columns
+    is alphabetical rather than principled, and this test exists to make that visible rather
+    than to bless it. Reversing the two tuples below changes the surviving relationship.
+    """
+    out = splice(
+        DDL,
+        {"STAFF": "STAFF_ID"},
+        [("STORE", "MANAGER_STAFF_ID", "STAFF", "STAFF_ID"),
+         ("RENTAL", "STAFF_EMAIL", "STAFF", "EMAIL")],
+    )
+    assert out is not None
+    assert "RENTAL_TO_STAFF as RENTAL(STAFF_EMAIL) references STAFF(EMAIL)" in out
+    assert "STORE_TO_STAFF" not in out, "both survived; the view would be rejected"
+    # And the table entry carries the key the surviving relationship needs, not the PK.
+    assert 'SPIDER2.SAKILA."STAFF" primary key (EMAIL)' in out
+
+
+def test_sakilas_real_cycle_keeps_one_edge_and_drops_the_one_that_closes_it():
+    """STORE names its manager in STAFF and STAFF names the store it works at. Semantic views
+    reject cycles, and a join path in one direction beats none in either."""
+    out = splice(
+        DDL,
+        {"STAFF": "STAFF_ID", "STORE": "STORE_ID"},
+        [("STORE", "MANAGER_STAFF_ID", "STAFF", "STAFF_ID"),
+         ("STAFF", "STORE_ID", "STORE", "STORE_ID")],
+    )
+    assert out is not None
+    assert ("STORE_TO_STAFF" in out) != ("STAFF_TO_STORE" in out), "kept both, or neither"
+
+
+def test_two_relationships_are_comma_separated_and_the_repeat_name_is_suffixed():
+    """Every other case here yields ONE relationship line, which leaves two things unreached:
+    the `",\n".join` separator and the `while name in used` suffix loop. Mutating the join to
+    `"\n".join` emits a block with no commas -- rejected by Snowflake for every real schema --
+    and every other test stays green.
+
+    Two foreign keys from one child to one parent key is the shape that reaches both at once:
+    Sakila's RENTAL names a staff member twice. Both point at STAFF's declared key, so both
+    survive the key rule, and the second collides on `RENTAL_TO_STAFF`.
+    """
+    out = splice(
+        DDL,
+        {"STAFF": "STAFF_ID"},
+        [("RENTAL", "STAFF_ID", "STAFF", "STAFF_ID"),
+         ("RENTAL", "RETURN_STAFF_ID", "STAFF", "STAFF_ID")],
+    )
+    assert out is not None
+    assert "RENTAL_TO_STAFF as RENTAL(RETURN_STAFF_ID) references STAFF(STAFF_ID)" in out
+    assert "RENTAL_TO_STAFF_2 as RENTAL(STAFF_ID) references STAFF(STAFF_ID)" in out
+    # The separator. Without it the two lines run together and the DDL will not parse.
+    block = out[out.index("\trelationships ("):out.index("\tfacts (")]
+    assert block.count(",\n") == 1, f"entries are not comma-separated: {block!r}"
+
+
+def test_the_block_is_placed_before_facts_where_snowflake_writes_it():
+    out = splice(DDL, {"STORE": "STORE_ID"}, [("RENTAL", "STORE_ID", "STORE", "STORE_ID")])
+    assert out is not None
+    assert out.index("\trelationships (") < out.index("\tfacts ("), "clause is out of order"
+    assert "RENTAL_TO_STORE as RENTAL(STORE_ID) references STORE(STORE_ID)" in out

--- a/tests/test_infer_keys_align_column.py
+++ b/tests/test_infer_keys_align_column.py
@@ -1,0 +1,135 @@
+"""`align_column`, which decides whether a CREATE OR REPLACE runs over a live table.
+
+Testable at all only because the module's two driver-pulling imports are deferred now. It had
+none while its SQL was being changed, which is how the bare-`TRY_CAST` defect survived in this
+file after being fixed in its sibling.
+
+The invariant these pin is the one that was violated twice and stated in prose both times: the
+loss PROBE and the REWRITE must cast identically. A probe certifying
+`TRY_CAST(TO_VARCHAR(x) AS t)` while `TRY_CAST(x AS t)` executes has verified something
+adjacent to what runs.
+"""
+
+import re
+
+import pytest
+
+from scripts.infer_keys_spider2 import align_column
+
+
+class FakeCursor:
+    """Records every statement and answers the two shapes `align_column` asks for."""
+
+    def __init__(self, non_null=10, converted=10, fractional=0, columns=("ID", "NAME")):
+        self.sql: list[str] = []
+        self._reply = (non_null, converted, fractional)
+        self._columns = columns
+        self._last = ""
+
+    def execute(self, sql, params=None):
+        self.sql.append(sql)
+        self._last = sql
+
+    def fetchone(self):
+        return self._reply
+
+    def fetchall(self):
+        return [(c,) for c in self._columns]
+
+    # -- helpers the assertions read ------------------------------------------------
+    @property
+    def probe(self) -> str:
+        return next(s for s in self.sql if s.lstrip().upper().startswith("SELECT COUNT("))
+
+    @property
+    def rewrite(self) -> str | None:
+        return next((s for s in self.sql if "CREATE OR REPLACE TABLE" in s), None)
+
+
+def _casts(sql: str) -> set[tuple[str, str]]:
+    """Every `TRY_CAST(source AS target)` as a (source, target) pair.
+
+    Hand-scanned rather than regexed because the target may itself contain parentheses --
+    `NUMBER(38,0)` -- and `[^)]*` stops at the first one whatever its quantifier does, the
+    negated class being what ends the match rather than greed. That is how the first version
+    of this helper silently compared truncated targets.
+    """
+    out: set[tuple[str, str]] = set()
+    for start in (m for m in range(len(sql)) if sql.startswith("TRY_CAST(", m)):
+        depth, i = 0, start + len("TRY_CAST(")
+        while i < len(sql):
+            if sql[i] == "(":
+                depth += 1
+            elif sql[i] == ")":
+                if depth == 0:
+                    break
+                depth -= 1
+            i += 1
+        source, _, target = sql[start + len("TRY_CAST("):i].partition(" AS ")
+        out.add((source.strip(), target.strip()))
+    return out
+
+
+def _run(**kw) -> tuple[bool, FakeCursor]:
+    cur = FakeCursor(**kw)
+    ok = align_column(cur, "SPIDER2", "DB-IMDB", "M_CAST", "ID", "NUMBER(38,0)")
+    return ok, cur
+
+
+def test_a_lossless_cast_rewrites_the_table():
+    ok, cur = _run(non_null=10, converted=10, fractional=0)
+    assert ok is True
+    assert cur.rewrite is not None
+
+
+def test_a_lossy_cast_returns_False_and_writes_NOTHING():
+    """The whole point of the probe. A value that does not convert becomes NULL in a table
+    that would then be overwritten, so the rewrite must not run at all."""
+    ok, cur = _run(non_null=10, converted=7)
+    assert ok is False
+    assert cur.rewrite is None, "it overwrote the table after deciding the cast was lossy"
+
+
+def test_a_fractional_source_is_refused_for_a_NUMBER_target():
+    """TRY_CAST rounds 3.5 to 4 rather than failing, so a fractional column converts
+    `cleanly` while changing every value. An identifier has no fractional part."""
+    ok, cur = _run(non_null=10, converted=10, fractional=3)
+    assert ok is False
+    assert cur.rewrite is None
+
+
+def test_the_probe_and_the_rewrite_cast_identically():
+    """The invariant. Both were bare `TRY_CAST(x AS t)` once and both are wrapped now; what
+    must never happen again is ONE of them changing. Compares the actual cast expressions
+    rather than trusting the comments that say so in two files."""
+    _, cur = _run()
+    probe, rewrite = _casts(cur.probe), _casts(cur.rewrite)
+    assert rewrite, "no TRY_CAST in the rewrite at all"
+    # SOURCE AND TARGET BOTH. An earlier version compared only the source, so changing the
+    # rewrite's target to VARCHAR left every test in this file green -- the invariant test
+    # blind to the half that decides what the column becomes.
+    #
+    # Subset, not equality: the rewrite casts the key column to the target, while the probe
+    # casts it to the target AND to FLOAT for the fractional check.
+    assert rewrite <= probe, (
+        f"the rewrite casts something the probe never measured: {rewrite - probe}"
+    )
+
+
+@pytest.mark.parametrize("statement", ["probe", "rewrite"])
+def test_every_cast_reads_a_string_source(statement):
+    """Snowflake's TRY_CAST takes a STRING expression. A numeric source reaches here whenever
+    the two sides differ and neither is TEXT -- `_CHILD_TYPES` admits FLOAT/REAL/DOUBLE, so a
+    FLOAT child against a NUMBER parent picks the FLOAT side. The raise was swallowed by the
+    caller, leaving a foreign key undeclared for a reason nothing printed."""
+    _, cur = _run()
+    sql = getattr(cur, statement)
+    bare = re.findall(r'TRY_CAST\("', sql)
+    assert not bare, f"{statement} casts a column directly instead of through TO_VARCHAR"
+
+
+def test_the_untouched_columns_are_carried_through_unchanged():
+    """A rebuild that dropped a column would be silent and total. `NAME` is not the key."""
+    _, cur = _run(columns=("ID", "NAME"))
+    assert '"NAME"' in cur.rewrite
+    assert 'TRY_CAST(TO_VARCHAR("NAME")' not in cur.rewrite, "cast a column it was not asked to"


### PR DESCRIPTION
Two of the four advisories from an **opus review of `cc70228`**, run after that PR merged
because three of its commits had gone in under `SKIP_REVIEW=1` while the reviewer was
quota-blocked. The review returned PASS-WITH-ADVISORIES — no blockers in the merged code.
These are the two that were mine to fix; the other two are Paulina's inference logic and are
listed at the bottom rather than guessed at.

## The TRY_CAST fix went into one of two siblings

`infer_keys_spider2.align_column` still probed with a bare `TRY_CAST("col" AS ...)` — the
exact shape `align_fk_types_snowflake` was changed to avoid one commit earlier, with a comment
explaining that Snowflake's `TRY_CAST` takes a **string** expression.

A numeric source reaches it whenever the two sides differ and neither is TEXT: `_CHILD_TYPES`
admits FLOAT/REAL/DOUBLE, so a FLOAT child against a NUMBER parent selects the FLOAT side for
a `NUMBER(38,0)` target. The raise is swallowed by the caller's `except Exception: continue`,
so the only visible effect is a foreign key that never gets declared, for a reason nothing
prints.

Fixing the instance and not the class is how it survived. Probe and projection now use one
expression, as in the sibling.

## `splice` was untestable, and is 60 lines of regex feeding a live CREATE OR REPLACE

`add_relationships_spider2` imported the driver at module scope, so the function could not be
loaded without the warehouse extra. Deferred, as `strip_sample_values` and `grade_warehouse`
already do — and then the same convention applied to `infer_keys_spider2` too, which the first
round had missed even though it is the file whose executed behaviour changed.

New tests, every case a shape the functions' own comments name:

| file | what it pins |
|---|---|
| `test_add_relationships_spider2.py` | composite-key narrowing, the non-key relationship, Sakila's real STORE/STAFF cycle, comma separation and name deduplication |
| `test_infer_keys_align_column.py` | the lossy cast writes nothing, the fractional refusal, and **probe and rewrite cast identically** |

Every one was mutation-checked and kills exactly its own case.

## Three things the tests found that prose had been asserting

- **`splice`'s tie-break is alphabetical.** Where two columns of one parent are referenced,
  which relationship survives is decided by `sorted(foreign)`, not by `primary` — `EMAIL`
  beats a declared `STAFF_ID` because it sorts first. Preferring a referenced column over
  `SHOW PRIMARY KEYS` is the stated intent; the tie-break being alphabetical is stated
  nowhere. Asserted as-is, to make it visible rather than to bless it.
- **The invariant test was blind to half the invariant.** It compared the cast *source* and
  ignored the *target*, so mutating the rewrite to `AS VARCHAR` left every test green. It
  compares `(source, target)` pairs now, hand-scanned — `NUMBER(38,0)` contains the paren a
  `[^)]*` stops at.
- **The comment replacing a stale enumeration was itself wrong, twice.** First a grep that
  matched nothing (the deferring scripts aren't the ones with `snowflake` in the filename),
  then one keyed on `import snowflake` alone that would miss `from snowflake.connector import`.
  The version here was run.

## Deferred

- **`align_fk_types` decides recast direction one FK pair at a time.** A TEXT parent shared by
  a TEXT child and a NUMBER child: aligning the second pair rewrites the parent to NUMBER and
  silently breaks the first child's already-declarable relationship, printing `aligned 1
  columns` and nothing about the loss.
- **`infer_keys_spider2`'s `all(...)` short-circuits after a CREATE OR REPLACE has run.** A
  partly-lossy set leaves one table rewritten while the state recording it never executes, and
  the same table is rewritten again under the VARCHAR target. This one mangles data and is the
  more serious of the pair.
- **The probe's FLOAT rendering.** `TRY_CAST(TO_VARCHAR(x) AS NUMBER(38,0))` depends on
  Snowflake's FLOAT→VARCHAR staying re-parseable; a value large enough to render in exponent
  form would fail and leave the key undeclared. Strictly narrower than the bare `TRY_CAST`,
  which failed that way for *every* numeric source — but a real edge, and confirming it needs
  a live warehouse.

Local suite `2060 passed`, with the same six pre-existing environment failures main has.
