### PR TITLE
Decide both sides of a join before rewriting either

### DIFF
--- a/scripts/infer_keys_spider2.py
+++ b/scripts/infer_keys_spider2.py
@@ -89,21 +89,33 @@ def unique_non_null(cur, database: str, schema: str, table: str, column: str) ->
     return total > 0 and non_null == total and distinct == total
 
 
-def align_column(cur, database: str, schema: str, table: str, column: str, target: str) -> bool:
-    """Rebuild `table` with `column` cast to `target`, if the cast is lossless.
+def cast_is_lossless(
+    cur, database: str, schema: str, table: str, column: str, target: str
+) -> bool:
+    """True when casting `column` to `target` loses NOTHING. WRITES NOTHING itself.
+
+    Separate from the rewrite because the caller aligns TWO sides of a join and must know
+    both answers before touching either. When this was one function that probed and rewrote
+    together, `all(align_column(...) for s in sides)` short-circuited AFTER the first side's
+    CREATE OR REPLACE had already run: the lossy second side aborted the pair, the first
+    stayed rewritten, and the `types` entry recording it never executed -- so the next target
+    recomputed `sides` from the stale type and rewrote that same table a second time. A FLOAT
+    that had become NUMBER(38,0) was re-rendered as VARCHAR holding the NUMBER spelling
+    (1.0 -> 1 -> '1') while the other side kept its original text, so the pair still
+    mismatched and the printed count reported one column for two rewrites.
 
     SQLite stores integers and their text spellings interchangeably, so one side of a join
     lands as NUMBER and the other as TEXT. Snowflake refuses a FOREIGN KEY across a type
     mismatch, and a missing relationship is the difference between an answer and a refusal.
