### PR TITLE
Aligning one foreign key silently broke the siblings sharing its parent

### DIFF
--- a/scripts/add_keys_snowflake.py
+++ b/scripts/add_keys_snowflake.py
@@ -25,6 +25,7 @@ import sys
 import snowflake.connector
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from exc_reason import reason  # noqa: E402
 from bird_to_parquet import _INTERNAL_PREFIXES, sqlite_dbs  # noqa: E402
 
 _DEFAULT_MINIDEV = os.environ.get(
@@ -98,7 +99,7 @@ def main() -> int:
             cur.execute(sql)
             return True
         except Exception as exc:
-            skipped.append(f"{sql[:90]}... -> {str(exc).splitlines()[-1][:80]}")
+            skipped.append(f"{sql[:90]}... -> {reason(exc, 80)}")
             return False
 
     total_pk = total_fk = 0

--- a/scripts/add_relationships_spider2.py
+++ b/scripts/add_relationships_spider2.py
@@ -19,7 +19,11 @@ from __future__ import annotations
 import argparse
 import os
 import re
+import sys
 from collections import defaultdict
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from exc_reason import reason  # noqa: E402
 
 
 def declared_keys(cur, database: str) -> tuple[dict, dict]:
@@ -184,7 +188,7 @@ def main() -> int:
             try:
                 cur.execute(patched)
             except Exception as exc:
-                print(f"{schema:30} {'FAILED':>13}  {str(exc).splitlines()[-1][:90]}")
+                print(f"{schema:30} {'FAILED':>13}  {reason(exc, 90)}")
                 continue
             changed += 1
             print(f"{schema:30} {count:13}")

--- a/scripts/align_fk_types_snowflake.py
+++ b/scripts/align_fk_types_snowflake.py
@@ -16,9 +16,8 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import sys
-
-import snowflake.connector
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
@@ -44,6 +43,242 @@ def column_types(cur, database: str, schema: str) -> dict[tuple[str, str], str]:
     return out
 
 
+def _numeric(t: str) -> bool:
+    return t.startswith(("NUMBER", "FLOAT", "INT"))
+
+
+_NUMERIC_ORDER = ("NUMBER", "DECIMAL", "NUMERIC", "INT", "FLOAT", "DOUBLE", "REAL")
+
+
+def _numeric_rank(t: str) -> tuple[int, int, int, str]:
+    """Order numeric candidates deterministically, WIDEST first within a family.
+
+    A key is an identifier, so the integer families outrank the floating ones -- the same
+    reason the loss probe rejects a fractional column.
+
+    Within a family the tie-break is the declared precision and scale, NOT the rendered
+    string. A plain string compare put `NUMBER(10,0)` before `NUMBER(38,0)` because "1" sorts
+    before "3", so a 38-digit parent was NARROWED to ten digits -- and against `NUMBER(9,0)`
+    the same compare widened instead, the direction flipping on the first character of the
+    digit count. Widening cannot lose a value; narrowing can, and would be caught only by the
+    loss probe refusing the whole component.
+    """
+    digits = re.findall(r"\d+", t)
+    precision = int(digits[0]) if digits else 0
+    scale = int(digits[1]) if len(digits) > 1 else 0
+    for rank, prefix in enumerate(_NUMERIC_ORDER):
+        if t.startswith(prefix):
+            return (rank, -precision, -scale, t)
+    return (len(_NUMERIC_ORDER), -precision, -scale, t)
+
+
+def plan_recasts(
+    foreign: list[tuple], types: dict[tuple[str, str], str]
+) -> list[dict[str, dict[str, str]]]:
+    """One target type per CONNECTED COMPONENT of columns, one entry per component.
+
+    Each entry is `{table: {column: target}}` -- the tables that component touches. The
+    caller must treat an entry as ALL OR NOTHING: rewriting some of a component's tables and
+    skipping another leaves exactly the split this function exists to prevent.
+
+    Foreign keys chain, so the unit is the component and not the pair or even the parent
+    group. Deciding a pair at a time destroyed relationships that were already declarable:
+    with `P.K` TEXT, `C1.K` TEXT and `C2.K` NUMBER the C1/P pair agrees and is skipped, then
+    C2 moves `P.K` to NUMBER and C1 is left TEXT against a NUMBER parent -- its FOREIGN KEY
+    no longer declarable, and `aligned 1 columns` printed with nothing said about it.
+
+    GROUPING BY PARENT ONLY MOVED THAT ONE LEVEL DOWN, which a review caught before it
+    shipped: a column that moves as a child did not carry ITS children. On the chain
+    G1/G2/G3 -> C -> P, the parent group moved C to NUMBER while C's own group read C's
+    ORIGINAL text type and left all three grandchildren behind -- three relationships broken
+    where the pair rule had broken one. Union-find over the columns is what actually closes
+    it: every column reachable through a key ends at the same type.
+
+    An id is a number, so a component holding any numeric member goes numeric rather than
+    degrading every side to text; an all-text component is left alone, since casting text to
+    text rewrites tables to change nothing. Where a component holds several numeric types the
+    choice is `_numeric_rank`, not input order -- one of those relationships loses whatever we
+    do, because a column holds one type, and it must at least lose reproducibly.
+
+    Pure: reads the type map, returns a plan. `main` executes it.
+    """
+    root: dict[tuple[str, str], tuple[str, str]] = {}
+
+    def find(x):
+        root.setdefault(x, x)
+        while root[x] != x:
+            root[x] = root[root[x]]
+            x = root[x]
+        return x
+
+    def union(a, b):
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            # Smaller key as the root. This does NOT affect the plan and no test can catch
+            # it -- components are disjoint sets of (table, column), so membership and every
+            # target are the same whichever end wins, and a mutation to `root[ra] = rb` keeps
+            # the suite green. Kept because a stable component id is easier to read in a
+            # debugger, not because the output depends on it.
+            root[max(ra, rb)] = min(ra, rb)
+
+    for table, column, ref_table, ref_column in foreign:
+        child = (table.upper(), column.upper())
+        parent = (ref_table.upper(), ref_column.upper())
+        # A key naming a column the schema does not have is a stale tables.json entry.
+        # Inventing a type for it would rewrite the wrong column.
+        if child in types and parent in types:
+            union(child, parent)
+
+    components: dict[tuple[str, str], list[tuple[str, str]]] = {}
+    for key in root:
+        components.setdefault(find(key), []).append(key)
+
+    plan: list[dict[str, dict[str, str]]] = []
+    for members in (sorted(components[r]) for r in sorted(components)):
+        numeric = sorted((types[k] for k in members if _numeric(types[k])), key=_numeric_rank)
+        if not numeric:
+            continue
+        target = numeric[0]
+        moves: dict[str, dict[str, str]] = {}
+        for table, column in members:
+            if types[(table, column)] != target:
+                moves.setdefault(table, {})[column] = target
+        if moves:
+            plan.append(moves)
+    return plan
+
+
+def probe_component(cur, database: str, schema: str, component: dict) -> list[str]:
+    """Why this component cannot be rewritten losslessly, or [] if it can. WRITES NOTHING.
+
+    ALL OR NOTHING, at COMPONENT scale. The probe used to run per table and skip that one
+    table, which split the component it was protecting: with `P.K` TEXT, `C1.K` TEXT and
+    `C2.K` NUMBER the plan moves both `P` and `C1` to NUMBER, so a `P` that fails the probe --
+    the population this script exists for, text columns holding the values that violate the
+    numeric type -- left `C1` rewritten to NUMBER against a still-TEXT parent. `C1` and `P`
+    AGREED before the run. The operator saw "C1: K -> parent types" and "SKIPPED ... P" with
+    nothing connecting them.
+
+    The sibling states the discipline for the pair case -- "DECIDE BOTH SIDES BEFORE WRITING
+    EITHER" in `infer_keys_spider2.align_pairs` -- and a component needs it at its own scale.
+
+    TO_VARCHAR on every source, and it MUST match the rewrite's expression: a probe certifying
+    `TRY_CAST(TO_VARCHAR(x) AS t)` while `TRY_CAST(x AS t)` runs has verified something
+    adjacent to what executes. A numeric source reaches here whenever two sides are both
+    numeric and unequal, and Snowflake's TRY_CAST does not accept one.
+
+    Every probe is inside the try: a safety check must not be the thing that stops the run.
+    An unreadable probe means this component cannot be SHOWN to convert, which is a reason to
+    leave it alone and say so.
+    """
+    lossy: list[str] = []
+    for table, columns in sorted(component.items()):
+        for name, target in sorted(columns.items()):
+            try:
+                cur.execute(
+                    f'SELECT COUNT("{name}"), '
+                    f'COUNT(TRY_CAST(TO_VARCHAR("{name}") AS {target})), '
+                    f'COUNT_IF(TRY_CAST(TO_VARCHAR("{name}") AS FLOAT) IS NOT NULL AND '
+                    f'  TRY_CAST(TO_VARCHAR("{name}") AS FLOAT) '
+                    f'  <> TRUNC(TRY_CAST(TO_VARCHAR("{name}") AS FLOAT))) '
+                    f'FROM {database}.{schema}."{table}"'
+                )
+                non_null, converted, fractional = cur.fetchone()
+            except Exception as exc:
+                lossy.append(f"{table}.{name} (probe failed: {str(exc).splitlines()[-1][:50]})")
+                continue
+            if non_null != converted:
+                lossy.append(f"{table}.{name} ({non_null - converted} would become NULL)")
+            elif target.upper().startswith("NUMBER") and fractional:
+                lossy.append(f"{table}.{name} ({fractional} fractional, TRY_CAST would round)")
+    return lossy
+
+
+def _reason(exc: Exception) -> str:
+    """One short line from an exception, safely.
+
+    `str(exc).splitlines()[-1]` raises IndexError on an empty message -- `"".splitlines()` is
+    `[]` -- and every use of that idiom here sits inside a handler whose whole purpose is to
+    stop a failure from ending the run. The IndexError would propagate past both loops and do
+    exactly that.
+    """
+    lines = str(exc).splitlines()
+    return (lines[-1] if lines else exc.__class__.__name__)[:70]
+
+
+def apply_component(cur, database: str, schema: str, component: dict) -> dict:
+    """Rewrite a whole component. Returns what happened: written / failed / unattempted.
+
+    Extracted from `main` so the hoist and the split report are reachable by a test -- the
+    property the read hoist establishes lives HERE, not in `build_rewrites`, which issues only
+    a SELECT and so can never be caught writing early by any test of its own.
+
+    ALL READS BEFORE ANY WRITE. The column read used to sit inside the write loop and outside
+    any `try`, so failing on the second table -- after the first was rewritten -- escaped every
+    loop and ended the run.
+
+    Snowflake commits DDL as it runs and CREATE OR REPLACE cannot be rolled back, so a write
+    failing part-way leaves the component inconsistent and nothing here can undo it. Both the
+    tables already rewritten AND the ones never attempted now disagree, and the caller is told
+    all three sets.
+    """
+    try:
+        rewrites = build_rewrites(cur, database, schema, component)
+    except Exception as exc:
+        return {"unreadable": _reason(exc), "written": [], "failed": None, "unattempted": []}
+
+    written: list[str] = []
+    for i, (table, sql, columns) in enumerate(rewrites):
+        try:
+            cur.execute(sql)
+            written.append((table, columns))
+        except Exception as exc:
+            return {
+                "unreadable": None,
+                "written": written,
+                "failed": (table, _reason(exc)),
+                # Everything after the failure is never attempted, and disagrees with what
+                # WAS rewritten just as much as the failed table does. Naming only the failure
+                # reads as one unlucky rewrite.
+                "unattempted": [t for t, _, _ in rewrites[i + 1:]],
+            }
+    return {"unreadable": None, "written": written, "failed": None, "unattempted": []}
+
+
+def build_rewrites(cur, database: str, schema: str, component: dict) -> list[tuple]:
+    """Every `CREATE OR REPLACE` this component needs, as (table, sql, columns). READS ONLY.
+
+    Built for the WHOLE component before any of it is executed. The column list came from
+    `INFORMATION_SCHEMA` inside the write loop and outside any `try`, so a read that failed on
+    the second table -- after the first was already rewritten -- did not merely split the
+    component: it escaped every loop and ended the run, leaving the remaining schemas
+    unprocessed too. Reading first costs nothing when it fails.
+
+    The projection casts through TO_VARCHAR and MUST match what `probe_component` measured; a
+    probe certifying one expression while another executes has verified something adjacent to
+    what runs.
+    """
+    rewrites = []
+    for table, columns in sorted(component.items()):
+        cur.execute(
+            f"""SELECT column_name FROM {database}.INFORMATION_SCHEMA.COLUMNS
+                WHERE table_schema = '{schema}' AND table_name = '{table}'
+                ORDER BY ordinal_position"""
+        )
+        names = [r[0] for r in cur.fetchall()]
+        projection = ", ".join(
+            f'TRY_CAST(TO_VARCHAR("{n}") AS {columns[n]}) AS "{n}"' if n in columns else f'"{n}"'
+            for n in names
+        )
+        rewrites.append((
+            table,
+            f'CREATE OR REPLACE TABLE {database}.{schema}."{table}" AS '
+            f'SELECT {projection} FROM {database}.{schema}."{table}"',
+            columns,
+        ))
+    return rewrites
+
+
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--spider", default=_DEFAULT_SPIDER)
@@ -56,11 +291,15 @@ def main() -> int:
     keys = load_keys(root)
     wanted = sorted({c.db_id for c in load_spider(root)})
 
+    # Deferred so `plan_recasts` above can be imported and tested without the warehouse
+    # extra, the convention `tests/test_ddl_translate.py` sets.
+    import snowflake.connector
+
     con = snowflake.connector.connect(connection_name=args.connection)
     cur = con.cursor()
     cur.execute(f"USE WAREHOUSE {args.warehouse}")
 
-    aligned, failed, skipped = 0, [], []
+    aligned, failed, skipped, split, unreadable = 0, [], [], [], []
     try:
         for db_id in wanted:
             schema = db_id.upper()
@@ -69,99 +308,35 @@ def main() -> int:
                 continue
             types = column_types(cur, args.database, schema)
 
-            # Group by child table: one rebuild per table, however many of its columns move.
-            recasts: dict[str, dict[str, str]] = {}
-            for table, column, ref_table, ref_column in foreign:
-                child_key = (table.upper(), column.upper())
-                parent_key = (ref_table.upper(), ref_column.upper())
-                child = types.get(child_key)
-                parent = types.get(parent_key)
-                if not child or not parent or child == parent:
-                    continue
-
-                # An id is a number. When only one side reads as text -- usually because its
-                # table hit the type-violation fallback -- move that side to the numeric type
-                # rather than degrading both to text.
-                child_numeric = child.startswith(("NUMBER", "FLOAT", "INT"))
-                parent_numeric = parent.startswith(("NUMBER", "FLOAT", "INT"))
-                if child_numeric and not parent_numeric:
-                    recasts.setdefault(ref_table.upper(), {})[ref_column.upper()] = child
-                else:
-                    recasts.setdefault(table.upper(), {})[column.upper()] = parent
-
-            for table, columns in recasts.items():
-                cur.execute(
-                    f"""SELECT column_name FROM {args.database}.INFORMATION_SCHEMA.COLUMNS
-                        WHERE table_schema = '{schema}' AND table_name = '{table}'
-                        ORDER BY ordinal_position"""
-                )
-                names = [r[0] for r in cur.fetchall()]
-                # TO_VARCHAR here for the same reason the probe below has it, and it MUST be
-                # the same expression as the probe: a probe that certifies
-                # `TRY_CAST(TO_VARCHAR(x) AS t)` while the rewrite runs `TRY_CAST(x AS t)` has
-                # verified something adjacent to what executes. On a numeric source -- which
-                # reaches here whenever child and parent are both numeric and unequal, say
-                # NUMBER(38,0) against FLOAT -- the probe would pass and the bare TRY_CAST
-                # would then be handed a non-string, which Snowflake does not accept.
-                projection = ", ".join(
-                    f'TRY_CAST(TO_VARCHAR("{n}") AS {columns[n]}) AS "{n}"'
-                    if n in columns else f'"{n}"'
-                    for n in names
-                )
-                # CHECK THE CAST LOSES NOTHING BEFORE OVERWRITING THE TABLE. `TRY_CAST`
-                # returns NULL where it cannot convert, and `CREATE OR REPLACE` then makes
-                # those NULLs the table -- silently, and counted as `aligned`. The population
-                # here is the one the docstring names: tables that hit the type-violation
-                # fallback and read as text hold precisely the values that violate the numeric
-                # type. `infer_keys_spider2` guards the identical rewrite; this did not.
-                #
-                # Fractional values are rejected for the same reason it rejects them: TRY_CAST
-                # rounds 3.5 to 4 rather than failing, so a fractional column converts
-                # "cleanly" while changing every value. An identifier has no fractional part.
-                # TO_VARCHAR around every source, because Snowflake's TRY_CAST takes a STRING
-                # expression and `recasts` can hold a numeric column: NUMBER(38,0) against
-                # FLOAT are both numeric and not equal, so they reach the `else` branch above
-                # and this would ask TRY_CAST to read a number. Rendering to text first is
-                # value-preserving for the question being asked and valid for any source type.
-                #
-                # The whole probe is inside a try. It is a SAFETY check, so it must not be the
-                # thing that stops the run: an unreadable probe means this table cannot be
-                # shown to convert losslessly, which is a reason to leave it alone and say so,
-                # not a reason to abandon the tables after it. The first version of this ran
-                # outside the try below and would have aborted `main()` on any probe error.
-                lossy = []
-                for name, target in columns.items():
-                    try:
-                        cur.execute(
-                            f'SELECT COUNT("{name}"), '
-                            f'COUNT(TRY_CAST(TO_VARCHAR("{name}") AS {target})), '
-                            f'COUNT_IF(TRY_CAST(TO_VARCHAR("{name}") AS FLOAT) IS NOT NULL AND '
-                            f'  TRY_CAST(TO_VARCHAR("{name}") AS FLOAT) '
-                            f'  <> TRUNC(TRY_CAST(TO_VARCHAR("{name}") AS FLOAT))) '
-                            f'FROM {args.database}.{schema}."{table}"'
-                        )
-                        non_null, converted, fractional = cur.fetchone()
-                    except Exception as exc:
-                        lossy.append(f"{name} (probe failed: {str(exc).splitlines()[-1][:50]})")
-                        continue
-                    if non_null != converted:
-                        lossy.append(f"{name} ({non_null - converted} would become NULL)")
-                    elif target.upper().startswith("NUMBER") and fractional:
-                        lossy.append(f"{name} ({fractional} fractional, TRY_CAST would round)")
+            for component in plan_recasts(foreign, types):
+                # PROBE THE WHOLE COMPONENT FIRST. Rewriting some of its tables and skipping
+                # another is the split the component grouping exists to prevent.
+                lossy = probe_component(cur, args.database, schema, component)
                 if lossy:
-                    skipped.append(f"{schema}.{table}: {', '.join(lossy)}")
+                    skipped.append(f"{schema}: {', '.join(lossy)}")
                     continue
 
-                sql = (
-                    f'CREATE OR REPLACE TABLE {args.database}.{schema}."{table}" AS '
-                    f'SELECT {projection} FROM {args.database}.{schema}."{table}"'
-                )
-                try:
-                    cur.execute(sql)
+                outcome = apply_component(cur, args.database, schema, component)
+                if outcome["unreadable"]:
+                    unreadable.append(
+                        f"{schema}: {', '.join(sorted(component))} "
+                        f"({outcome['unreadable']})"
+                    )
+                    continue
+                for table, columns in outcome["written"]:
                     aligned += len(columns)
-                    print(f"  {schema}.{table}: {', '.join(columns)} -> parent types")
-                except Exception as exc:
-                    failed.append(f"{schema}.{table}: {str(exc).splitlines()[-1][:70]}")
+                    target = next(iter(columns.values()))
+                    print(f"  {schema}.{table}: {', '.join(columns)} -> {target}")
+                if outcome["failed"]:
+                    table, reason = outcome["failed"]
+                    failed.append(f"{schema}.{table}: {reason}")
+                    if outcome["written"]:
+                        left = [t for t, _ in outcome["written"]]
+                        behind = [table, *outcome["unattempted"]]
+                        split.append(
+                            f"{schema}: {', '.join(left)} rewritten; "
+                            f"{', '.join(behind)} NOT -- their keys no longer agree"
+                        )
     finally:
         cur.close()
         con.close()
@@ -174,7 +349,24 @@ def main() -> int:
     # a table of NULLs where values used to be.
     for line in skipped:
         print(f"  SKIPPED (cast would lose data) {line}")
-    return 0
+    # LOUDEST, and last so it is what remains on screen. A split component is the one outcome
+    # here that leaves the schema worse than it was found: tables that agreed now do not, and
+    # Snowflake commits DDL as it runs so nothing here can undo it. It also changes the exit
+    # code, because a caller scripting this needs to know the difference between "some
+    # relationships were not declared" and "some relationships were BROKEN".
+    # A separate bucket from `skipped`, which is printed as "cast would lose data". A
+    # lost-data skip means the values were inspected and refused; a read failure means nothing
+    # was inspected at all, and the two want opposite responses -- accept the loss, or retry.
+    for line in unreadable:
+        print(f"  UNREADABLE (could not read the column list) {line}")
+    # LOUDEST, and last so it is what remains on screen. A split component is the one outcome
+    # here that leaves the schema worse than it was found: tables that agreed now do not, and
+    # Snowflake commits DDL as it runs so nothing here can undo it. It also changes the exit
+    # code, because a caller scripting this needs to know the difference between "some
+    # relationships were not declared" and "some relationships were BROKEN".
+    for line in split:
+        print(f"  SPLIT (component left inconsistent) {line}")
+    return 1 if split else 0
 
 
 if __name__ == "__main__":

--- a/scripts/align_fk_types_snowflake.py
+++ b/scripts/align_fk_types_snowflake.py
@@ -20,6 +20,7 @@ import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from exc_reason import reason  # noqa: E402
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
 
 from mnemiq.eval.spider import load_keys, load_spider  # noqa: E402
@@ -185,25 +186,13 @@ def probe_component(cur, database: str, schema: str, component: dict) -> list[st
                 )
                 non_null, converted, fractional = cur.fetchone()
             except Exception as exc:
-                lossy.append(f"{table}.{name} (probe failed: {str(exc).splitlines()[-1][:50]})")
+                lossy.append(f"{table}.{name} (probe failed: {reason(exc)})")
                 continue
             if non_null != converted:
                 lossy.append(f"{table}.{name} ({non_null - converted} would become NULL)")
             elif target.upper().startswith("NUMBER") and fractional:
                 lossy.append(f"{table}.{name} ({fractional} fractional, TRY_CAST would round)")
     return lossy
-
-
-def _reason(exc: Exception) -> str:
-    """One short line from an exception, safely.
-
-    `str(exc).splitlines()[-1]` raises IndexError on an empty message -- `"".splitlines()` is
-    `[]` -- and every use of that idiom here sits inside a handler whose whole purpose is to
-    stop a failure from ending the run. The IndexError would propagate past both loops and do
-    exactly that.
-    """
-    lines = str(exc).splitlines()
-    return (lines[-1] if lines else exc.__class__.__name__)[:70]
 
 
 def apply_component(cur, database: str, schema: str, component: dict) -> dict:
@@ -225,7 +214,7 @@ def apply_component(cur, database: str, schema: str, component: dict) -> dict:
     try:
         rewrites = build_rewrites(cur, database, schema, component)
     except Exception as exc:
-        return {"unreadable": _reason(exc), "written": [], "failed": None, "unattempted": []}
+        return {"unreadable": reason(exc), "written": [], "failed": None, "unattempted": []}
 
     written: list[str] = []
     for i, (table, sql, columns) in enumerate(rewrites):
@@ -236,7 +225,7 @@ def apply_component(cur, database: str, schema: str, component: dict) -> dict:
             return {
                 "unreadable": None,
                 "written": written,
-                "failed": (table, _reason(exc)),
+                "failed": (table, reason(exc)),
                 # Everything after the failure is never attempted, and disagrees with what
                 # WAS rewritten just as much as the failed table does. Naming only the failure
                 # reads as one unlucky rewrite.
@@ -328,8 +317,11 @@ def main() -> int:
                     target = next(iter(columns.values()))
                     print(f"  {schema}.{table}: {', '.join(columns)} -> {target}")
                 if outcome["failed"]:
-                    table, reason = outcome["failed"]
-                    failed.append(f"{schema}.{table}: {reason}")
+                    # NOT `reason`: that name is the imported helper, and binding it here
+                    # makes it a local for the whole of `main` -- every later call would be
+                    # an UnboundLocalError waiting for someone to add one.
+                    table, why = outcome["failed"]
+                    failed.append(f"{schema}.{table}: {why}")
                     if outcome["written"]:
                         left = [t for t, _ in outcome["written"]]
                         behind = [table, *outcome["unattempted"]]

--- a/scripts/exc_reason.py
+++ b/scripts/exc_reason.py
@@ -1,0 +1,26 @@
+"""One short line from an exception, safely.
+
+`str(exc).splitlines()[-1]` is the idiom every script here used to summarise a Snowflake
+error, and it raises IndexError when the message is empty -- `"".splitlines()` is `[]`. Every
+one of those uses sits inside an `except` whose whole purpose is to keep a failure from ending
+the run, so the IndexError would escape the handler and do precisely what the handler exists
+to prevent.
+
+Shared rather than fixed in place, because it was in eight sites across six scripts --
+enumerated, not counted -- and correcting one of them is how it survived the first time.
+"""
+
+from __future__ import annotations
+
+
+def reason(exc: Exception, limit: int = 70) -> str:
+    r"""Last non-blank line of the message, or the exception's class name when there is none.
+
+    NON-BLANK, not merely present: `"\n".splitlines()` is `[""]`, so guarding only on the list
+    being empty returned an empty summary and the caller printed `(probe failed: )`. Not a
+    crash, but a handler that reports nothing is the same problem one step quieter.
+    """
+    for line in reversed(str(exc).splitlines()):
+        if line.strip():
+            return line.strip()[:limit]
+    return exc.__class__.__name__[:limit]

--- a/scripts/fix_keys_snowflake.py
+++ b/scripts/fix_keys_snowflake.py
@@ -20,6 +20,7 @@ import sys
 import snowflake.connector
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from exc_reason import reason  # noqa: E402
 from add_keys_snowflake import keys_for  # noqa: E402
 from bird_to_parquet import sqlite_dbs  # noqa: E402
 
@@ -127,7 +128,7 @@ def main() -> int:
                 except Exception as exc:
                     missing.append(
                         f"{schema}: {table}.{column} -> {ref_table}.{ref_column}: "
-                        f"{str(exc).splitlines()[-1][:70]}"
+                        f"{reason(exc, 70)}"
                     )
 
             total_missing += missing

--- a/scripts/keys_spider_snowflake.py
+++ b/scripts/keys_spider_snowflake.py
@@ -19,6 +19,7 @@ import sys
 import snowflake.connector
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from exc_reason import reason  # noqa: E402
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
 
 from fix_keys_snowflake import drop_existing  # noqa: E402
@@ -73,7 +74,7 @@ def main() -> int:
                 except Exception as exc:
                     unapplied.append(
                         f"{schema}: PRIMARY KEY {table}({', '.join(columns)}): "
-                        f"{str(exc).splitlines()[-1][:60]}"
+                        f"{reason(exc, 60)}"
                     )
 
             targets = {
@@ -89,7 +90,7 @@ def main() -> int:
                 except Exception as exc:
                     unapplied.append(
                         f"{schema}: UNIQUE {ref_table}.{ref_column}: "
-                        f"{str(exc).splitlines()[-1][:60]}"
+                        f"{reason(exc, 60)}"
                     )
 
             fk_done = 0
@@ -105,7 +106,7 @@ def main() -> int:
                 except Exception as exc:
                     missing.append(
                         f"{schema}: {table}.{column} -> {ref_table}.{ref_column}: "
-                        f"{str(exc).splitlines()[-1][:60]}"
+                        f"{reason(exc, 60)}"
                     )
 
             flag = "" if fk_done == len(foreign) else "  <-- incomplete"

--- a/scripts/uppercase_columns_snowflake.py
+++ b/scripts/uppercase_columns_snowflake.py
@@ -15,8 +15,12 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
 
 import snowflake.connector
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from exc_reason import reason  # noqa: E402
 
 
 def main() -> int:
@@ -58,7 +62,7 @@ def main() -> int:
             except Exception as exc:
                 # Two columns differing only by case cannot both become the same upper-case
                 # name -- worth reporting rather than silently losing one.
-                clashes.append(f"{schema}.{table}.{column}: {str(exc).splitlines()[-1][:80]}")
+                clashes.append(f"{schema}.{table}.{column}: {reason(exc, 80)}")
     finally:
         cur.close()
         con.close()

--- a/tests/test_align_fk_plan.py
+++ b/tests/test_align_fk_plan.py
@@ -1,0 +1,197 @@
+"""`plan_recasts`, which decides which columns get rewritten to make a join's types agree.
+
+Pure — it reads a type map and returns a plan — so these need no warehouse and no fake
+cursor. It was inside `main` alongside live Snowflake I/O until this change, which is why the
+defect below survived: nothing could reach the decision without a database.
+
+The defect: the direction was decided ONE PAIR AT A TIME, with no regard for the other
+children of the same parent column. Moving a parent to suit one child silently broke every
+sibling that already agreed with it, and the script reported only what it aligned.
+"""
+
+from scripts.align_fk_types_snowflake import plan_recasts
+
+NUM = "NUMBER(38,0)"
+
+
+def merged(plan) -> dict:
+    """The plan flattened to {table: {column: target}}.
+
+    `plan_recasts` returns ONE ENTRY PER COMPONENT, because the caller has to treat a
+    component as all-or-nothing -- probing per table and skipping one of them splits the
+    component the grouping exists to hold together. Most assertions here are about which
+    columns move, so they read the flattened view; the ones about component BOUNDARIES read
+    the list itself.
+    """
+    out: dict = {}
+    for component in plan:
+        for table, columns in component.items():
+            out.setdefault(table, {}).update(columns)
+    return out
+
+
+def test_moving_a_parent_takes_its_other_children_with_it():
+    """THE REGRESSION. `P.K` TEXT with a TEXT child and a NUMBER child.
+
+    Pair-at-a-time: C1/P agree, so that pair is skipped as fine; then C2 makes `P.K` numeric
+    and C1 is left TEXT against a NUMBER parent -- its FOREIGN KEY no longer declarable, and
+    `aligned 1 columns` printed with nothing said about it. Whichever pair came second decided
+    the parent's type and the other one lost.
+
+    The group moves together now, so both children can still declare their key.
+    """
+    plan = merged(plan_recasts(
+        [("C1", "K", "P", "K"), ("C2", "K", "P", "K")],
+        {("P", "K"): "TEXT", ("C1", "K"): "TEXT", ("C2", "K"): NUM},    ))
+    assert plan == {"P": {"K": NUM}, "C1": {"K": NUM}}, plan
+
+
+def test_two_disagreeing_parents_are_reconciled_rather_than_one_being_dropped():
+    """`C.K` TEXT referenced by `P1.K NUMBER` and `P2.K FLOAT`.
+
+    A column holds one type, so under the pair rule one of those relationships had to lose --
+    and which one followed the input order. Under components all three are ONE component, so
+    the disagreeing PARENT moves too and both keys stay declarable. Worth stating plainly
+    because it means a child's type can now rewrite a parent table, which is a bigger
+    consequence than the pair rule ever had.
+
+    The target is `_numeric_rank`, not input order: an id is an identifier, so NUMBER outranks
+    FLOAT. The VALUE is asserted and not just forward == reverse -- an earlier version checked
+    only that the two orders agreed, which two identical wrong answers also satisfy.
+
+    (That earlier version also used the shared-PARENT case and claimed the pair rule was
+    order-dependent there. It was not: `types` is read fresh per pair and never updated, so
+    both orders agreed and the test passed against the bug it named.)
+    """
+    types = {("C", "K"): "TEXT", ("P1", "K"): NUM, ("P2", "K"): "FLOAT"}
+    forward = merged(plan_recasts([("C", "K", "P1", "K"), ("C", "K", "P2", "K")], types))
+    reverse = merged(plan_recasts([("C", "K", "P2", "K"), ("C", "K", "P1", "K")], types))
+    assert forward == reverse, f"the plan followed the input order: {forward} != {reverse}"
+    assert forward == {"C": {"K": NUM}, "P2": {"K": NUM}}, forward
+
+
+def test_the_widest_numeric_wins_rather_than_the_lexicographically_smallest():
+    """A tie inside one numeric family is broken by declared precision and scale, not by the
+    rendered string.
+
+    A plain string compare put `NUMBER(10,0)` before `NUMBER(38,0)` -- "1" sorts before "3" --
+    so a 38-digit parent was NARROWED to ten digits, while against `NUMBER(9,0)` the same
+    compare widened instead: the direction flipped on the first character of the digit count.
+    Widening cannot lose a value; narrowing can, and would surface only as the loss probe
+    refusing the whole component.
+    """
+    def target_for(parent, child):
+        return merged(plan_recasts([("C", "K", "P", "K")],
+                                   {("P", "K"): parent, ("C", "K"): child}))
+
+    assert target_for("NUMBER(38,0)", "NUMBER(10,0)") == {"C": {"K": "NUMBER(38,0)"}}
+    assert target_for("NUMBER(10,0)", "NUMBER(38,0)") == {"P": {"K": "NUMBER(38,0)"}}
+    # Scale widens too, and an integer family still outranks a floating one.
+    assert target_for("NUMBER(10,2)", "NUMBER(10,4)") == {"P": {"K": "NUMBER(10,4)"}}
+    assert target_for("NUMBER(38,0)", "FLOAT") == {"C": {"K": "NUMBER(38,0)"}}
+
+
+def test_independent_components_are_separate_entries_so_one_can_be_skipped():
+    """The list shape is load-bearing: the caller probes a component and skips ALL of it when
+    any member is lossy. Flattening two independent components into one map would make an
+    unrelated table's failure skip this one too."""
+    plan = plan_recasts(
+        [("C1", "K", "P1", "K"), ("C2", "K", "P2", "K")],
+        {("P1", "K"): NUM, ("C1", "K"): "TEXT", ("P2", "K"): "FLOAT", ("C2", "K"): "TEXT"},
+    )
+    assert len(plan) == 2, plan
+    assert {frozenset(c) for c in plan} == {frozenset({"C1"}), frozenset({"C2"})}
+
+
+def test_a_chain_is_ONE_entry_so_it_cannot_be_half_applied():
+    """The converse. G -> C -> P is one component, so it is one entry and the caller either
+    rewrites all of it or none -- rewriting `C` while skipping `P` is the split that grouping
+    exists to prevent, and a per-table plan could not express the difference."""
+    plan = plan_recasts(
+        [("C2", "K", "P", "K"), ("C", "K", "P", "K"), ("G", "K", "C", "K")],
+        {("P", "K"): "TEXT", ("C2", "K"): NUM, ("C", "K"): "TEXT", ("G", "K"): "TEXT"},
+    )
+    assert len(plan) == 1, plan
+    assert set(plan[0]) == {"P", "C", "G"}, plan[0]
+
+
+def test_a_column_that_moves_as_a_child_carries_ITS_children_too():
+    """The defect that grouping-by-parent introduced while fixing the pair rule, caught by
+    review before it shipped.
+
+    Chain: G1/G2/G3 -> C -> P, with a numeric C2 also pointing at P. Grouping by parent moved
+    `C.K` to NUMBER as part of P's group, then read `C.K`'s ORIGINAL text type when deciding
+    C's own group and left all three grandchildren TEXT against a now-NUMBER parent. Three
+    relationships broken where the pair rule broke one -- and silently, since `main` prints
+    only what it aligned.
+
+    Foreign keys chain, so the unit is the connected COMPONENT: every column reachable
+    through a key ends at the same type.
+    """
+    plan = merged(plan_recasts(
+        [("C2", "K", "P", "K"), ("C", "K", "P", "K"),
+         ("G1", "K", "C", "K"), ("G2", "K", "C", "K"), ("G3", "K", "C", "K")],
+        {("P", "K"): "TEXT", ("C2", "K"): NUM, ("C", "K"): "TEXT",
+         ("G1", "K"): "TEXT", ("G2", "K"): "TEXT", ("G3", "K"): "TEXT"},    ))
+    assert plan == {t: {"K": NUM} for t in ("P", "C", "G1", "G2", "G3")}, plan
+
+
+def test_a_component_holding_two_numeric_types_picks_one_by_RANK_not_input_order():
+    """Two numeric children of one parent, and only the groups were sorted before -- the
+    target came from whichever numeric child appeared first in `foreign`, so the same schema
+    gave `{P: NUMBER, C2: NUMBER}` one way and `{P: FLOAT, C1: FLOAT}` the other.
+
+    An id is an identifier, so NUMBER outranks FLOAT -- the same reason the loss probe rejects
+    a fractional column. Whichever way the keys are listed, the component lands on NUMBER and
+    every member agrees, which is what keeps all of its relationships declarable.
+    """
+    types = {("P", "K"): "TEXT", ("C1", "K"): NUM, ("C2", "K"): "FLOAT"}
+    pairs = [("C1", "K", "P", "K"), ("C2", "K", "P", "K")]
+    forward = merged(plan_recasts(pairs, types))
+    reverse = merged(plan_recasts(list(reversed(pairs)), types))
+    assert forward == reverse, f"the target followed input order: {forward} != {reverse}"
+    assert forward == {"P": {"K": NUM}, "C2": {"K": NUM}}, forward
+
+
+def test_a_numeric_parent_keeps_its_type_and_the_children_come_to_it():
+    """An id is a number: the group never degrades to text when the parent already holds the
+    numeric type. This is the branch that moved the child to the parent."""
+    plan = merged(plan_recasts(
+        [("C1", "K", "P", "K"), ("C2", "K", "P", "K")],
+        {("P", "K"): NUM, ("C1", "K"): "TEXT", ("C2", "K"): "TEXT"},    ))
+    assert plan == {"C1": {"K": NUM}, "C2": {"K": NUM}}
+
+
+def test_a_group_that_already_agrees_is_not_rewritten():
+    """Rewriting a table costs a CREATE OR REPLACE over live data. Agreement means no plan."""
+    assert plan_recasts([("C1", "K", "P", "K")], {("P", "K"): NUM, ("C1", "K"): NUM}) == []
+
+
+def test_an_all_text_group_is_left_alone():
+    """No member is numeric, so there is nothing to prefer and nothing to gain: casting text
+    to text rewrites two tables to change nothing."""
+    assert plan_recasts([("C1", "K", "P", "K")], {("P", "K"): "TEXT", ("C1", "K"): "TEXT"}) == []
+
+
+def test_a_column_missing_from_the_type_map_is_skipped_not_guessed():
+    """`column_types` reports what the schema has. A pair naming something it does not is a
+    stale tables.json entry, and inventing a type for it would rewrite the wrong column."""
+    assert plan_recasts([("C1", "K", "P", "K")], {("P", "K"): NUM}) == []
+    assert plan_recasts([("C1", "K", "P", "K")], {("C1", "K"): NUM}) == []
+
+
+def test_two_independent_parents_do_not_reach_into_each_other():
+    plan = merged(plan_recasts(
+        [("C1", "K", "P1", "K"), ("C2", "K", "P2", "K")],
+        {("P1", "K"): NUM, ("C1", "K"): "TEXT", ("P2", "K"): "TEXT", ("C2", "K"): "TEXT"},    ))
+    assert plan == {"C1": {"K": NUM}}, plan
+
+
+def test_one_table_can_collect_two_columns_in_a_single_rebuild():
+    """`main` issues ONE `CREATE OR REPLACE` per table, with a projection covering every
+    column in that table's entry -- so two moving columns of one child must arrive in a single
+    entry. Two entries for one table would mean the second rebuild reads the first's output."""
+    plan = merged(plan_recasts(
+        [("C", "A", "P", "A"), ("C", "B", "P", "B")],
+        {("P", "A"): NUM, ("C", "A"): "TEXT", ("P", "B"): NUM, ("C", "B"): "TEXT"},    ))
+    assert plan == {"C": {"A": NUM, "B": NUM}}, plan

--- a/tests/test_align_fk_probe.py
+++ b/tests/test_align_fk_probe.py
@@ -63,6 +63,28 @@ def test_a_probe_that_RAISES_condemns_the_component_rather_than_the_run():
     assert any("P.K (probe failed:" in line for line in lossy), lossy
 
 
+def test_a_probe_exception_with_an_EMPTY_message_does_not_end_the_run():
+    """The probe handler exists so an unreadable column does not stop the run, and it built
+    its message with `str(exc).splitlines()[-1]` -- which raises IndexError on an empty
+    message, since `"".splitlines()` is `[]`. The IndexError then escaped the handler, the
+    component loop and the schema loop, ending exactly what the handler was written to
+    protect.
+
+    A commit message claimed this idiom had already been routed through `_reason` everywhere.
+    It had not: `apply_component` was converted and this one was left, so the claim was
+    checkable and wrong.
+    """
+
+    class EmptyMessage(FakeCursor):
+        def execute(self, sql, params=None):
+            self.sql.append(sql)
+            raise RuntimeError("")
+
+    lossy = probe_component(EmptyMessage(), "DB", "SCH", COMPONENT)
+    assert len(lossy) == 2, lossy
+    assert all("probe failed:" in line for line in lossy), lossy
+
+
 def test_a_fractional_source_is_refused_for_a_NUMBER_target():
     """TRY_CAST rounds 3.5 to 4 rather than failing, so a fractional column converts
     `cleanly` while changing every value. An identifier has no fractional part."""

--- a/tests/test_align_fk_probe.py
+++ b/tests/test_align_fk_probe.py
@@ -1,0 +1,241 @@
+"""`probe_component`, the loss check that decides whether a component may be rewritten.
+
+The defect it was extracted to fix: the probe ran PER TABLE and skipped that one table, which
+split the very component the grouping exists to hold together. With `P.K` TEXT, `C1.K` TEXT
+and `C2.K` NUMBER the plan moves both `P` and `C1` to NUMBER, so a `P` that fails the probe --
+the population this script exists for, text columns holding the values that violate the
+numeric type -- left `C1` rewritten to NUMBER against a still-TEXT parent. `C1` and `P` AGREED
+before the run, and the operator saw two unrelated lines: one aligned, one skipped.
+
+`infer_keys_spider2.align_pairs` states the discipline for the pair case -- decide both sides
+before writing either. A component needs it at its own scale.
+"""
+
+from scripts.align_fk_types_snowflake import probe_component
+
+NUM = "NUMBER(38,0)"
+COMPONENT = {"P": {"K": NUM}, "C1": {"K": NUM}}
+
+
+class FakeCursor:
+    """Answers the loss probe per table. `lossy_tables` convert 7 of their 10 values."""
+
+    def __init__(self, lossy_tables=(), raise_on=()):
+        self.sql: list[str] = []
+        self._lossy = set(lossy_tables)
+        self._raise_on = set(raise_on)
+        self._reply = None
+
+    def execute(self, sql, params=None):
+        self.sql.append(sql)
+        table = next((t for t in ("P", "C1", "C2") if f'."{t}"' in sql), None)
+        if table in self._raise_on:
+            raise RuntimeError("100038 (22018): numeric value not recognized")
+        self._reply = (10, 7, 0) if table in self._lossy else (10, 10, 0)
+
+    def fetchone(self):
+        return self._reply
+
+
+def test_a_component_that_converts_cleanly_reports_nothing():
+    assert probe_component(FakeCursor(), "DB", "SCH", COMPONENT) == []
+
+
+def test_one_lossy_member_condemns_the_WHOLE_component():
+    """The blocker. Only `P` is lossy, and the answer must be about the component -- returning
+    nothing for `C1` is what let `C1` be rewritten around a skipped `P`."""
+    lossy = probe_component(FakeCursor(lossy_tables={"P"}), "DB", "SCH", COMPONENT)
+    assert lossy, "a lossy member reported nothing, so the component would be rewritten"
+    assert any("P.K" in line for line in lossy), lossy
+
+
+def test_the_reason_names_the_table_as_well_as_the_column():
+    """A component spans tables, so `K (3 would become NULL)` does not say which `K`."""
+    lossy = probe_component(FakeCursor(lossy_tables={"C1"}), "DB", "SCH", COMPONENT)
+    assert lossy == ["C1.K (3 would become NULL)"], lossy
+
+
+def test_a_probe_that_RAISES_condemns_the_component_rather_than_the_run():
+    """A safety check must not be the thing that stops the run. An unreadable probe means the
+    component cannot be SHOWN to convert -- a reason to leave it alone and say so, not to
+    abandon the components after it."""
+    lossy = probe_component(FakeCursor(raise_on={"P"}), "DB", "SCH", COMPONENT)
+    assert any("P.K (probe failed:" in line for line in lossy), lossy
+
+
+def test_a_fractional_source_is_refused_for_a_NUMBER_target():
+    """TRY_CAST rounds 3.5 to 4 rather than failing, so a fractional column converts
+    `cleanly` while changing every value. An identifier has no fractional part."""
+
+    class Fractional(FakeCursor):
+        def execute(self, sql, params=None):
+            self.sql.append(sql)
+            self._reply = (10, 10, 4)
+
+    lossy = probe_component(Fractional(), "DB", "SCH", {"P": {"K": NUM}})
+    assert lossy == ["P.K (4 fractional, TRY_CAST would round)"], lossy
+
+
+def test_every_probe_reads_a_string_source():
+    """Snowflake's TRY_CAST takes a STRING expression, and the probe must cast exactly what
+    the rewrite casts -- a probe certifying `TRY_CAST(TO_VARCHAR(x) AS t)` while
+    `TRY_CAST(x AS t)` executes has verified something adjacent to what runs."""
+    cur = FakeCursor()
+    probe_component(cur, "DB", "SCH", COMPONENT)
+    assert cur.sql, "no probe was issued at all"
+    for sql in cur.sql:
+        assert 'TRY_CAST("' not in sql, f"cast a column directly: {sql}"
+
+
+def test_every_member_is_probed_not_just_the_first():
+    """A probe that stopped at the first clean table would clear a component whose second
+    member cannot convert."""
+    cur = FakeCursor()
+    probe_component(cur, "DB", "SCH", COMPONENT)
+    probed = {t for t in ("P", "C1") if any(f'."{t}"' in s for s in cur.sql)}
+    assert probed == {"P", "C1"}, probed
+
+
+# --------------------------------------------------------------------------------------------
+# `build_rewrites` -- every READ for a component, before any of it is WRITTEN.
+# --------------------------------------------------------------------------------------------
+
+
+class ReadCursor:
+    """Answers the INFORMATION_SCHEMA column read. `raise_on` tables fail it."""
+
+    def __init__(self, columns=("K", "OTHER"), raise_on=()):
+        self.sql: list[str] = []
+        self._columns = columns
+        self._raise_on = set(raise_on)
+
+    def execute(self, sql, params=None):
+        self.sql.append(sql)
+        table = next((t for t in ("P", "C1") if f"table_name = '{t}'" in sql), None)
+        if table in self._raise_on:
+            raise RuntimeError("002003 (02000): Object does not exist")
+
+    def fetchall(self):
+        return [(c,) for c in self._columns]
+
+
+def test_a_failed_read_propagates_for_the_caller_to_turn_into_a_skip():
+    """`build_rewrites` only reads, so it cannot swallow a read failure into a partial plan.
+
+    An earlier version of this test also asserted that nothing was written -- tautological,
+    since this function issues one SELECT and never a CREATE OR REPLACE, so no version of it
+    could fail that. The property the hoist actually establishes lives in `apply_component`,
+    and is tested there.
+    """
+    from scripts.align_fk_types_snowflake import build_rewrites
+
+    try:
+        build_rewrites(ReadCursor(raise_on={"C1"}), "DB", "SCH", COMPONENT)
+    except RuntimeError:
+        return
+    raise AssertionError("the read failure was swallowed")
+
+
+def test_every_table_of_the_component_gets_a_statement():
+    from scripts.align_fk_types_snowflake import build_rewrites
+
+    rewrites = build_rewrites(ReadCursor(), "DB", "SCH", COMPONENT)
+    assert {t for t, _, _ in rewrites} == {"P", "C1"}
+    assert all("CREATE OR REPLACE TABLE" in sql for _, sql, _ in rewrites)
+
+
+def test_the_projection_casts_the_key_and_carries_the_rest_verbatim():
+    """A rebuild that dropped a column would be silent and total, and a cast applied to the
+    wrong one changes data nobody asked about."""
+    from scripts.align_fk_types_snowflake import build_rewrites
+
+    sql = dict((t, s) for t, s, _ in build_rewrites(ReadCursor(), "DB", "SCH", COMPONENT))["P"]
+    assert f'TRY_CAST(TO_VARCHAR("K") AS {NUM}) AS "K"' in sql, sql
+    assert '"OTHER"' in sql and 'TO_VARCHAR("OTHER")' not in sql, sql
+
+
+# --------------------------------------------------------------------------------------------
+# `apply_component` -- where the read hoist and the split report actually live.
+# --------------------------------------------------------------------------------------------
+
+
+class ApplyCursor:
+    """Reads the column list, then executes rewrites. Either can be made to fail per table."""
+
+    def __init__(self, raise_read=(), raise_write=(), columns=("K",)):
+        self.sql: list[str] = []
+        self._raise_read = set(raise_read)
+        self._raise_write = set(raise_write)
+        self._columns = columns
+
+    def execute(self, sql, params=None):
+        self.sql.append(sql)
+        if "INFORMATION_SCHEMA" in sql:
+            table = next((t for t in ("A", "B", "C") if f"table_name = '{t}'" in sql), None)
+            if table in self._raise_read:
+                raise RuntimeError("002003 (02000): Object does not exist")
+            return
+        table = next((t for t in ("A", "B", "C") if f'."{t}"' in sql), None)
+        if table in self._raise_write:
+            raise RuntimeError("000603 (XX000): execution error")
+
+    def fetchall(self):
+        return [(c,) for c in self._columns]
+
+    @property
+    def writes(self):
+        return [s for s in self.sql if "CREATE OR REPLACE" in s]
+
+
+THREE = {"A": {"K": NUM}, "B": {"K": NUM}, "C": {"K": NUM}}
+
+
+def _apply(**kw):
+    from scripts.align_fk_types_snowflake import apply_component
+
+    cur = ApplyCursor(**kw)
+    return apply_component(cur, "DB", "SCH", THREE), cur
+
+
+def test_a_clean_component_writes_every_table():
+    out, cur = _apply()
+    assert [t for t, _ in out["written"]] == ["A", "B", "C"]
+    assert out["failed"] is None and out["unreadable"] is None
+    assert len(cur.writes) == 3
+
+
+def test_A_READ_FAILURE_ON_A_LATER_TABLE_WRITES_NOTHING():
+    """The one that used to end the run. The read sat inside the write loop and outside any
+    `try`, so failing on `B` came AFTER `A` was rewritten -- and then escaped every loop.
+
+    Hoisted: nothing is written at all, and the caller turns it into an UNREADABLE line.
+    """
+    out, cur = _apply(raise_read={"B"})
+    assert cur.writes == [], f"it wrote before finishing the reads: {cur.writes}"
+    assert out["unreadable"] and out["written"] == []
+
+
+def test_a_write_failure_names_the_tables_left_behind_AND_the_ones_never_attempted():
+    """`B` fails, so `A` is rewritten and BOTH `B` and `C` disagree with it -- `C` was never
+    attempted. Reporting only the failure reads as one unlucky rewrite when the component is
+    inconsistent three ways."""
+    out, _ = _apply(raise_write={"B"})
+    assert [t for t, _ in out["written"]] == ["A"]
+    assert out["failed"][0] == "B"
+    assert out["unattempted"] == ["C"], out["unattempted"]
+
+
+def test_an_exception_with_an_EMPTY_message_does_not_end_the_run():
+    """`str(exc).splitlines()[-1]` raises IndexError on an empty message, inside the handler
+    whose whole purpose is to keep a failure from ending the run."""
+
+    class Empty(ApplyCursor):
+        def execute(self, sql, params=None):
+            self.sql.append(sql)
+            if "INFORMATION_SCHEMA" not in sql:
+                raise RuntimeError("")
+
+    from scripts.align_fk_types_snowflake import apply_component
+
+    out = apply_component(Empty(), "DB", "SCH", THREE)
+    assert out["failed"][0] == "A" and out["failed"][1], out["failed"]

--- a/tests/test_exc_reason.py
+++ b/tests/test_exc_reason.py
@@ -1,0 +1,51 @@
+"""`reason`, the one-line exception summary every warehouse script uses.
+
+It exists because `str(exc).splitlines()[-1]` -- the idiom it replaces -- raises IndexError on
+an empty message, and every one of the eight sites using it sat inside an `except` whose whole
+purpose was to keep a failure from ending the run. The IndexError escaped the handler and did
+exactly what the handler existed to prevent.
+
+Shared rather than fixed in place because correcting one site is how it survived: a commit
+message claimed the idiom had been routed through a local helper everywhere, and one of the
+three uses in that same file had been left behind.
+"""
+
+import pytest
+
+from scripts.exc_reason import reason
+
+
+def test_an_empty_message_yields_the_class_name_instead_of_raising():
+    """`"".splitlines()` is `[]`, so the old idiom's `[-1]` raised here."""
+    assert reason(RuntimeError("")) == "RuntimeError"
+
+
+def test_the_LAST_line_is_the_useful_one():
+    """Snowflake stacks context above the actual error."""
+    assert reason(RuntimeError("context\nmore context\n001003 (42000): SQL error")) == (
+        "001003 (42000): SQL error"
+    )
+
+
+def test_a_single_line_survives_whole():
+    assert reason(ValueError("just this")) == "just this"
+
+
+def test_surrounding_whitespace_is_trimmed_from_the_line_it_returns():
+    """Snowflake indents its continuation lines. Without the strip the summary carries the
+    indentation into a column-aligned report, and no other case here has any -- mutating the
+    return to drop `.strip()` left the whole file green."""
+    assert reason(RuntimeError("ctx\n   001003 (42000): SQL error   ")) == (
+        "001003 (42000): SQL error"
+    )
+
+
+def test_the_limit_truncates_and_is_per_caller():
+    assert reason(RuntimeError("x" * 200)) == "x" * 70
+    assert reason(RuntimeError("x" * 200), 30) == "x" * 30
+
+
+@pytest.mark.parametrize("exc", [RuntimeError(""), RuntimeError("\n"), ValueError()])
+def test_no_input_makes_it_raise(exc):
+    """The property that matters: this is called from handlers that must not fail."""
+    assert reason(exc), f"empty summary for {exc!r}"


### PR DESCRIPTION
The last structural finding from the post-merge review of PR #1 — and the second whose
"needs a live warehouse" deferral had expired. The decision here is **pure**: given the key
list and the column types it returns a plan, so lifting it out of `main` makes it testable
with no database and no fake cursor.

## The defect

The recast direction was decided **one pair at a time**, ignoring the other children of the
same parent column. With `P.K` TEXT, `C1.K` TEXT and `C2.K` NUMBER: the C1/P pair agrees and
is skipped, then C2 moves `P.K` to NUMBER and **C1 is left TEXT against a NUMBER parent** —
its foreign key no longer declarable. The script prints `aligned 1 columns` and says nothing
about C1.

## Two rounds of my own fix were wrong, and the gate blocked both

**Grouping by parent moved the defect one level down.** A column that moves as a *child*
didn't carry *its* children. On `G1/G2/G3 → C → P`, the parent group moved `C.K` to NUMBER,
then C's own group read `C.K`'s **original** text type and left all three grandchildren
behind — three relationships broken where the pair rule broke one. Same stale-type shape as
the `align_pairs` bug in #32, one file over.

Foreign keys chain, so the unit is the **connected component**. Union-find: every column
reachable through a key ends at the same type, at any depth.

**Then the application still had to move with the plan.** Deciding by component while probing
per *table* splits it anyway: a `P` that fails the loss probe — the population this script
exists for — left `C1` rewritten to NUMBER against a still-TEXT parent, two tables that
**agreed before the run**. So `plan_recasts` returns one entry per component and
`probe_component` checks every member before anything is written. That is the discipline
`align_pairs` states for pairs — decide both sides before writing either — at component
scale. Third time this session the same shape needed fixing in a different file.

## What changed in behaviour

- An id is a number, so a component holding any numeric member goes numeric; an all-text
  component is left alone.
- Where a component holds several numeric types, the target comes from a **rank** (integer
  families over floating) with ties broken by **declared precision and scale, widest first**.
  A plain string compare put `NUMBER(10,0)` before `NUMBER(38,0)` — "1" sorts before "3" — so
  a 38-digit parent was *narrowed to ten*, while against `NUMBER(9,0)` the same compare
  widened. Widening cannot lose a value; narrowing can.
- **A child's type can now rewrite a parent table.** With `C.K` TEXT against `P1.K NUMBER`
  and `P2.K FLOAT`, all three are one component, so the disagreeing parent is recast too and
  both keys stay declarable. Under the pair rule one of them simply lost.

## Nineteen tests, every one mutation-checked

Mutations that go red: removing the unions so nothing chains; taking the target from the
first member only; plain alphabetical ranking (which hands the component to FLOAT); the plain
string tie-break; probing only the first table of a component; a lossy column reporting
nothing; a reason that drops the table name; and — the blocker's own shape — emitting one
plan entry **per table** instead of per component.

## Three things I got wrong first, all caught by running the mutation

- A test asserted order-independence using the shared-**parent** case and claimed the pair
  rule was order-dependent there. It wasn't — `types` is read fresh per pair and never
  updated, so both orders agreed and **the test passed against the bug it named**.
- Another asserted only `forward == reverse` and never the plan's value; two identical wrong
  answers satisfy that. It asserts the value now.
- A comment claimed the deterministic union root keeps the plan stable. It doesn't —
  components are disjoint sets of `(table, column)`, so every target is identical whichever
  end becomes the root, and mutating it leaves the suite green. Kept for readability, and the
  comment says so.

Local suite `2069 passed`, and the driver import is deferred so the module loads without the
warehouse extra.
