### PR TITLE
Six red tests were two bugs, a wrong idiom, and a port that belongs to one machine

### DIFF
--- a/tests/acme_dsn.py
+++ b/tests/acme_dsn.py
@@ -1,0 +1,99 @@
+"""The ACME Postgres DSN, in one place.
+
+A module rather than a conftest helper, and not because conftest would not work -- measured,
+`from conftest import acme_dsn` resolves here, since pytest puts the test directory on
+`sys.path`. It is a module because an import naming the thing it imports is easier to follow
+than one naming the file pytest happens to load first, and because `requires_acme` below is a
+plain value rather than a fixture and has no reason to live in a fixture file.
+"""
+
+import os
+
+import pytest
+
+
+def acme_dsn() -> str:
+    """The ACME Postgres DSN, decided in ONE place and mirroring `docker-compose.yml`.
+
+    Fifteen occurrences across fifteen files, enumerated rather than counted: thirteen
+    spelling port 5433 and two spelling 5432. **5433 is not this project's port** --
+    `docker-compose.yml` declares `${MNEMIQ_PG_PORT:-5432}`. It is one machine, where another
+    project's Postgres took 5432 first and the operator recorded the override in `.env`.
+
+    The engine reads `os.environ` only (`Settings` says so), so a bare `pytest` never sees
+    that file and every module fell through to its literal: the thirteen on 5433 passed by
+    coincidence, and the two on 5432 reached the OTHER project's database and failed
+    authentication. Fixing THAT by moving the two to 5433 was the wrong direction, and a
+    review caught it -- it takes one machine's port collision for the project's truth.
+
+    Compose's own precedence: an explicit DSN, else a port override, else compose's declared
+    default.
+
+    ONLY THE FIRST LEVEL DECIDES ANYTHING A TEST SEES. `requires_acme` skips unless
+    MNEMIQ_PG_DSN is set, so a test that actually runs always took that branch. The other two
+    exist because `_DSN = acme_dsn()` sits at MODULE level in thirteen of the fifteen callers
+    and is evaluated at import, before a skip mark can apply -- so this has to return a string
+    rather than raise, or collection fails on a machine with no database. (The two exceptions
+    call it lazily inside a `_dsn()` helper, and they are exactly the two that historically
+    spelled 5432.) They document the project's port; they are not a working fallback, and
+    reading them as one is how this docstring first described them.
+    """
+    dsn = os.getenv("MNEMIQ_PG_DSN")
+    if dsn:
+        return dsn
+    port = os.getenv("MNEMIQ_PG_PORT", "5432")
+    return f"postgresql://mnemiq:mnemiq@localhost:{port}/acme"
+
+
+# EXPLICIT OPT-IN, matching what this project already does everywhere else it needs a live
+# database: `test_write_live` skips without MNEMIQ_PG_DSN, `test_oracle_adapter` skips without
+# MNEMIQ_ORACLE_TEST_DSN, and `conftest._seed_acme` no-ops without both its variables.
+#
+# The alternative -- try the compose default and let the connection fail -- is what these
+# modules did, and it produced seventeen red tests on a machine whose Postgres is not on the
+# default port. A red test means a defect; "no database here" is not one. Skipping says so,
+# and pytest prints the count, so the coverage is not silently lost either.
+requires_acme = pytest.mark.skipif(
+    not os.getenv("MNEMIQ_PG_DSN"),
+    reason="set MNEMIQ_PG_DSN to run the ACME Postgres tests (see .env / docker-compose.yml)",
+)
+
+
+# ACME has 29 tables and still does. The catalogue reports 32 because the ENGINE writes three
+# of its own into the same schema -- mnemiq_answer_log, mnemiq_eval_run, mnemiq_version -- so
+# they are introspected and reach the snapshot. `== 29` did not break because the dataset
+# grew, which is what the first version of this fix claimed. That the engine's tables are
+# introspected at all is a question about the engine, recorded rather than changed here.
+ACME_MIN_TABLES = 29
+
+# `'mnemiq%'`, NOT `'mnemiq\_%'`. Measured through this adapter: the underscore form returns
+# 32 and the plain form 29, so the backslash was read as a literal and the exclusion silently
+# did not happen. A backslash is not a LIKE escape without an ESCAPE clause here; whether any
+# given engine treats it as one is exactly the assumption that made this wrong, so the
+# predicate avoids needing to know. Nothing in ACME begins with "mnemiq".
+_NOT_ENGINE = "table_name NOT LIKE 'mnemiq%'"
+_PUBLIC = "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public'"
+
+
+def source_table_count(adapter) -> int:
+    """Every table in the attached catalogue's `public` schema, engine bookkeeping included.
+
+    SINGLE-ATTACH ONLY. The adapter's own reads also filter `table_catalog`, and this does
+    not: `DuckDBPostgresAdapter` attaches exactly one catalog so the two agree, but
+    `FederatedAdapter` attaches one per source into one connection, where this would sum
+    them. Every caller here is the single-source adapter; a federated caller would need the
+    catalogue name passed in.
+    """
+    return adapter.execute(_PUBLIC)[0][0]
+
+
+def assert_acme_seeded(adapter) -> None:
+    """A FLOOR on ACME's own tables, which asking the source alone cannot give.
+
+    Comparing a snapshot to the catalogue only proves they agree: a half-seeded ACME agrees
+    with itself and passes. The floor is what validates the FIXTURE, and it must EXCLUDE the
+    engine's three tables -- counting all 32 pads it by exactly three, so a fixture missing
+    three ACME tables would still clear a floor of 29, absorbing the case it exists to catch.
+    """
+    n = adapter.execute(f"{_PUBLIC} AND {_NOT_ENGINE}")[0][0]
+    assert n >= ACME_MIN_TABLES, f"ACME looks unseeded: {n} of its tables present"

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,14 +1,15 @@
-import os
 
 import pytest
 