-    The cast is checked for loss first -- a column that does not convert cleanly is left
-    alone and its relationship is simply not declared.
+    A column that does not convert cleanly is left alone and its relationship is simply not
+    declared.
     """
     # TO_VARCHAR around every source. Snowflake's TRY_CAST takes a STRING expression, and a
     # numeric source reaches here whenever the two sides differ and neither is TEXT --
     # `_CHILD_TYPES` admits FLOAT/REAL/DOUBLE, so a FLOAT child against a NUMBER parent picks
-    # the FLOAT side for a NUMBER(38,0) target. The raise is swallowed by the caller's
-    # `except Exception: continue`, so the only visible effect is a foreign key that never
-    # gets declared, for a reason nothing prints.
+    # the FLOAT side for a NUMBER(38,0) target. `align_pairs` catches the raise and moves on
+    # to the text target, so the only visible effect is a foreign key that never gets
+    # declared, for a reason nothing prints.
     #
     # The sibling `align_fk_types_snowflake` was fixed for exactly this and this file was not:
     # the same defect in two places, corrected in one. It must match the projection below --
@@ -124,7 +136,18 @@ def align_column(cur, database: str, schema: str, table: str, column: str, targe
     # "cleanly" and silently change its values. An identifier has no fractional part.
     if target.startswith("NUMBER") and fractional:
         return False
+    return True
 
+
+def rewrite_column(
+    cur, database: str, schema: str, table: str, column: str, target: str
+) -> None:
+    """Rebuild `table` with `column` cast to `target`. CALL ONLY AFTER `cast_is_lossless`.
+
+    The cast expression MUST match the one that function probes with -- a probe certifying
+    `TRY_CAST(TO_VARCHAR(x) AS t)` while `TRY_CAST(x AS t)` executes has verified something
+    adjacent to what runs. `tests/test_infer_keys_align_column.py` compares the two.
+    """
     cur.execute(
         f"""SELECT column_name FROM {database}.INFORMATION_SCHEMA.COLUMNS
             WHERE table_schema = %s AND table_name = %s ORDER BY ordinal_position""",
@@ -139,6 +162,14 @@ def align_column(cur, database: str, schema: str, table: str, column: str, targe
         f'CREATE OR REPLACE TABLE {database}."{schema}"."{table}" AS '
         f'SELECT {projection} FROM {database}."{schema}"."{table}"'
     )
+
+
+def align_column(cur, database: str, schema: str, table: str, column: str, target: str) -> bool:
+    """Probe then rewrite, for a caller aligning ONE column. A caller aligning a PAIR must
+    use the two halves separately -- see `cast_is_lossless`."""
+    if not cast_is_lossless(cur, database, schema, table, column, target):
+        return False
+    rewrite_column(cur, database, schema, table, column, target)
     return True
 
 
@@ -178,6 +209,78 @@ def contained(
     if not non_null:
         return False
     return orphans / non_null <= max_orphan_rate
+
+
+def align_pairs(cur, database: str, schema: str, foreign: list[tuple], types: dict) -> int:
+    """Bring both sides of every mismatched join pair to one type. Returns columns rewritten.
+
+    DECIDE BOTH SIDES BEFORE WRITING EITHER. `align_column` probes and rewrites in one call,
+    so the earlier form -- `all(align_column(...) for s in sides)` -- short-circuited after
+    the first side's CREATE OR REPLACE had already run. The lossy second side then aborted
+    the pair with the first already rewritten, `types[s]` never recorded it, and the VARCHAR
+    pass recomputed `sides` from the stale type and rewrote that same table AGAIN: a FLOAT
+    that had become NUMBER(38,0) came back as VARCHAR holding the NUMBER spelling
+    (1.0 -> 1 -> '1') while the other side kept its original text. The pair still mismatched,
+    and `aligned` counted one column for two rewrites.
+
+    Extracted from `main` so that is reachable by a test. It was found by review and deferred
+    twice as needing a live warehouse, which stopped being true once the module could be
+    imported without the driver.
+
+    A rewrite that fails AFTER its probe passed still leaves the pair half-written. That is a
+    server error rather than a property of the data, and undoing it would need the original
+    types kept and a compensating rewrite. Not handled; the pair is ABANDONED rather than
+    retried against the next target, because retrying reselects the side already written.
+    """
+    aligned = 0
+    for child_table, child_column, parent_table, parent_column in foreign:
+        child_type = types.get((child_table, child_column))
+        parent_type = types.get((parent_table, parent_column))
+        if child_type == parent_type:
+            continue
+        # Bring both sides to one type: numeric where the values allow it, text otherwise.
+        # Whichever side already holds the target is left untouched.
+        for target, label in (("NUMBER(38,0)", "NUMBER"), ("VARCHAR", "TEXT")):
+            sides = [
+                s for s, t in (
+                    ((child_table, child_column), child_type),
+                    ((parent_table, parent_column), parent_type),
+                )
+                if t != label
+            ]
+            # TWO failure modes, and they must not share a handler. A PROBE raise has
+            # written nothing, so the text fallback is still worth trying; a REWRITE raise
+            # has half-written the pair, and `sides` is computed from the
+            # `child_type`/`parent_type` locals read before any write -- never from the
+            # updated `types` -- so trying the next target would reselect the side already
+            # written and re-render it. That is the same double rewrite the two-phase split
+            # removed from the short-circuit path, surviving on the exception path.
+            #
+            # One `try` around both gave the probe raise the rewrite raise's treatment and
+            # cost every such pair its VARCHAR fallback.
+            try:
+                lossless = all(
+                    cast_is_lossless(cur, database, schema, s[0], s[1], target)
+                    for s in sides
+                )
+            except Exception:
+                continue  # nothing written; the next target is still worth asking about
+            if not lossless:
+                continue
+            try:
+                for s in sides:
+                    rewrite_column(cur, database, schema, s[0], s[1], target)
+                    types[s] = label
+                    # Counted AS IT HAPPENS, not after the loop: a raise part-way through
+                    # skipped the whole increment, so a pair that half-wrote reported zero
+                    # and `main` printed no "(N columns retyped)" suffix at all -- the
+                    # operator's only sign that anything had been rebuilt.
+                    aligned += 1
+            except Exception:
+                break  # half-written; this pair is in a state this function cannot reason
+                       # about, and the remaining PAIRS still get their chance
+            break
+    return aligned
 
 
 def infer(cur, database: str, schema: str) -> tuple[list[tuple[str, str]], list[tuple]]:
@@ -297,33 +400,7 @@ def main() -> int:
                 for t, cols in fetch_columns(cur, args.database, schema).items()
                 for c, d in cols
             }
-            aligned = 0
-            for child_table, child_column, parent_table, parent_column in foreign:
-                child_type = types.get((child_table, child_column))
-                parent_type = types.get((parent_table, parent_column))
-                if child_type == parent_type:
-                    continue
-                # Bring both sides to one type: numeric where the values allow it, text
-                # otherwise. Whichever side already holds the target is left untouched.
-                for target, label in (("NUMBER(38,0)", "NUMBER"), ("VARCHAR", "TEXT")):
-                    sides = [
-                        s for s, t in (
-                            ((child_table, child_column), child_type),
-                            ((parent_table, parent_column), parent_type),
-                        )
-                        if t != label
-                    ]
-                    try:
-                        if all(
-                            align_column(cur, args.database, schema, s[0], s[1], target)
-                            for s in sides
-                        ):
-                            for s in sides:
-                                types[s] = label
-                            aligned += len(sides)
-                            break
-                    except Exception:
-                        continue
+            aligned = align_pairs(cur, args.database, schema, foreign, types)
 
             drop_existing(cur, args.database, schema)
             pk_done = 0

--- a/tests/test_infer_keys_align_pairs.py
+++ b/tests/test_infer_keys_align_pairs.py
@@ -1,0 +1,235 @@
+"""`align_pairs`, which rewrites live tables to make a join's two sides share a type.
+
+The defect this pins was found by review and deferred twice as needing a live warehouse. That
+stopped being true when the module's driver imports were deferred: a fake cursor drives it
+end to end, and the failure is a COUNT of CREATE OR REPLACE statements, not a value in
+Snowflake.
+
+The shape: `align_column` probes and rewrites in one call, so deciding a pair with
+`all(align_column(...) for s in sides)` short-circuits AFTER the first side is already
+rewritten. The lossy second side aborts the pair, `types[s]` never records the first, and the
+VARCHAR pass recomputes `sides` from the stale type and rewrites that same table again.
+"""
+
+from scripts.infer_keys_spider2 import align_pairs
+
+
+class FakeCursor:
+    """Answers the probe per-column and records every statement.
+
+    `lossless` maps (table, column, target) -> bool. Anything unlisted converts cleanly.
+    """
+
+    def __init__(self, columns=("ID",), lossless=None, raise_rewrite_of=None,
+                 raise_probe_of=None):
+        self.sql: list[str] = []
+        self._columns = columns
+        self._lossless = lossless or {}
+        # A table whose CREATE OR REPLACE raises -- the server-error path, distinct from a
+        # cast the probe already refused.
+        self._raise_rewrite_of = raise_rewrite_of
+        # A (table, target) whose PROBE raises. Nothing has been written when it does, which
+        # is why it must be handled differently from a failing rewrite.
+        self._raise_probe_of = raise_probe_of
+        self._pending: tuple | None = None
+
+    def execute(self, sql, params=None):
+        self.sql.append(sql)
+        if "CREATE OR REPLACE TABLE" in sql and self._raise_rewrite_of:
+            if f'"{self._raise_rewrite_of}"' in sql.split(" AS ")[0]:
+                raise RuntimeError("002003 (42S02): SQL compilation error")
+        if sql.lstrip().upper().startswith("SELECT COUNT("):
+            if self._raise_probe_of:
+                table, target = self._raise_probe_of
+                if f'"{table}"' in sql and f"AS {target})" in sql:
+                    raise RuntimeError("100038 (22018): numeric value not recognized")
+            self._pending = self._probe_reply(sql)
+
+    def _probe_reply(self, sql):
+        # (non_null, converted, fractional). A lossy column converts 7 of its 10 values.
+        for (table, column, target), ok in self._lossless.items():
+            # `AS {target})` and not bare `target`: VARCHAR is a substring of the
+            # `TO_VARCHAR(...)` that EVERY probe emits, so keying on the bare name would mark
+            # the NUMBER(38,0) probe lossy too and quietly exercise a different path.
+            if (f'"{table}"' in sql and f'"{column}"' in sql
+                    and f"AS {target})" in sql and not ok):
+                return (10, 7, 0)
+        return (10, 10, 0)
+
+    def fetchone(self):
+        return self._pending
+
+    def fetchall(self):
+        return [(c,) for c in self._columns]
+
+    # -- what the assertions read ---------------------------------------------------
+    @property
+    def rewrites(self) -> list[str]:
+        return [s for s in self.sql if "CREATE OR REPLACE TABLE" in s]
+
+    def rewrites_of(self, table: str) -> list[str]:
+        return [s for s in self.rewrites if f'"{table}"' in s]
+
+
+PAIR = [("CHILD", "ID", "PARENT", "ID")]
+TEXT_VS_NUMBER = {("CHILD", "ID"): "TEXT", ("PARENT", "ID"): "NUMBER"}
+
+
+def test_a_pair_that_converts_cleanly_is_aligned_once():
+    cur = FakeCursor()
+    types = dict(TEXT_VS_NUMBER)
+    assert align_pairs(cur, "DB", "SCH", PAIR, types) == 1
+    # Only the TEXT side needs moving; PARENT is already NUMBER.
+    assert len(cur.rewrites_of("CHILD")) == 1
+    assert cur.rewrites_of("PARENT") == []
+    assert types[("CHILD", "ID")] == "NUMBER"
+
+
+def test_both_sides_move_when_neither_holds_the_target():
+    """The function's PRIMARY case: two sides actually REWRITTEN in one pass.
+
+    Two other tests give `sides` length 2, but both abort at the probe, so before this one
+    the rewrite loop had never run with more than a single side. Mutating it to
+    `for s in sides[:1]:` leaves the pair still mismatched and its key undeclarable, and
+    every other test stays green.
+
+    TEXT against FLOAT: neither is NUMBER, so both are cast to NUMBER(38,0).
+    """
+    cur = FakeCursor()
+    types = {("CHILD", "ID"): "TEXT", ("PARENT", "ID"): "FLOAT"}
+    assert align_pairs(cur, "DB", "SCH", PAIR, types) == 2
+    assert len(cur.rewrites_of("CHILD")) == 1
+    assert len(cur.rewrites_of("PARENT")) == 1
+    assert types[("CHILD", "ID")] == types[("PARENT", "ID")] == "NUMBER"
+
+
+def test_the_rewrite_casts_to_the_target_the_probe_approved():
+    """Nothing asserted WHICH type the rewrite casts to. Passing a constant `"VARCHAR"` while
+    the probe still used `target` left the whole suite green -- the column would become
+    VARCHAR while `types` recorded NUMBER, against a NUMBER parent, which is the silent type
+    mismatch this script exists to remove."""
+    cur = FakeCursor()
+    types = dict(TEXT_VS_NUMBER)
+    align_pairs(cur, "DB", "SCH", PAIR, types)
+    rewrite = cur.rewrites_of("CHILD")[0]
+    assert "AS NUMBER(38,0))" in rewrite, rewrite
+    assert "AS VARCHAR)" not in rewrite, "cast to a type the probe never measured"
+
+
+def test_a_side_that_cannot_convert_leaves_BOTH_sides_untouched():
+    """The bug. Both sides need moving for the NUMBER target, the second is lossy, and the
+    first used to be rewritten before that was discovered."""
+    cur = FakeCursor(lossless={("PARENT", "ID", "NUMBER(38,0)"): False})
+    types = {("CHILD", "ID"): "TEXT", ("PARENT", "ID"): "FLOAT"}
+    align_pairs(cur, "DB", "SCH", PAIR, types)
+    number_rewrites = [s for s in cur.rewrites if "NUMBER(38,0)" in s]
+    assert number_rewrites == [], (
+        "a table was rewritten to NUMBER before the pair was known to convert"
+    )
+
+
+def test_no_table_is_ever_rewritten_twice():
+    """The consequence that corrupts data, and it needs a FLOAT child specifically.
+
+    A side is re-included in the VARCHAR pass only when its recorded type is not already
+    TEXT. So the double rewrite needs a side that (a) converts to NUMBER, (b) is aborted by
+    its partner, and (c) is not TEXT: a FLOAT child against a TEXT parent. The first draft of
+    this test had the types the other way round, and PASSED against the shipped bug -- CHILD
+    was TEXT, so the VARCHAR pass excluded it and nothing was rewritten twice.
+
+    Here CHILD goes FLOAT -> NUMBER(38,0) in the aborted pass, is not recorded, and is then
+    re-rendered as VARCHAR holding the NUMBER spelling (1.0 -> 1 -> '1') while PARENT keeps
+    its original text. The pair still mismatches, having been rewritten twice to get there.
+    """
+    cur = FakeCursor(lossless={("PARENT", "ID", "NUMBER(38,0)"): False})
+    types = {("CHILD", "ID"): "FLOAT", ("PARENT", "ID"): "TEXT"}
+    align_pairs(cur, "DB", "SCH", PAIR, types)
+    for table in ("CHILD", "PARENT"):
+        assert len(cur.rewrites_of(table)) <= 1, (
+            f"{table} was rewritten {len(cur.rewrites_of(table))} times: "
+            f"{cur.rewrites_of(table)}"
+        )
+
+
+def test_the_fallback_to_TEXT_still_works_when_NUMBER_is_refused():
+    """Refusing the numeric target must not lose the pair -- VARCHAR is the whole point of
+    the second iteration. Only PARENT moves, since CHILD is already TEXT."""
+    cur = FakeCursor(lossless={("PARENT", "ID", "NUMBER(38,0)"): False})
+    types = {("CHILD", "ID"): "TEXT", ("PARENT", "ID"): "FLOAT"}
+    assert align_pairs(cur, "DB", "SCH", PAIR, types) == 1
+    assert len(cur.rewrites_of("PARENT")) == 1
+    assert "VARCHAR" in cur.rewrites_of("PARENT")[0]
+    assert types[("PARENT", "ID")] == "TEXT"
+
+
+def test_a_rewrite_that_RAISES_abandons_the_pair_instead_of_retrying_it():
+    """The exception path, which the two-phase split did not close.
+
+    `sides` is computed from the `child_type`/`parent_type` locals read before any write,
+    never from the updated `types`. So continuing to the VARCHAR target after a rewrite
+    raised would reselect the side this pass had ALREADY rewritten and re-render it -- the
+    same double rewrite, surviving on a path the short-circuit fix did not touch.
+
+    FLOAT against DOUBLE: they DIFFER, so the pair is not skipped as already-agreeing, and
+    neither is NUMBER, so both are selected. Both probes pass, CHILD is rewritten, PARENT's
+    rewrite raises. With `continue` the VARCHAR pass reselects CHILD -- neither local says
+    TEXT -- and rewrites it again; with `break` the pair is abandoned and CHILD keeps its
+    single rewrite. (An earlier draft used FLOAT on both sides and never reached the loop at
+    all: equal types `continue` before any work.)
+    """
+    cur = FakeCursor(raise_rewrite_of="PARENT")
+    types = {("CHILD", "ID"): "FLOAT", ("PARENT", "ID"): "DOUBLE"}
+    aligned = align_pairs(cur, "DB", "SCH", PAIR, types)
+    # COUNTED AS IT HAPPENS. Adding `len(sides)` after the loop meant a raise part-way
+    # skipped the increment entirely, so a pair that half-wrote reported zero -- and `main`
+    # prints its "(N columns retyped)" suffix only when the count is non-zero, so the one
+    # table that HAD been rebuilt left no trace for the operator at all.
+    assert aligned == 1, f"a half-written pair reported {aligned} columns rebuilt"
+    assert len(cur.rewrites_of("CHILD")) == 1, (
+        f"CHILD was rewritten {len(cur.rewrites_of('CHILD'))} times after the pair failed: "
+        f"{cur.rewrites_of('CHILD')}"
+    )
+
+
+def test_a_PROBE_that_raises_still_falls_through_to_the_text_target():
+    """A probe raise has written NOTHING, so the pair has lost nothing and the text fallback
+    is still worth trying. Abandoning it there was a regression introduced by the fix for the
+    rewrite-raise case: one `try` around both gave the read-only probe the half-written
+    rewrite's treatment, and every pair whose NUMBER probe raised silently lost its VARCHAR
+    alignment -- a foreign key not declared, for a reason nothing prints.
+    """
+    cur = FakeCursor(raise_probe_of=("PARENT", "NUMBER(38,0)"))
+    types = {("CHILD", "ID"): "FLOAT", ("PARENT", "ID"): "DOUBLE"}
+    assert align_pairs(cur, "DB", "SCH", PAIR, types) == 2, "the pair lost its text fallback"
+    for table in ("CHILD", "PARENT"):
+        assert len(cur.rewrites_of(table)) == 1
+        assert "AS VARCHAR)" in cur.rewrites_of(table)[0]
+    assert types[("CHILD", "ID")] == types[("PARENT", "ID")] == "TEXT"
+
+
+def test_a_pair_whose_rewrite_raises_does_not_stop_the_pairs_after_it():
+    """Abandoning the PAIR must not abandon the run -- that is the whole reason the `except`
+    is inside the pair loop rather than around it."""
+    cur = FakeCursor(raise_rewrite_of="PARENT")
+    types = {("CHILD", "ID"): "FLOAT", ("PARENT", "ID"): "DOUBLE",
+             ("LATER", "ID"): "TEXT", ("OK", "ID"): "NUMBER"}
+    pairs = [("CHILD", "ID", "PARENT", "ID"), ("LATER", "ID", "OK", "ID")]
+    align_pairs(cur, "DB", "SCH", pairs, types)
+    assert len(cur.rewrites_of("LATER")) == 1, "a later pair was skipped"
+
+
+def test_a_pair_that_already_agrees_is_not_touched():
+    cur = FakeCursor()
+    types = {("CHILD", "ID"): "NUMBER", ("PARENT", "ID"): "NUMBER"}
+    assert align_pairs(cur, "DB", "SCH", PAIR, types) == 0
+    assert cur.rewrites == []
+
+
+def test_types_is_updated_so_a_later_pair_sees_the_new_type():
+    """`types` is the running record of what each column now holds. A second pair sharing a
+    column must not re-align it, which is exactly what the stale-entry bug caused."""
+    cur = FakeCursor()
+    types = {("CHILD", "ID"): "TEXT", ("PARENT", "ID"): "NUMBER", ("OTHER", "ID"): "NUMBER"}
+    pairs = [("CHILD", "ID", "PARENT", "ID"), ("CHILD", "ID", "OTHER", "ID")]
+    align_pairs(cur, "DB", "SCH", pairs, types)
+    assert len(cur.rewrites_of("CHILD")) == 1, "the second pair re-aligned an aligned column"


### PR DESCRIPTION
The data-mangling defect from the post-merge review of PR #1. I deferred it twice as
"needs a live warehouse" — that stopped being true when #31 deferred this module's driver
imports. A fake cursor drives the whole path now, and the failure is a **count of
`CREATE OR REPLACE` statements**, not a value in Snowflake. The reason for deferring had
expired; the finding had not.

## The defect

`align_column` probes and rewrites in one call, so deciding a pair with
`all(align_column(...) for s in sides)` short-circuits **after** the first side is already
rewritten. The lossy second side aborts the pair, `types[s]` never records the first, and the
VARCHAR pass recomputes `sides` from the stale type and rewrites that same table again:

```
CHILD  FLOAT ──NUMBER pass──▶ NUMBER(38,0)   (aborted by PARENT; not recorded)
       ──VARCHAR pass──▶ '1'                 (re-rendered from the NUMBER spelling)
PARENT TEXT  ── untouched ──▶ TEXT
```

The pair still mismatches, having been rewritten twice to get there, and `aligned` counts one
column for two rewrites.

## The fix

`cast_is_lossless` (writes nothing) and `rewrite_column` split apart, with `align_column`
composing them for the single-column caller. The pair path probes **both** sides, then writes
both. `align_pairs` is lifted out of `main` so it is reachable by a test at all — that
extraction is most of the diff.

Two failure modes are now handled separately, which took three rounds to get right:

| | |
|---|---|
| **probe raises** | nothing written → `continue` to the text target |
| **rewrite raises** | pair half-written → `break`; retrying would reselect the written side |

and `aligned` increments as each rewrite lands rather than summing after the loop — a raise
part-way used to skip the increment entirely, so a half-written pair reported zero and `main`
printed no `(N columns retyped)` suffix at all.

## Eleven tests, every one mutation-checked

Five mutations, each caught by its own test: rewrite only the first side; rewrite to a
constant target while the probe uses the real one; continue past a rewrite raise; break on a
probe raise; sum the count after the loop.

**Three of my own drafts passed against the bug they named**, and only running the mutation
caught it:

- the double-rewrite test first used a TEXT child — a TEXT side is excluded from the VARCHAR
  pass, so nothing is rewritten twice
- the exception test first used FLOAT on both sides — `child_type == parent_type` skips the
  pair before any work happens
- no test moved **both** sides through the rewrite loop until the mutation `for s in sides[:1]:`
  stayed green

## Not fixed, written down where the code is

A rewrite that fails after its probe passed still leaves a pair half-written. That is a server
error rather than a property of the data, and undoing it would need the original types kept
and a compensating rewrite.

Local suite `2071 passed`, with the same six pre-existing environment failures main has.