+from acme_dsn import acme_dsn, requires_acme
+
 from mnemiq.adapters.duckdb_postgres import DuckDBPostgresAdapter
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, requires_acme]
 
 
 def _dsn():
-    return os.getenv("MNEMIQ_PG_DSN", "postgresql://mnemiq:mnemiq@localhost:5432/acme")
+    return acme_dsn()
 
 
 def test_introspect_sees_acme_tables():

--- a/tests/test_answer_live.py
+++ b/tests/test_answer_live.py
@@ -2,6 +2,8 @@ import os
 
 import pytest
 
+from acme_dsn import acme_dsn, requires_acme
+
 from mnemiq.adapters.duckdb_postgres import DuckDBPostgresAdapter
 from mnemiq.agent.budget import Budget
 from mnemiq.agent.loop import Agent
@@ -24,9 +26,10 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.live_llm,
     pytest.mark.skipif(not os.getenv("MNEMIQ_LLM_API_KEY"), reason="no live LLM configured"),
+    requires_acme,
 ]
 
-_DSN = "postgresql://mnemiq:mnemiq@localhost:5433/acme"
+_DSN = acme_dsn()
 
 
 class _StaticAuthz:

--- a/tests/test_ask_live.py
+++ b/tests/test_ask_live.py
@@ -2,6 +2,8 @@ import os
 
 import pytest
 
+from acme_dsn import acme_dsn, requires_acme
+
 from mnemiq.adapters.duckdb_postgres import DuckDBPostgresAdapter
 from mnemiq.authz.grants import GrantSet
 from mnemiq.config import Settings
@@ -22,9 +24,10 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.live_llm,
     pytest.mark.skipif(not os.getenv("MNEMIQ_LLM_API_KEY"), reason="no live LLM configured"),
+    requires_acme,
 ]
 
-_DSN = "postgresql://mnemiq:mnemiq@localhost:5433/acme"
+_DSN = acme_dsn()
 
 
 class _StaticAuthz:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -2,12 +2,19 @@ import os
 
 import pytest
 
+from acme_dsn import (
+    acme_dsn,
+    assert_acme_seeded,
+    requires_acme,
+    source_table_count,
+)
+
 from mnemiq.adapters.duckdb_postgres import DuckDBPostgresAdapter
 from mnemiq.catalog import introspect
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, requires_acme]
 
-_DSN = "postgresql://mnemiq:mnemiq@localhost:5433/acme"
+_DSN = acme_dsn()
 
 
 def _dsn():
@@ -15,8 +22,15 @@ def _dsn():
 
 
 def test_introspect_returns_tables_with_columns():
-    tables = introspect(DuckDBPostgresAdapter(_dsn()))
-    assert len(tables) == 29
+    adapter = DuckDBPostgresAdapter(_dsn())
+    tables = introspect(adapter)
+    # Against the SOURCE, not a frozen number. `== 29` broke when the catalogue reached 32,
+    # and a count that has to be edited whenever the schema changes fails on the one event
+    # that is not a defect. This still catches introspection dropping a table.
+    assert len(tables) == source_table_count(adapter)
+    # And the fixture is really seeded -- the equality above would pass on a half-seeded ACME
+    # agreeing with itself.
+    assert_acme_seeded(adapter)
     party = next(t for t in tables if t.name == "party")
     colnames = {c.name for c in party.columns}
     assert "party_type_code" in colnames  # from Party.csv header

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,10 +101,17 @@ def test_write_reports_a_refusal_and_exits_zero(monkeypatch, capsys):
     assert "may not write" in capsys.readouterr().out
 
 
-def test_cmd_enrich_lazy_imports_resolve(capsys):
+def test_cmd_enrich_lazy_imports_resolve(capsys, monkeypatch):
     # Regression (plan-29): _cmd_enrich's import block runs BEFORE the pg_dsn check, so a
     # no-DSN Settings still exercises every lazy import. Folding bird_runner._flag into
     # settings.enrich_facts/examples broke `import _flag` here until enrich was updated.
+    #
+    # The DSN is cleared explicitly. `Settings()` reads `os.environ`, so this unit test
+    # depended on MNEMIQ_PG_DSN being ABSENT from the shell -- with it exported, the check
+    # this test is built on passes, execution falls through to the LLM check, and the test
+    # fails with "LLM base_url/api_key not configured" for a reason that has nothing to do
+    # with lazy imports. A test whose premise is that a setting is missing has to remove it.
+    monkeypatch.delenv("MNEMIQ_PG_DSN", raising=False)
     from mnemiq.cli import _cmd_enrich
     from mnemiq.config import Settings
     assert _cmd_enrich(Settings()) == 1  # no pg_dsn -> 1, but only after imports resolve

--- a/tests/test_decide.py
+++ b/tests/test_decide.py
@@ -2,12 +2,14 @@ import os
 
 import pytest
 
+from acme_dsn import acme_dsn, requires_acme
+
 from mnemiq.sql.decide import decide
 from mnemiq.sql.verdict import Approved, Refusal, RefusalCode
 
 VISIBLE = {"claim": {"claim_identifier", "claim_open_date"}, "policy": {"policy_identifier"}}
 
-_DSN = "postgresql://mnemiq:mnemiq@localhost:5433/acme"
+_DSN = acme_dsn()
 
 
 def test_an_approved_query_carries_both_dialects_and_its_references():
@@ -63,6 +65,7 @@ def test_transpiling_targets_the_source_dialect():
 
 
 @pytest.mark.integration
+@requires_acme
 def test_explain_proves_the_query_against_the_real_source():
     from mnemiq.adapters.duckdb_postgres import DuckDBPostgresAdapter
 
@@ -76,6 +79,7 @@ def test_explain_proves_the_query_against_the_real_source():
 
 
 @pytest.mark.integration
+@requires_acme
 def test_a_query_the_snapshot_believes_but_the_source_denies_is_refused():
     # the snapshot says claim.ghost_column exists; the source disagrees. Only EXPLAIN knows.
     from mnemiq.adapters.duckdb_postgres import DuckDBPostgresAdapter

--- a/tests/test_enrich_acme_live.py
+++ b/tests/test_enrich_acme_live.py
@@ -3,6 +3,8 @@ import re
 
 import pytest
 
+from acme_dsn import acme_dsn, requires_acme
+
 from mnemiq.adapters.duckdb_postgres import DuckDBPostgresAdapter
 from mnemiq.config import Settings
 from mnemiq.enrichment.enricher import LLMEnricher
@@ -14,9 +16,10 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.live_llm,
     pytest.mark.skipif(not os.getenv("MNEMIQ_LLM_API_KEY"), reason="no live LLM configured"),
+    requires_acme,
 ]
 
-_DSN = "postgresql://mnemiq:mnemiq@localhost:5433/acme"
+_DSN = acme_dsn()
 
 
 def test_live_enrichment_gives_acme_its_meaning():

--- a/tests/test_enrich_structural.py
+++ b/tests/test_enrich_structural.py
@@ -2,14 +2,21 @@ import os
 
 import pytest
 
+from acme_dsn import (
+    acme_dsn,
+    assert_acme_seeded,
+    requires_acme,
+    source_table_count,
+)
+
 from mnemiq.adapters.duckdb_postgres import DuckDBPostgresAdapter
 from mnemiq.enrichment.pipeline import enrich_structural
 from mnemiq.store.bootstrap import init_store
 from mnemiq.store.snapshot_store import current_version, load_snapshot, save_snapshot
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, requires_acme]
 
-_DSN = "postgresql://mnemiq:mnemiq@localhost:5433/acme"
+_DSN = acme_dsn()
 
 
 def _adapter():
@@ -22,8 +29,16 @@ def snap():
 
 
 def test_pipeline_covers_the_whole_source(snap):
-    assert len(snap.source_bindings) == 29
-    assert len(snap.columns) > 29
+    adapter = _adapter()
+    # One binding per table the SOURCE has, which is what "covers the whole source" means.
+    # It was `== 29` against a catalogue that now reports 32.
+    # FIRST, so an unseeded database says so. Reached with MNEMIQ_PG_DSN set and nothing
+    # seeded -- a supported state, since `conftest._seed_acme` no-ops without the CSV
+    # directory -- a later `0 > 0` fails with a bare AssertionError instead.
+    assert_acme_seeded(adapter)
+    tables = source_table_count(adapter)
+    assert len(snap.source_bindings) == tables
+    assert len(snap.columns) > tables
     assert snap.relationships, "ACME has foreign keys"
     assert all(j.status in {"done", "failed"} for j in snap.jobs)
 

--- a/tests/test_eval_live.py
+++ b/tests/test_eval_live.py
@@ -2,6 +2,8 @@ import os
 
 import pytest
 
+from acme_dsn import acme_dsn, requires_acme
+
 from mnemiq.adapters.duckdb_postgres import DuckDBPostgresAdapter
 from mnemiq.config import Settings
 from mnemiq.enrichment.enricher import LLMEnricher
@@ -17,9 +19,10 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.live_llm,
     pytest.mark.skipif(not os.getenv("MNEMIQ_LLM_API_KEY"), reason="no live LLM configured"),
+    requires_acme,
 ]
 
-_DSN = "postgresql://mnemiq:mnemiq@localhost:5433/acme"
+_DSN = acme_dsn()
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -3,12 +3,14 @@ import os
 import pyarrow as pa
 import pytest
 
+from acme_dsn import acme_dsn, requires_acme
+
 from mnemiq.adapters.duckdb_postgres import DuckDBPostgresAdapter
 from mnemiq.execute.runner import ExecutionError, run
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, requires_acme]
 
-_DSN = "postgresql://mnemiq:mnemiq@localhost:5433/acme"
+_DSN = acme_dsn()
 
 
 def _adapter():

--- a/tests/test_golden_set.py
+++ b/tests/test_golden_set.py
@@ -2,10 +2,12 @@ import os
 
 import pytest
 
+from acme_dsn import acme_dsn, requires_acme
+
 from mnemiq.adapters.duckdb_postgres import DuckDBPostgresAdapter
 from mnemiq.eval.golden import load_cases
 
-_DSN = "postgresql://mnemiq:mnemiq@localhost:5433/acme"
+_DSN = acme_dsn()
 _PATH = "evals/acme.json"
 
 
@@ -29,6 +31,7 @@ def test_answerable_cases_have_gold_sql_and_unanswerable_ones_do_not():
 
 
 @pytest.mark.integration
+@requires_acme
 def test_every_gold_query_runs_and_returns_rows():
     """Ground truth must actually be true. A golden set nobody ran is a wish list."""
     adapter = DuckDBPostgresAdapter(os.getenv("MNEMIQ_PG_DSN", _DSN))

--- a/tests/test_modes_live.py
+++ b/tests/test_modes_live.py
@@ -6,6 +6,8 @@ import os
 
 import pytest
 
+from acme_dsn import acme_dsn, requires_acme
+
 from mnemiq.adapters.duckdb_postgres import DuckDBPostgresAdapter
 from mnemiq.config import Settings
 from mnemiq.contract import IdentityContext
@@ -24,9 +26,10 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.live_llm,
     pytest.mark.skipif(not os.getenv("MNEMIQ_LLM_API_KEY"), reason="no live LLM configured"),
+    requires_acme,
 ]
 
-_DSN = "postgresql://mnemiq:mnemiq@localhost:5433/acme"
+_DSN = acme_dsn()
 
 
 def _identity():

--- a/tests/test_pg_foreign_keys.py
+++ b/tests/test_pg_foreign_keys.py
@@ -2,11 +2,13 @@ import os
 
 import pytest
 
+from acme_dsn import acme_dsn, requires_acme
+
 from mnemiq.adapters.duckdb_postgres import DuckDBPostgresAdapter
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, requires_acme]
 
-_DSN = "postgresql://mnemiq:mnemiq@localhost:5433/acme"
+_DSN = acme_dsn()
 
 
 def test_foreign_keys_runs_and_returns_a_list():

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -2,13 +2,15 @@ import os
 
 import pytest
 
+from acme_dsn import acme_dsn, requires_acme
+
 from mnemiq.adapters.duckdb_postgres import DuckDBPostgresAdapter
 from mnemiq.catalog import introspect
 from mnemiq.enrichment.profiling import profile_column, profile_table
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, requires_acme]
 
-_DSN = "postgresql://mnemiq:mnemiq@localhost:5433/acme"
+_DSN = acme_dsn()
 
 
 def _adapter():

--- a/tests/test_retrieval_live.py
+++ b/tests/test_retrieval_live.py
@@ -2,6 +2,8 @@ import os
 
 import pytest
 
+from acme_dsn import acme_dsn, requires_acme
+
 from mnemiq.adapters.duckdb_postgres import DuckDBPostgresAdapter
 from mnemiq.authz.grants import GrantSet
 from mnemiq.config import Settings
@@ -19,9 +21,10 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.live_llm,
     pytest.mark.skipif(not os.getenv("MNEMIQ_LLM_API_KEY"), reason="no live LLM configured"),
+    requires_acme,
 ]
 
-_DSN = "postgresql://mnemiq:mnemiq@localhost:5433/acme"
+_DSN = acme_dsn()
 
 
 class _StaticAuthz:

--- a/tests/test_seed_acme.py
+++ b/tests/test_seed_acme.py
@@ -2,17 +2,25 @@ import os
 
 import pytest
 
+from acme_dsn import acme_dsn, requires_acme
+
 from scripts.seed_acme import seed
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, requires_acme]
 
 
 def _dsn():
-    return os.getenv("MNEMIQ_PG_DSN", "postgresql://mnemiq:mnemiq@localhost:5432/acme")
+    return acme_dsn()
 
 
 def test_seed_loads_party_rows():
-    data_dir = os.environ["MNEMIQ_ACME_DATA_DIR"]  # .../ACME_Insurance
+    # SKIP, not KeyError. `conftest._seed_acme` already treats this var as optional -- it
+    # no-ops unless both it and MNEMIQ_PG_DSN are set -- so a checkout with Postgres running
+    # and no CSV directory is a supported state, and this was the one place that turned it
+    # into a red test. Six failures in the local suite is how a seventh goes unnoticed.
+    data_dir = os.getenv("MNEMIQ_ACME_DATA_DIR")  # .../ACME_Insurance
+    if not data_dir:
+        pytest.skip("set MNEMIQ_ACME_DATA_DIR to the ACME CSV directory to run the seed test")
     counts = seed(_dsn(), data_dir)
     assert len(counts) == 29  # all 29 CSVs load (13 typed from DDL + 16 inferred)
     assert counts["party"] == 30  # Party.csv has 30 data rows (inferred table)

--- a/tests/test_write_live.py
+++ b/tests/test_write_live.py
@@ -7,6 +7,7 @@ import pytest
 
 from mnemiq.adapters.duckdb import DuckDBPostgresAdapter
 from mnemiq.authz.grants import GrantSet
+from mnemiq.config import Settings
 from mnemiq.contract import Column, IdentityContext, Snapshot
 from mnemiq.runtime import Runtime
 
@@ -36,8 +37,16 @@ def test_write_inserts_a_row_end_to_end():
             Column(id=f"{_TABLE}.id", object_id=_TABLE, name="id"),
             Column(id=f"{_TABLE}.note", object_id=_TABLE, name="note"),
         ])
+        # SETTINGS WITH WRITES ENABLED, not None. `Runtime.write` passes
+        # `writes_enabled=bool(self.settings and self.settings.write_enabled)` to the decider
+        # (M3: the deployment switch reaches the decider so a disabled deployment refuses in
+        # our vocabulary). With `settings=None` that is always False, so this test could not
+        # pass -- and nothing noticed, because it is gated on MNEMIQ_PG_DSN and that gate had
+        # never been opened in a local run. Written, and broken the moment it ran.
         rt = Runtime(con=None, snapshot=snap, adapter=DuckDBPostgresAdapter(dsn, read_only=False),
-                     agent=None, embedder=None, authz=_WriteAuthz(_TABLE), settings=None)
+                     agent=None, embedder=None, authz=_WriteAuthz(_TABLE),
+                     settings=Settings(llm_base_url="x", llm_api_key="k", llm_model="m",
+                                       pg_dsn=dsn, write_enabled=True))
         identity = IdentityContext(tenant_id="t", principal_id="u", roles=["writer"])
 
         res = rt.write(f"INSERT INTO {_TABLE} (id, note) VALUES (1, 'hello')", identity)


### PR DESCRIPTION
The local suite ran **six red** for long enough that a seventh went unnoticed inside one
session: a timing assertion in `test_function_inventory` went red under load and read as one
of the six. That is what a permanently-red suite costs.

## The six

| | |
|---|---|
| `test_adapter` (3) | defaulted to port **5432**, where another project's Postgres lives on this machine — wrong database, failed auth |
| `test_seed_acme` (1) | `os.environ[...]` on a variable `conftest._seed_acme` already treats as **optional** |
| `test_catalog`, `test_enrich_structural` (2) | frozen `== 29` against a catalogue now reporting 32 |

## My first fix was wrong, and the review caught it

I read `docker ps`, saw Postgres on 5433, saw eleven modules hardcoding 5433, and moved the
other two to match. But `docker-compose.yml` declares `${MNEMIQ_PG_PORT:-5432}` — **5432 is
this project's port.** 5433 is one machine where another project took 5432 first and the
operator recorded the override in `.env`. The thirteen were the bug; the two were right.

I had inferred the project's truth from local runtime state and then spread it further.

The DSN now lives in `tests/acme_dsn.py` with compose's own precedence. Fifteen occurrences
across fifteen files are gone — *enumerated*, after a `wc -l` in my commit message said
sixteen.

## ACME did not grow either

Also wrong in my first draft. ACME still has 29 tables. The catalogue reports 32 because the
**engine writes three of its own into the same schema** — `mnemiq_answer_log`,
`mnemiq_eval_run`, `mnemiq_version`. They are introspected and reach the snapshot, which is a
question about the engine and is recorded here rather than changed.

The counts ask the source instead, so `test_pipeline_covers_the_whole_source` finally tests
what its name says: one binding per table. Mutating `introspect` to drop a table turns both
files red.

**A floor is kept alongside**, because asking the database alone lost what the frozen number
had — it validated the *fixture*. A half-seeded ACME agrees with itself and passes an
equality against its own catalogue. The floor counts ACME's tables **only**: counting all 32
padded it by exactly three, so a fixture missing three ACME tables would still clear a floor
of 29 — absorbing the case it exists to catch. Demonstrated both ways: drop the exclusion and
a floor of 30 passes against 32; restore it and the same floor fails with *"ACME looks
unseeded: 29 of its tables present"*.

## Skip, don't fail, when there is no database

Matching what this project already does everywhere else it needs one — `test_write_live`,
`test_oracle_adapter`, `conftest._seed_acme` all gate on an explicit variable. Trying a
default and letting the connection fail is what produced **seventeen** red tests once the
default was right for the project rather than for this machine. A red test means a defect;
"no database here" is not one.

The gate is **per-test** in `test_decide` and `test_golden_set`: those two have no
module-level `integration` mark, so only their Postgres tests carry one and the rest run in
CI. A module gate would have skipped those too.

## Two pre-existing failures surfaced, both failing identically on `main`

- **`test_cmd_enrich_lazy_imports_resolve`** is a *unit* test reading ambient environment.
  `Settings()` reads `os.environ`, so its premise — no DSN configured — held only in an
  unconfigured shell. It clears the variable now.
- **`test_write_inserts_a_row_end_to_end`** passed `settings=None` while `Runtime.write`
  computes `writes_enabled=bool(self.settings and self.settings.write_enabled)`. Always
  False, so **the test could not pass** — and nothing noticed, because it is gated on
  `MNEMIQ_PG_DSN` and that gate had never been opened locally.

## Measured, not assumed

| configuration | result |
|---|---|
| CI's selection (`-m "not integration and not live_llm"`) | `2049 passed, 59 deselected` — **identical on `origin/main`** |
| bare `pytest` | `2049 passed, 60 skipped` |
| `MNEMIQ_PG_DSN` exported | `2087 passed, 22 skipped` |

One method note worth carrying: a mutation restored with `cp` can leave Python running **stale
bytecode**. `.pyc` invalidation keys on the source's (mtime-seconds, size), and
`ACME_MIN_TABLES = 29` → `30` is the same length — so a mutate-and-restore inside one second
reused the cached module and the restored file reported the *mutated* result. Both floor
checks were re-run under `PYTHONDONTWRITEBYTECODE=1`.
