### PR TITLE
Evaluate two external text-to-SQL models against this engine's numbers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,7 @@ MNEMIQ_SOURCE_ID=  # single-source id
 MNEMIQ_STORE_PATH=  # DuckDB semantic store path
 MNEMIQ_MODE=  # default answer mode: instant|thinking|deep
 MNEMIQ_WRITE_ENABLED=False  # attach the source read-write (governed writes)
+MNEMIQ_CARD_STYLE=cards  # schema card form for the GENERATOR: cards|ddl. `ddl` renders CREATE TABLE for a model fine-tuned on DDL; the retrieval index always embeds `cards`.
 MNEMIQ_GUIDED_SQL=False  # constrained decoding: force non-empty sql (response_format json_schema; works on vLLM and OpenAI-compatible endpoints)
 MNEMIQ_ASSERTIVE_SQL=False  # assertive prompt: attempt an answer instead of deferring
 MNEMIQ_GUARD_UNDEFINED_TERMS=False  # M35: refuse a declared business term with no certified definition (withdrawn -- see plan_query)

--- a/scripts/run_native_slm.py
+++ b/scripts/run_native_slm.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+"""Run a text-to-SQL SLM through ITS OWN native prompt, not mnemiq's.
+
+This is a POSITIVE CONTROL, not a product measurement. Arctic-Text2SQL-R1 and
+OmniSQL are trained on the OmniSQL prompt template; feeding them mnemiq's
+prompt and reading a low score would confound "bad model" with "wrong prompt".
+So this script reproduces the model's native input as faithfully as it can and
+asks one question: does our harness reproduce roughly the score the model's
+authors published? It reports EX over every case it ran, and additionally over a
+subset if `<out>.excluded.json` exists beside the output.
+
+KNOWN CONFOUND, not fixed: the prompt's stock sentence claims the schema block
+carries primary keys, foreign keys and constraints. It does not -- the blocks are
+columns and example values only. On a join-heavy benchmark a low reproduction is
+therefore partly attributable to this, which is the confound the control exists
+to rule out. The wording is verbatim from the reference prompt and changing it
+would trade one fidelity gap for another.
+
+If it does NOT, the gap is in the harness, the subset, or the grading -- and
+every later number comparing this model to mnemiq is uninterpretable until
+that is resolved. Nothing else should be run before this passes.
+
+The prompt format is taken verbatim from OmniSQL's own worked example
+(github.com/RUCKBReasoning/OmniSQL, examples/example_1.txt). Its schema block
+carries per-column example VALUES -- the model's native input is a
+value-grounded schema, which is the profiling step under another name.
+
+Grading reuses `mnemiq.eval.grade.results_match(..., allow_extra_columns=False)`,
+the BIRD execution-accuracy reading of the contract agreed with beacon. Output
+is the JSONL shape `beacon/scripts/load_eval_reports.py` ingests, so beacon
+re-grades every row independently and prints the disagreement table.
+
+Usage:
+    source .env                      # MNEMIQ_PG_DSN etc.; Settings reads os.environ only
+    .venv/bin/python scripts/run_native_slm.py \\
+        --base-url http://HOST:8000/v1 --model arctic --limit 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures as cf
+import datetime
+import decimal
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse as up
+import urllib.request
+
+import sqlite3
+
+import psycopg
+import pyarrow as pa
+
+from mnemiq.eval.bird import load_bird
+from mnemiq.eval.grade import normalize, results_match
+
+ROWS_PREVIEW = 1000  # mnemiq caps result sets here; match it so both sides preview alike
+
+MINIDEV = os.environ.get(
+    "MNEMIQ_MINIDEV_DIR", os.path.expanduser("~/src/dataset/bird-minidev/MINIDEV"))
+
+# Verbatim from OmniSQL examples/example_1.txt. Do not "improve" the wording:
+# the model was trained against these exact strings, and paraphrase is drift.
+PROMPT = """Task Overview:
+You are a data science expert. Below, you are provided with a database schema \
+and a natural language question. Your task is to understand the schema and \
+generate a valid SQL query to answer the question.
+
+Database Engine:
+{engine}
+
+Database Schema:
+{schema}
+This schema describes the database's structure, including tables, columns, \
+primary keys, foreign keys, and any relevant relationships or constraints.
+
+Question:
+{question}
+
+Instructions:
+- Make sure you only output the information that is asked in the question. \
+If the question asks for a specific column, make sure to only include that \
+column in the SELECT clause, nothing more.
+- The generated query should return all of the information asked in the \
+question without any missing or extra information.
+- Before generating the final SQL query, please think through the steps of how \
+to write the query.
+
+Output Format:
+In your answer, please enclose the generated SQL query in a code block:
+```sql
+-- Your SQL query
+```
+
+Take a deep breath and think step by step to find the correct SQL query."""
+
+
+def bird_dsn(base: str, db: str = "bird_dev") -> str:
+    return up.urlparse(base)._replace(path=f"/{db}").geturl()
+
+
+def tables_by_db() -> dict[str, list[str]]:
+    with open(os.path.join(MINIDEV, "dev_tables.json")) as fh:
+        return {e["db_id"]: list(e["table_names_original"]) for e in json.load(fh)}
+
+
+def build_schema(conn: psycopg.Connection, tables: list[str], samples: int = 2) -> str:
+    """CREATE TABLE blocks with per-column example values, OmniSQL style.
+
+    Values come from the live `bird_dev`, not from the SQLite originals, so the
+    schema the model reads is the schema its SQL will actually run against.
+    """
+    # `dev_tables.json` keeps BIRD's original casing (`Patient`, `Player_Attributes`) but the
+    # loader lowercased every table into `bird_dev`. An exact-name lookup therefore returned
+    # nothing and SILENTLY DROPPED the table -- two databases went out with an entirely empty
+    # schema, and the model invented plausible names (`patients`, `players`) that could not
+    # execute. Resolve case-insensitively, and refuse to emit a schema that lost a table.
+    with conn.cursor() as cur:
+        cur.execute("SELECT table_name FROM information_schema.tables WHERE table_schema='public'")
+        live = {r[0].lower(): r[0] for r in cur.fetchall()}
+    resolved, dropped = [], []
+    for t in tables:
+        actual = live.get(t.lower())
+        (resolved if actual else dropped).append(actual or t)
+    if dropped:
+        raise RuntimeError(
+            f"schema would omit {len(dropped)} declared table(s): {dropped}. "
+            "A partial schema is scored as a model error; fix the mapping instead.")
+
+    blocks: list[str] = []
+    for t in resolved:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT column_name, data_type FROM information_schema.columns "
+                "WHERE table_schema='public' AND table_name=%s ORDER BY ordinal_position", (t,))
+            cols = cur.fetchall()
+        if not cols:
+            raise RuntimeError(f"table {t!r} resolved but has no columns -- refusing to continue")
+        lines = []
+        for name, dtype in cols:
+            ex = ""
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        f'SELECT DISTINCT "{name}" FROM "{t}" '
+                        f'WHERE "{name}" IS NOT NULL LIMIT {samples}')
+                    vals = [r[0] for r in cur.fetchall()]
+                if vals:
+                    # Normalise BEFORE repr. Raw `repr(date(2012, 8, 26))` renders
+                    # `datetime.date(2012, 8, 26)` into the schema block -- Python
+                    # internals shown to a model that was trained on `'2012-08-26'`,
+                    # in every date column of every prompt.
+                    rendered = ", ".join(
+                        repr(_cell(v) if not isinstance(v, str) else v[:40]) for v in vals)
+                    ex = f" -- example: [{rendered}]"
+            except Exception:
+                conn.rollback()  # a column we cannot sample is not a reason to fail the case
+            # Quote anything not a bare lowercase identifier: `Academic Year` and `County Code`
+            # are real mini-dev column names, and a model told they are bare will emit
+            # unquoted Postgres that cannot parse -- a prompt defect scored as a model error.
+            ident = name if re.fullmatch(r"[a-z_][a-z0-9_]*", name) else f'"{name}"'
+            lines.append((f"    {ident} {dtype}", ex))
+        # Comma separates columns; the comment trails it, as in OmniSQL's example. The last
+        # column takes no comma -- that example only gets away with one because PRIMARY KEY
+        # and CONSTRAINT lines follow it, and these blocks carry neither.
+        body = "\n".join(
+            decl + ("," if i < len(lines) - 1 else "") + ex
+            for i, (decl, ex) in enumerate(lines))
+        blocks.append(f"CREATE TABLE {t} (\n{body}\n);")
+    return "\n\n".join(blocks)
+
+
+def _cell(v):
+    """One result cell as a JSON-native value.
+
+    `json.dumps(default=str)` looked harmless and silently stringified every
+    `Decimal`, so beacon compared '109398.548387096774' against the NUMBER
+    109398.548387096774 and failed 12 answers my own grader had passed. The
+    disagreement was mine, not the graders'. Numbers stay numbers.
+    """
+    if isinstance(v, decimal.Decimal):
+        return float(v)
+    if isinstance(v, (datetime.date, datetime.datetime, datetime.time)):
+        return v.isoformat()
+    if isinstance(v, (bytes, bytearray, memoryview)):
+        return bytes(v).hex()
+    if isinstance(v, (int, float, str, bool)) or v is None:
+        return v
+    return str(v)
+
+
+SQL_BLOCK = re.compile(r"```sql\s*(.*?)```", re.S | re.I)
+
+
+def extract_sql(text: str) -> str:
+    """Last fenced sql block wins -- these models reason first and answer last."""
+    found = SQL_BLOCK.findall(text or "")
+    if found:
+        return found[-1].strip()
+    # No fence: take the tail from the LAST SELECT/WITH. `re.search` returns the leftmost
+    # match, which picks up a discarded draft ("SELECT count(*) ... but that is wrong.
+    # Actually: SELECT name ...") and hands back something that cannot execute -- an
+    # extraction defect then scored as a model error.
+    starts = [m.start() for m in re.finditer(r"(?is)\b(?:select|with)\b", text or "")]
+    return (text[starts[-1]:].strip() if starts else "")
+
+
+class RequestRejected(Exception):
+    """The server answered and refused. Not retryable, and not a transport fault."""
+
+
+class TransportFailed(Exception):
+    """The server could not be reached. NOT the same as a model that answered badly.
+
+    Collapsing the two is how a dead SSH tunnel became "the model emitted no SQL" and
+    produced a 15.20% that looked like a result. A transport failure must reach the
+    summary as its own state and must void the run, not enter the denominator.
+    """
+
+
+def generate(base_url: str, model: str, prompt: str, timeout: float, max_tokens: int,
+             attempts: int = 4, n: int = 1, temperature: float = 0.0) -> list[str]:
+    """`n` completions in ONE request, so the prompt is prefilled once and only decode scales.
+
+    Returns a list so the caller cannot silently read a single answer out of a vote.
+    """
+    body = json.dumps({
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+        "n": n,
+    }).encode()
+    last: Exception | None = None
+    for attempt in range(attempts):
+        req = urllib.request.Request(
+            base_url.rstrip("/") + "/chat/completions", data=body,
+            headers={"Content-Type": "application/json"}, method="POST")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as r:
+                choices = json.loads(r.read())["choices"]
+                return [c["message"]["content"] for c in choices]
+        except urllib.error.HTTPError as exc:
+            # 4xx is the server understanding us and refusing -- a context-length 400 is a
+            # prompt problem, and retrying it four times then reporting "fix the transport"
+            # names the wrong fault.
+            # NOT `body`: that name holds the encoded request payload, and assigning the
+            # error text to it made attempt 2 rebuild the request with `data=<str>`, which
+            # raises TypeError inside urlopen before any network call -- so the documented
+            # backoff never reached the server on the 5xx path and one transient 503 voided
+            # the run with a Python type error as its diagnosis.
+            detail = exc.reason
+            try:
+                detail = exc.read().decode("utf-8", "replace")[:300] or exc.reason
+            except Exception:  # noqa: BLE001 - a body we cannot read is not a second failure
+                pass
+            if 400 <= exc.code < 500:
+                raise RequestRejected(f"HTTP {exc.code}: {detail}") from exc
+            last = exc
+            if attempt < attempts - 1:
+                time.sleep(2 ** attempt)  # the 5xx path must back off too, not fall through
+        except Exception as exc:  # noqa: BLE001 - any transport fault is retryable here
+            last = exc
+            if attempt < attempts - 1:
+                time.sleep(2 ** attempt)  # 1s, 2s, 4s: rides out a tunnel restart
+    raise TransportFailed(str(last))
+
+
+def sqlite_conn(db_id: str):
+    """BIRD ships one .sqlite per database; there is no flat shared schema as in `bird_dev`."""
+    path = os.path.join(MINIDEV, "dev_databases", db_id, f"{db_id}.sqlite")
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"no SQLite database for {db_id!r} at {path}")
+    con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    con.text_factory = lambda b: b.decode("utf-8", "replace")  # BIRD has non-UTF8 bytes
+    return con
+
+
+def build_schema_sqlite(con, samples: int = 2) -> str:
+    """The same value-grounded CREATE TABLE blocks, read from SQLite's own catalog."""
+    names = [r[0] for r in con.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")]
+    blocks = []
+    for t in names:
+        cols = [(r[1], r[2] or "text") for r in con.execute(f'PRAGMA table_info("{t}")')]
+        if not cols:
+            continue
+        lines = []
+        for name, dtype in cols:
+            ex = ""
+            try:
+                vals = [r[0] for r in con.execute(
+                    f'SELECT DISTINCT "{name}" FROM "{t}" WHERE "{name}" IS NOT NULL '
+                    f'LIMIT {samples}')]
+                if vals:
+                    ex = " -- example: [" + ", ".join(
+                        repr(_cell(v) if not isinstance(v, str) else v[:40]) for v in vals) + "]"
+            except Exception:
+                pass
+            ident = name if re.fullmatch(r"[a-z_][a-z0-9_]*", name) else f'"{name}"'
+            lines.append((f"    {ident} {dtype}", ex))
+        body = "\n".join(decl + ("," if i < len(lines) - 1 else "") + ex
+                          for i, (decl, ex) in enumerate(lines))
+        blocks.append(f"CREATE TABLE {t} (\n{body}\n);")
+    return "\n\n".join(blocks)
+
+
+def run_sql_sqlite(con, sql: str, timeout_s: float = 30.0) -> pa.Table | None:
+    """Execute with a hard wall-clock cap.
+
+    A candidate with a missing join condition is a cartesian product, and `financial.trans`
+    has about a million rows. Without a cap one such query span at 97% CPU for 1h39m and
+    blocked the whole grading pass -- the run looked alive, wrote nothing, and forfeited
+    every generation still held in memory. SQLite has no statement timeout, so the abort
+    goes through the progress handler, which is the only interrupt point it offers.
+    """
+    deadline = time.time() + timeout_s
+    con.set_progress_handler(lambda: 1 if time.time() > deadline else 0, 10_000)
+    try:
+        cur = con.execute(sql)
+        rows = cur.fetchall()
+        names = [d[0] for d in cur.description] if cur.description else []
+        cols = list(zip(*rows)) if rows else [() for _ in names]  # by position; see run_sql
+        return pa.Table.from_arrays([pa.array(list(c)) for c in cols], names=names)
+    except Exception:
+        return None
+    finally:
+        con.set_progress_handler(None, 0)
+
+
+def _result_key(t: pa.Table | None):
+    """A hashable canonical form of a result set, for voting.
+
+    Candidates vote on WHAT THEY RETURNED, not on how they spelled it -- two different
+    queries with the same rows are one vote, which is the whole point of execution-based
+    self-consistency. Row order is discarded (sorted) because BIRD's own EX compares sets.
+    `None` means the query did not run, and non-running candidates never win a vote.
+    """
+    if t is None or t.num_columns == 0:
+        return None
+    rows = [tuple(normalize(v) for v in r)
+            for r in zip(*[c.to_pylist() for c in t.columns])]
+    return tuple(sorted(rows, key=repr))
+
+
+def vote(cands: list[tuple[str, pa.Table | None]]):
+    """Pick the SQL whose result set the most candidates agree on.
+
+    Ties and all-failed groups resolve to the FIRST candidate offering that result, so the
+    function is deterministic given its input. Returns (sql, table, n_votes, n_groups).
+    """
+    groups: dict[object, list[tuple[str, pa.Table | None]]] = {}
+    for sql, tbl in cands:
+        key = _result_key(tbl)
+        if key is None:
+            continue                      # a query that did not run is not evidence
+        groups.setdefault(key, []).append((sql, tbl))
+    if not groups:
+        return (cands[0][0] if cands else ""), None, 0, 0
+    best = max(groups.values(), key=len)
+    return best[0][0], best[0][1], len(best), len(groups)
+
+
+def run_sql(conn: psycopg.Connection, sql: str, timeout_s: float = 30.0) -> pa.Table | None:
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f"SET LOCAL statement_timeout = {int(timeout_s * 1000)}")
+            cur.execute(sql)
+            rows = cur.fetchall()
+            names = [d.name for d in cur.description] if cur.description else []
+        # By POSITION, not through a dict: `SELECT T2.name, T1.name, ...` is real gold in
+        # this corpus (question 901), and a dict collapses the two into one column -- for
+        # the gold AND the candidate, so a candidate missing a column grades correct. The
+        # engine's own adapter avoids this the same way and says so.
+        cols = list(zip(*rows)) if rows else [() for _ in names]
+        return pa.Table.from_arrays([pa.array(list(c)) for c in cols], names=names)
+    except Exception:
+        conn.rollback()
+        return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base-url", required=True, help="vLLM OpenAI-compatible /v1 URL")
+    ap.add_argument("--model", required=True, help="served-model-name")
+    ap.add_argument("--out", default="eval-reports/native-slm.jsonl")
+    ap.add_argument("--engine", default="PostgreSQL", help="the Database Engine line")
+    ap.add_argument("--backend", choices=["postgres", "sqlite"], default="postgres",
+                    help="sqlite runs BIRD's own per-database files in its native dialect")
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--db", action="append", dest="dbs")
+    ap.add_argument("--timeout", type=float, default=180.0)
+    ap.add_argument("--max-tokens", type=int, default=2048)
+    ap.add_argument("--candidates", type=int, default=1,
+                    help="samples per question; >1 enables execution-based majority voting")
+    ap.add_argument("--temperature", type=float, default=None,
+                    help="default 0.0 single-shot, 0.8 when --candidates > 1")
+    ap.add_argument("--concurrency", type=int, default=8,
+                    help="parallel generation requests; execution stays sequential")
+    args = ap.parse_args()
+    if args.temperature is None:
+        # Voting needs diverse samples; greedy would return the same answer N times and
+        # report a unanimous vote that measured nothing. 0.8 is the paper's rollout value.
+        args.temperature = 0.0 if args.candidates == 1 else 0.8
+
+    pg = os.environ.get("MNEMIQ_PG_DSN")
+    if not pg and args.backend == "postgres":
+        print("MNEMIQ_PG_DSN unset -- `source .env` first", file=sys.stderr)
+        return 2
+
+    sqlite_mode = args.backend == "sqlite"
+    if sqlite_mode and args.engine == "PostgreSQL":
+        # The prompt must name the engine the SQL will actually run on; leaving the default
+        # here would tell a SQLite-trained model to write Postgres against SQLite.
+        args.engine = "SQLite"
+    cases = load_bird(MINIDEV, dialect="sqlite" if sqlite_mode else "postgresql",
+                      limit=args.limit, db_ids=args.dbs)
+    per_db = tables_by_db()
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+
+    conns: dict[str, object] = {}
+    if sqlite_mode:
+        for case in cases:
+            db = case.db_id or ""
+            if db not in conns:
+                conns[db] = sqlite_conn(db)
+        conn = None
+    else:
+        conn = psycopg.connect(bird_dsn(pg))
+    exec_sql = (lambda q, db: run_sql_sqlite(conns[db], q)) if sqlite_mode else \
+               (lambda q, db: run_sql(conn, q))
+    schema_cache: dict[str, str] = {}
+    counts = {"correct": 0, "wrong": 0, "error": 0}
+    n_empty_sql = 0
+    n_transport = 0
+    n_votes_for_winner = n_groups_total = 0
+
+    # Schemas first: build_schema samples the database, so it shares the one connection
+    # and must finish before any worker thread touches it.
+    for case in cases:
+        db = case.db_id or ""
+        if db not in schema_cache:
+            schema_cache[db] = (build_schema_sqlite(conns[db]) if sqlite_mode
+                                else build_schema(conn, per_db.get(db, [])))
+
+    # GENERATION is parallel (~15s each, and the server batches happily); EXECUTION and
+    # GRADING stay sequential on the single connection. Splitting them this way keeps the
+    # concurrency entirely inside HTTP calls that share no state -- a pool of threads all
+    # issuing psycopg on one connection is a data race, not a speedup.
+    def gen_one(case):
+        prompt = PROMPT.format(
+            engine=args.engine, schema=schema_cache[case.db_id or ""], question=case.question)
+        t0 = time.time()
+        try:
+            raws = generate(args.base_url, args.model, prompt, args.timeout, args.max_tokens,
+                            n=args.candidates, temperature=args.temperature)
+        except RequestRejected as exc:
+            # The server answered and refused. Not a transport fault, so it does not void
+            # the run -- but it is not an answer either, so it grades as no SQL.
+            print(f"  REQUEST REJECTED for {case.id}: {exc}", file=sys.stderr)
+            return [""], (time.time() - t0) * 1000.0
+        except TransportFailed as exc:
+            print(f"  TRANSPORT FAILED for {case.id}: {exc}", file=sys.stderr)
+            return None, (time.time() - t0) * 1000.0   # None != [] : unreached, not unanswered
+        return [extract_sql(r) for r in raws], (time.time() - t0) * 1000.0
+
+    print(f"generating {len(cases)} with {args.concurrency} workers ...", flush=True)
+    t_gen = time.time()
+    with cf.ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+        generated = list(pool.map(gen_one, cases))  # map preserves input order
+    print(f"generation done in {time.time() - t_gen:.0f}s; executing and grading ...", flush=True)
+    # Generation is the expensive half and lived only in memory until a grading stall threw
+    # it away. Persist it first: a crash after this point costs minutes, not GPU hours.
+    gen_path = args.out + ".generations.json"
+    with open(gen_path, "w") as gh:
+        json.dump([{"case_id": c.id, "sql": g[0], "ms": g[1]}
+                   for c, g in zip(cases, generated)], gh)
+    print(f"generations saved to {gen_path}", flush=True)
+
+    with open(args.out, "w") as out:
+        for i, (case, (sql, ms)) in enumerate(zip(cases, generated), 1):
+            db = case.db_id or ""
+            if sql is not None:
+                # Execute EVERY candidate, then vote on results. With --candidates 1 this is
+                # one execution and the vote is a no-op, so the single-shot path is unchanged.
+                executed = [(q, exec_sql(q, db) if q else None) for q in sql]
+                sql, cand_tbl, votes, groups = vote(executed)
+                n_votes_for_winner += votes
+                n_groups_total += groups
+            if sql is None:
+                n_transport += 1
+                out.write(json.dumps({
+                    "case_id": case.id, "outcome": "error", "sql": "",
+                    "db_id": db, "ms": round(ms, 1), "error": "transport",
+                }) + "\n")
+                counts["error"] = counts.get("error", 0) + 1
+                continue
+            if not sql:
+                n_empty_sql += 1
+
+            cand = cand_tbl
+            gold = exec_sql(case.gold_sql, db) if case.gold_sql else None
+
+            if gold is None:
+                outcome = "error"          # our gold did not run: not the model's fault
+            elif cand is None:
+                outcome = "wrong"          # model produced nothing runnable
+            else:
+                outcome = "correct" if results_match(
+                    gold, cand, allow_extra_columns=False) else "wrong"
+            counts[outcome] = counts.get(outcome, 0) + 1
+
+            # beacon GRADES BY COMPARISON and never executes SQL, so a push that carries
+            # only the query is refused. Ship the rows this run actually returned, bounded,
+            # with the true count beside them.
+            rows_preview = row_count = None
+            if cand is not None:
+                as_rows = [list(t) for t in zip(*[c.to_pylist() for c in cand.columns])] \
+                    if cand.num_columns else []
+                row_count = len(as_rows)
+                rows_preview = [[_cell(v) for v in r] for r in as_rows[:ROWS_PREVIEW]]
+
+            out.write(json.dumps({
+                "case_id": case.id, "outcome": outcome, "sql": sql,
+                "db_id": db, "ms": round(ms, 1),
+                "engine_rows": rows_preview, "engine_row_count": row_count,
+            }) + "\n")
+            out.flush()
+            if i % 25 == 0 or i == len(cases):
+                # Divide by what was GRADED. Dividing by `i` prints the very quantity the
+                # void rule below suppresses, into a log that gets read back.
+                ex = 100.0 * counts["correct"] / max(1, i - n_transport)
+                print(f"  [{i}/{len(cases)}] EX={ex:.2f}%  {counts}", flush=True)
+
+    n = len(cases)
+    print(f"\nmodel={args.model} engine={args.engine} n={n}")
+    if args.candidates > 1:
+        graded = max(1, n - n_transport)
+        print(f"voting: {args.candidates} samples @ T={args.temperature}  "
+              f"mean winning votes {n_votes_for_winner / graded:.2f}/{args.candidates}  "
+              f"mean distinct result groups {n_groups_total / graded:.2f}")
+    print(f"correct={counts['correct']} wrong={counts['wrong']} "
+          f"error={counts['error']}  empty-sql={n_empty_sql}  transport-failed={n_transport}")
+    print(f"wrote {args.out}")
+
+    # A run that could not reach the server for some of its questions has no score. Printing
+    # one anyway is how 244 refused connections became "the model scored 15.20%".
+    if n_transport:
+        print(f"\nRUN VOID: {n_transport}/{n} questions never reached the model. "
+              f"No accuracy is reported. Fix the transport and re-run.", file=sys.stderr)
+        print("NATIVE_CONTROL_EXIT=1")
+        return 1
+
+    ex = 100.0 * counts["correct"] / n if n else 0.0
+    print(f"EX={ex:.2f}% over all {n}")
+    # Resolved BESIDE --out, not against the process CWD: a fixed relative path either
+    # skipped silently or applied one run's exclusions to another's output.
+    excluded_path = args.out + ".excluded.json"
+    if os.path.exists(excluded_path):
+        with open(excluded_path) as eh:
+            excl = set(json.load(eh))
+        kept = [c for c in cases if c.id not in excl]
+        with open(args.out) as fh:
+            rows = {json.loads(line)["case_id"]: json.loads(line) for line in fh}
+        corr = sum(1 for c in kept if rows.get(c.id, {}).get("outcome") == "correct")
+        print(f"EX={100.0 * corr / len(kept):.2f}% over the {len(kept)} mnemiq also graded "
+              f"(gold <= 1000 rows) -- this is the like-for-like number")
+    print("NATIVE_CONTROL_EXIT=0")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/slm-pipeline-env.sh
+++ b/scripts/slm-pipeline-env.sh
@@ -16,12 +16,22 @@
 # runs it in a CHILD shell -- it prints all three confirmation lines, exits 0, and the
 # parent's MNEMIQ_LLM_* stay on the hosted model. The operator then runs the "local SLM"
 # arm against the hosted endpoint holding a receipt that says otherwise. Refuse that.
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+# `BASH_SOURCE` is undefined in zsh, and the operator's login shell IS zsh -- the first
+# version of this guard passed under `zsh ./slm-pipeline-env.sh` and printed the false
+# receipt it exists to refuse. Detect sourcing in both shells.
+_sourced=0
+if [ -n "${ZSH_VERSION:-}" ]; then
+  case "${ZSH_EVAL_CONTEXT:-}" in *:file*) _sourced=1 ;; esac
+elif [ -n "${BASH_VERSION:-}" ]; then
+  (return 0 2>/dev/null) && _sourced=1
+fi
+if [ "$_sourced" -ne 1 ]; then
   echo "slm-pipeline-env.sh must be SOURCED, not executed:" >&2
-  echo "  source ${BASH_SOURCE[0]} <base-url> <model-name>" >&2
+  echo "  source scripts/slm-pipeline-env.sh <base-url> <model-name>" >&2
   echo "Executing it changes nothing in your shell." >&2
   exit 64
 fi
+unset _sourced
 
 # `set -u` is deliberately NOT used: this file is sourced, and leaving nounset on would
 # persist into the operator's interactive shell for the rest of the session.
@@ -30,6 +40,10 @@ _base="${1:?usage: source slm-pipeline-env.sh <base-url> <model-name>}"
 _model="${2:?usage: source slm-pipeline-env.sh <base-url> <model-name>}"
 
 : "${MNEMIQ_LLM_BASE_URL:?source .env first}"
+# The key is propagated by all three pins below and was never checked: unset, embed/enrich
+# export empty, fall through to the `local` placeholder, and hit the hosted URL with the
+# vLLM key -- a 401 under a line that has just printed "hosted (unchanged)".
+: "${MNEMIQ_LLM_API_KEY:?source .env first}"
 
 # 1. hold embeddings where they already work
 export MNEMIQ_EMBED_BASE_URL="${MNEMIQ_EMBED_BASE_URL:-$MNEMIQ_LLM_BASE_URL}"

--- a/scripts/slm-pipeline-env.sh
+++ b/scripts/slm-pipeline-env.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Source this to run mnemiq's pipeline with GENERATION on a local vLLM model while
+# everything else stays on the hosted endpoint. Usage:
+#
+#   set -a; source .env; set +a          # Settings() reads os.environ only, no env_file
+#   source scripts/slm-pipeline-env.sh http://HOST:8003/v1 arctic
+#
+# THE ORDER MATTERS. `embed_base_url` and `embed_api_key` default to the CHAT values,
+# so repointing chat at vLLM drags embeddings along with it -- to a server that has no
+# embedding model, which fails retrieval rather than reporting a misconfiguration.
+# Pin embeddings (and enrichment) to the hosted endpoint FIRST, then move chat.
+#
+# Enrichment is pinned for a second reason: this arm exists to vary the GENERATOR and
+# nothing else. Let the local model enrich as well and two variables move at once.
+# BLOCKER this script earned: it is mode 755 with a shebang, so `./slm-pipeline-env.sh`
+# runs it in a CHILD shell -- it prints all three confirmation lines, exits 0, and the
+# parent's MNEMIQ_LLM_* stay on the hosted model. The operator then runs the "local SLM"
+# arm against the hosted endpoint holding a receipt that says otherwise. Refuse that.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  echo "slm-pipeline-env.sh must be SOURCED, not executed:" >&2
+  echo "  source ${BASH_SOURCE[0]} <base-url> <model-name>" >&2
+  echo "Executing it changes nothing in your shell." >&2
+  exit 64
+fi
+
+# `set -u` is deliberately NOT used: this file is sourced, and leaving nounset on would
+# persist into the operator's interactive shell for the rest of the session.
+
+_base="${1:?usage: source slm-pipeline-env.sh <base-url> <model-name>}"
+_model="${2:?usage: source slm-pipeline-env.sh <base-url> <model-name>}"
+
+: "${MNEMIQ_LLM_BASE_URL:?source .env first}"
+
+# 1. hold embeddings where they already work
+export MNEMIQ_EMBED_BASE_URL="${MNEMIQ_EMBED_BASE_URL:-$MNEMIQ_LLM_BASE_URL}"
+export MNEMIQ_EMBED_API_KEY="${MNEMIQ_EMBED_API_KEY:-$MNEMIQ_LLM_API_KEY}"
+
+# 2. hold the semantic layer constant
+export MNEMIQ_ENRICH_BASE_URL="${MNEMIQ_ENRICH_BASE_URL:-$MNEMIQ_LLM_BASE_URL}"
+export MNEMIQ_ENRICH_API_KEY="${MNEMIQ_ENRICH_API_KEY:-$MNEMIQ_LLM_API_KEY}"
+export MNEMIQ_ENRICH_MODEL="${MNEMIQ_ENRICH_MODEL:-$MNEMIQ_LLM_MODEL}"
+
+# 3. the judge follows chat too -- `verify_endpoint()` defaults by the same `or
+#    llm_base_url` rule as `embed_endpoint()`, so under MNEMIQ_VERIFY=1 it would ride
+#    onto the local model and move a second variable.
+export MNEMIQ_VERIFY_BASE_URL="${MNEMIQ_VERIFY_BASE_URL:-$MNEMIQ_LLM_BASE_URL}"
+export MNEMIQ_VERIFY_API_KEY="${MNEMIQ_VERIFY_API_KEY:-$MNEMIQ_LLM_API_KEY}"
+# The judge's MODEL resolves separately (`verify_model or llm_model`), so pinning only
+# url+key would ask the hosted endpoint for the local served-model-name.
+export MNEMIQ_VERIFY_MODEL="${MNEMIQ_VERIFY_MODEL:-$MNEMIQ_LLM_MODEL}"
+
+# 4. only now move generation
+export MNEMIQ_LLM_BASE_URL="$_base"
+export MNEMIQ_LLM_MODEL="$_model"
+export MNEMIQ_LLM_API_KEY="${MNEMIQ_LOCAL_API_KEY:-local}"   # vLLM ignores it; Settings requires one
+
+echo "generation -> $MNEMIQ_LLM_MODEL @ $MNEMIQ_LLM_BASE_URL"
+echo "embeddings -> hosted (unchanged)"
+echo "enrichment -> hosted (unchanged)"
+echo "verifier   -> hosted (unchanged)"
+unset _base _model

--- a/src/mnemiq/config.py
+++ b/src/mnemiq/config.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 
+from typing import Literal
+
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -76,6 +78,13 @@ class Settings(BaseSettings):
                                      description="default answer mode: instant|thinking|deep")
     write_enabled: bool = Field(default=False, description="attach the source read-write (governed writes)")
     # --- behavior levers / MCP standalone identity ---
+    # Validated, not free text: `style != "ddl"` in the renderer means `DDL` or `ddl ` would
+    # silently select the OTHER form, and the run record would not say which one produced the
+    # score -- a 35.7% form and a 50.5% form told apart only by shell history.
+    card_style: Literal["cards", "ddl"] = Field(default="cards",
+                            description="schema card form for the GENERATOR: cards|ddl. "
+                                        "`ddl` renders CREATE TABLE for a model fine-tuned "
+                                        "on DDL; the retrieval index always embeds `cards`.")
     guided_sql: bool = Field(default=False, description="constrained decoding: force non-empty sql (response_format json_schema; works on vLLM and OpenAI-compatible endpoints)")
     assertive_sql: bool = Field(default=False, description="assertive prompt: attempt an answer instead of deferring")
     # M35, off by default: withdrawn on its own pre-registered criterion. Beacon's answerable band

--- a/src/mnemiq/eval/engine.py
+++ b/src/mnemiq/eval/engine.py
@@ -196,6 +196,11 @@ def build_engine(
         # reached this door and not the product's -- which is why the test that guards it compares
         # the two call sites rather than either one alone.
         packet = retrieve(con, question, IDENTITY, authz, embedder, k=k,
+                          # Same Settings field the product door reads, not a second env
+                          # lookup: MNEMIQ_CARD_STYLE resolves through Settings, which
+                          # validates it, so `DDL` or a stray space cannot silently select
+                          # the other form.
+                          card_style=settings.card_style,
                           definitions=definitions, table_facts=snapshot.table_facts,
                           metrics=snapshot.metrics, dimensions=snapshot.dimensions,
                           columns=snapshot.columns, ontology_index=ontology_index,

--- a/src/mnemiq/runtime.py
+++ b/src/mnemiq/runtime.py
@@ -128,6 +128,9 @@ class Runtime:
                 # to 24 -- a second copy of a number is a second thing to forget.
                 k=self.settings.retrieval_k if self.settings else DEFAULT_RETRIEVAL_K,
                 table_facts=self.snapshot.table_facts if self.snapshot else (),
+                # Both doors pass this or the eval measures a prompt form `ask` cannot emit
+                # -- the M81 shape the two-doors guard exists to catch, which it did.
+                card_style=self.settings.card_style if self.settings else "cards",
                 # Definitions ride with the snapshot: the glossary channel had no runtime
                 # producer until the ontology digest, so this stayed unfed from Plan 08 until SP1.
                 definitions=self.snapshot.definitions if self.snapshot else (),

--- a/src/mnemiq/semantic/cards.py
+++ b/src/mnemiq/semantic/cards.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 from mnemiq.contract import Column, Snapshot
 from mnemiq.sql.policy import AccessPolicy
+
+
+_BARE_IDENT = re.compile(r"[a-z_][a-z0-9_]*")
 
 
 @dataclass
@@ -29,7 +33,8 @@ def render_facts_block(tf) -> str:
     return "\n".join(lines)
 
 
-def build_cards(snapshot: Snapshot, policy: AccessPolicy | None = None) -> list[SchemaCard]:
+def build_cards(snapshot: Snapshot, policy: AccessPolicy | None = None,
+                style: str = "cards") -> list[SchemaCard]:
     """One self-sufficient card per table: what it is, what it holds, how it joins.
 
     This is the retrieval unit -- indexed, matched, and later read by the agent to write
@@ -44,6 +49,10 @@ def build_cards(snapshot: Snapshot, policy: AccessPolicy | None = None) -> list[
     Redaction lives here, in the renderer, rather than in a pass over rendered text: parsing this
     format back apart would be a second implementation of the card vocabulary, free to drift from
     the one that writes it. Registers M7 and D52 are what that costs.
+
+    `style="ddl"` re-spells the finished card as `CREATE TABLE` for a generator that was
+    fine-tuned on DDL. It is deliberately NOT the default and NOT what `build_index`
+    embeds: the indexed card must stay the form top-k was measured on.
     """
     columns: dict[str, list[Column]] = {}
     for column in snapshot.columns:
@@ -60,6 +69,7 @@ def build_cards(snapshot: Snapshot, policy: AccessPolicy | None = None) -> list[
     cards: list[SchemaCard] = []
     for table in tables:
         lines = [f"TABLE {table}", "COLUMNS:"]
+        ddl: list[tuple[str, str, str]] = []   # (name, data_type, trailing note)
         for column in columns.get(table, []):
             if policy is not None and (table, column.name) in policy.denied:
                 continue  # not merely unreadable: the identity is not told it exists
@@ -75,6 +85,8 @@ def build_cards(snapshot: Snapshot, policy: AccessPolicy | None = None) -> list[
             if masked:
                 # Nameable, not readable. Everything below this point is derived from the values.
                 lines.append(line + " MASKED for this identity: do not select or filter on it.")
+                ddl.append((column.name, column.data_type or "text",
+                            "MASKED for this identity: do not select or filter on it."))
                 continue
             if column.description:
                 line += f" {column.description}"
@@ -98,10 +110,51 @@ def build_cards(snapshot: Snapshot, policy: AccessPolicy | None = None) -> list[
             if column.code_scheme:
                 line += f" Codes from {column.code_scheme.label}."
             lines.append(line)
+            # The DDL form is built from the SAME fields in the SAME redaction branch, never by
+            # parsing `line` back apart. A column name may itself contain parentheses --
+            # `Enrollment (K-12)` is a real mini-dev column -- so any split of the rendered
+            # prose lands in the wrong place, which is the drift the docstring above warns of.
+            # Include the parenthesised annotations, not just the trailing prose. Slicing
+            # past `"".join(parts)` dropped semantic_type and pii_level, so a column the
+            # cards form labels `(text, identifier, high)` reached a ddl-style generator
+            # with no PII marker at all.
+            annotations = ", ".join(
+                a for a in (column.semantic_type,
+                            column.pii_level if column.pii_level not in (None, "none") else None)
+                if a)
+            prose = line[len("".join(parts)):].strip()
+            ddl.append((column.name, column.data_type or "text",
+                        "; ".join(x for x in (annotations, prose) if x)))
 
         if table in joins:
             lines.append("RELATIONSHIPS:")
             lines.extend(joins[table])
 
-        cards.append(SchemaCard(object_id=table, text="\n".join(lines)))
+        text = ("\n".join(lines) if style != "ddl"
+                else _render_ddl(table, ddl, joins.get(table, [])))
+        cards.append(SchemaCard(object_id=table, text=text))
     return cards
+
+
+def _render_ddl(table: str, cols: list[tuple[str, str, str]], rels: list[str]) -> str:
+    """The same card, spelled as `CREATE TABLE`, from the structured columns.
+
+    A text-to-SQL model fine-tuned on DDL is sensitive to the SHAPE of its schema input, not
+    only its content: Arctic-Text2SQL-R1 scored 50.5% on mini-dev through its own
+    DDL-and-examples prompt and 35.7% on identical content through the `TABLE/COLUMNS:` form,
+    with retrieval, dialect and decoding each ruled out as the cause.
+
+    Callers pass what the redaction loop already decided -- a denied column never arrives, a
+    masked one arrives carrying its mask note -- so this re-spells and decides nothing.
+    """
+    if not cols:
+        return f"CREATE TABLE {table} (\n);"
+    body = "\n".join(
+        f"    {name if _BARE_IDENT.fullmatch(name) else chr(34) + name + chr(34)} {dtype}"
+        + ("," if i < len(cols) - 1 else "")
+        + (f"  -- {note}" if note else "")
+        for i, (name, dtype, note) in enumerate(cols))
+    out = f"CREATE TABLE {table} (\n{body}\n);"
+    if rels:
+        out += "\n-- " + "\n-- ".join(r.lstrip("- ") for r in rels)
+    return out

--- a/src/mnemiq/semantic/retrieval.py
+++ b/src/mnemiq/semantic/retrieval.py
@@ -57,14 +57,26 @@ def _rank(rows: list[tuple[str, float]]) -> dict[str, int]:
     return {object_id: rank for rank, (object_id, _score) in enumerate(rows, start=1)}
 
 
-def _attach_facts(cards: list[RetrievedCard], table_facts: Sequence[TableFacts]) -> None:
-    """Insert each retrieved table's structural-facts block right after its TABLE line. Facts
-    live here, NOT in the indexed card, so they never perturb retrieval top-k."""
+def _attach_facts(cards: list[RetrievedCard], table_facts: Sequence[TableFacts],
+                  card_style: str = "cards") -> None:
+    """Attach each retrieved table's structural-facts block. Facts live here, NOT in the
+    indexed card, so they never perturb retrieval top-k.
+
+    Where the block goes depends on the card form. Splicing after the first line is right
+    for `TABLE x` and WRONG for `CREATE TABLE x (` -- it drops `GRAIN:`/`GOTCHAS:` between
+    the header and the first column and hands the generator malformed DDL, which is the one
+    thing the ddl form exists to avoid. In ddl style the block follows the closing paren,
+    commented, so it is legal SQL either way.
+    """
     by_id = {tf.object_id: tf for tf in table_facts}
     for c in cards:
         tf = by_id.get(c.object_id)
         block = render_facts_block(tf) if tf else ""
         if not block:
+            continue
+        if card_style == "ddl":
+            commented = "\n".join(f"-- {line}" if line else "--" for line in block.split("\n"))
+            c.card = f"{c.card}\n{commented}"
             continue
         head, _, rest = c.card.partition("\n")
         c.card = f"{head}\n{block}\n{rest}" if rest else f"{head}\n{block}"
@@ -127,6 +139,7 @@ def retrieve(
     columns: Sequence[Column] = (),
     ontology_index=None,
     snapshot=None,
+    card_style: str = "cards",
 ) -> ContextPacket:
     """Hybrid retrieval, scoped to the identity's grants *before* anything is ranked.
 
@@ -206,9 +219,13 @@ def retrieve(
         from mnemiq.semantic.cards import build_cards
         from mnemiq.sql.policy import build_access_policy
 
+        # `card_style` reaches only THIS re-render, the identity-scoped copy handed to the
+        # generator. `build_index` keeps the default, so the embedded card stays the form
+        # top-k was measured on and retrieval is untouched by the generator's preference.
         scoped = {
             card.object_id: card.text
-            for card in build_cards(snapshot, policy=build_access_policy(snapshot, grants))
+            for card in build_cards(
+                snapshot, policy=build_access_policy(snapshot, grants), style=card_style)
         }
     packet.cards = [
         RetrievedCard(
@@ -220,7 +237,7 @@ def retrieve(
         if object_id in cards
     ]
     packet.enrichment_version = next(iter(cards.values()))[1] if cards else None
-    _attach_facts(packet.cards, table_facts)
+    _attach_facts(packet.cards, table_facts, card_style)
     # After the cards are chosen, because a certified measure rides with its table -- see
     # `semantic.measures` for why that rule differs from the glossary's word-matching one.
     table_ids = [c.object_id for c in packet.cards]

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -205,3 +205,63 @@ def test_card_names_the_code_scheme():
     card = build_cards(snap)[0].text
     assert "ICD-10-CM" in card
     assert "E11 = Type 2 diabetes" in card
+
+
+def test_ddl_style_renders_the_same_card_as_create_table():
+    """`style="ddl"` exists because a DDL-trained generator reads shape, not only content.
+
+    Measured: one such model scored 50.5% on mini-dev through a DDL-and-examples prompt
+    and 35.7% on identical content through the TABLE/COLUMNS: form.
+    """
+    card = next(c for c in build_cards(_snapshot(), style="ddl") if c.object_id == "claim")
+
+    assert card.text.startswith("CREATE TABLE claim (")
+    assert card.text.rstrip().endswith(";") or "\n-- " in card.text
+    assert "TABLE claim\nCOLUMNS:" not in card.text
+    assert "claim_identifier integer" in card.text
+
+
+def test_ddl_style_quotes_identifiers_that_need_it():
+    """`Enrollment (K-12)` is a real mini-dev column: its NAME contains parentheses.
+
+    The first version of this renderer parsed the prose card back apart and split on the
+    first " (", which landed inside the name and produced `"Enrollment" K-12`.
+    """
+    snapshot = Snapshot(
+        version="v1", source_id="acme", created_at="2026-07-13T00:00:00Z",
+        source_bindings=[SourceBinding(
+            id="sb:frpm", source_id="acme", object_id="frpm",
+            source_object="frpm", binding_type="table")],
+        columns=[
+            Column(id="frpm.cdscode", object_id="frpm", name="cdscode", data_type="text"),
+            Column(id="frpm.enr", object_id="frpm", name="Enrollment (K-12)",
+                   data_type="real", description="K-12 enrollment count"),
+        ],
+    )
+    text = build_cards(snapshot, style="ddl")[0].text
+
+    assert '"Enrollment (K-12)" real' in text
+    assert "cdscode text," in text          # bare lowercase stays unquoted
+    assert '"Enrollment" K-12' not in text  # the parsing defect
+
+
+def test_build_index_embeds_the_cards_form(tmp_path):
+    """Top-k stays the form it was measured on, whatever the generator is handed.
+
+    The first version of this guard asserted on `build_cards(_snapshot())` and never
+    reached `build_index`: mutating that call to `style="ddl"` left it green, because
+    `claim_identifier integer` still contains every substring the retrieval tests look
+    for. Reading the stored card back is what makes the mutation fail.
+    """
+    from mnemiq.llm.embeddings import FakeEmbedder
+    from mnemiq.semantic.store import build_index
+    from mnemiq.store.bootstrap import init_store
+
+    con = init_store(str(tmp_path / "s.duckdb"))
+    assert build_index(con, _snapshot(), FakeEmbedder()) == 2
+
+    stored = [r[0] for r in con.execute("SELECT card FROM semantic_object").fetchall()]
+    assert stored, "nothing indexed, so the assertions below prove nothing"
+    for card in stored:
+        assert card.startswith("TABLE ")
+        assert "CREATE TABLE" not in card

--- a/tests/test_native_slm_harness.py
+++ b/tests/test_native_slm_harness.py
@@ -1,0 +1,141 @@
+"""The pure functions in `scripts/run_native_slm.py` decide a reported accuracy.
+
+Every case here is a defect that actually shipped in that script and was found by
+review rather than by use, which is why they are pinned rather than described.
+"""
+
+from __future__ import annotations
+
+import datetime
+import decimal
+import importlib.util
+import pathlib
+import sqlite3
+import time
+
+import pyarrow as pa
+import pytest
+
+_PATH = pathlib.Path(__file__).resolve().parents[1] / "scripts" / "run_native_slm.py"
+_spec = importlib.util.spec_from_file_location("run_native_slm", _PATH)
+slm = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(slm)
+
+
+def _table(names, rows):
+    """Build by position, the way the harness must, so duplicate names survive."""
+    cols = list(zip(*rows)) if rows else [() for _ in names]
+    return pa.Table.from_arrays([pa.array(list(c)) for c in cols], names=names)
+
+
+class TestExtractSql:
+    def test_a_fenced_block_wins(self):
+        assert slm.extract_sql("thinking\n```sql\nSELECT 1\n```") == "SELECT 1"
+
+    def test_the_last_fence_wins_because_these_models_answer_last(self):
+        text = "```sql\nSELECT 1\n```\nwait, better:\n```sql\nSELECT 2\n```"
+        assert slm.extract_sql(text) == "SELECT 2"
+
+    def test_unfenced_takes_the_LAST_select_not_the_first(self):
+        # `re.search` returns the leftmost match, so this used to hand back the discarded
+        # draft -- unrunnable SQL, graded as a model error rather than an extraction bug.
+        text = ("SELECT count(*) FROM t but that is wrong.\n"
+                "Actually the answer is:\nSELECT name FROM t WHERE x=1")
+        assert slm.extract_sql(text) == "SELECT name FROM t WHERE x=1"
+
+    def test_no_sql_at_all_is_empty_not_an_exception(self):
+        assert slm.extract_sql("I cannot answer that.") == ""
+        assert slm.extract_sql("") == ""
+        assert slm.extract_sql(None) == ""
+
+
+class TestRunSqlConstruction:
+    """Through `run_sql_sqlite`, so the construction that held the defect is what runs.
+
+    The previous version of this test built both tables with the helper below, which
+    already calls `from_arrays` -- so reverting the fix in `run_sql_sqlite` left every
+    test green. This one fails if it is reverted.
+    """
+
+    def test_duplicate_output_names_survive_execution(self):
+        con = sqlite3.connect(":memory:")
+        con.execute("CREATE TABLE t (name text, location text)")
+        con.execute("INSERT INTO t VALUES ('b', 'c')")
+        # `cur.description` is ['name', 'name', 'location'] -- 3 via from_arrays, 2 via a dict.
+        got = slm.run_sql_sqlite(con, "SELECT 'a' AS name, name, location FROM t")
+        assert got is not None
+        assert got.num_columns == 3, "duplicate output names collapsed"
+        assert got.column_names == ["name", "name", "location"]
+
+    def test_a_query_that_cannot_run_is_None_not_an_empty_table(self):
+        con = sqlite3.connect(":memory:")
+        assert slm.run_sql_sqlite(con, "SELECT * FROM nope") is None
+
+    def test_the_execution_cap_aborts_a_runaway(self):
+        con = sqlite3.connect(":memory:")
+        con.execute("CREATE TABLE t (x integer)")
+        con.executemany("INSERT INTO t VALUES (?)", [(i,) for i in range(2000)])
+        t0 = time.time()
+        got = slm.run_sql_sqlite(con, "SELECT COUNT(*) FROM t a, t b, t c", timeout_s=2.0)
+        assert got is None, "the cap did not fire"
+        assert time.time() - t0 < 15, "the cap fired far too late"
+
+
+class TestResultKey:
+    def test_duplicate_column_names_do_not_collapse(self):
+        # `SELECT T2.name, T1.name, T1.location` is real gold in this corpus. Built through
+        # a dict, the 3-column gold became 2 -- and so did a candidate missing a column,
+        # which then graded correct.
+        gold = _table(["name", "name", "location"], [("a", "b", "c")])
+        assert gold.num_columns == 3
+        candidate = _table(["name", "location"], [("b", "c")])
+        assert slm._result_key(gold) != slm._result_key(candidate)
+
+    def test_row_order_is_irrelevant(self):
+        a = _table(["x"], [(1,), (2,)])
+        b = _table(["x"], [(2,), (1,)])
+        assert slm._result_key(a) == slm._result_key(b)
+
+    def test_a_query_that_did_not_run_has_no_key(self):
+        assert slm._result_key(None) is None
+
+
+class TestVote:
+    def test_the_majority_result_wins(self):
+        t1, t2 = _table(["x"], [(1,)]), _table(["x"], [(2,)])
+        sql, tbl, votes, groups = slm.vote(
+            [("A", t1), ("B", t2), ("C", t1)])
+        assert (sql, votes, groups) == ("A", 2, 2)
+        assert tbl is t1
+
+    def test_a_query_that_did_not_run_is_not_evidence(self):
+        # Three non-runners must not out-vote one runner: they are absent, not agreeing.
+        t = _table(["x"], [(1,)])
+        sql, _, votes, groups = slm.vote(
+            [("bad1", None), ("bad2", None), ("bad3", None), ("good", t)])
+        assert (sql, votes, groups) == ("good", 1, 1)
+
+    def test_all_candidates_failing_yields_no_table_and_no_votes(self):
+        sql, tbl, votes, groups = slm.vote([("a", None), ("b", None)])
+        assert (sql, tbl, votes, groups) == ("a", None, 0, 0)
+
+    def test_semantically_equal_results_vote_together(self):
+        # Different SQL, same rows: one vote, which is the point of execution-based voting.
+        t1 = _table(["x"], [(1,)])
+        t2 = _table(["x"], [(1,)])
+        _, _, votes, groups = slm.vote([("q1", t1), ("q2", t2)])
+        assert (votes, groups) == (2, 1)
+
+
+class TestCell:
+    def test_decimals_stay_numbers(self):
+        # `default=str` stringified these, and an independent grader then disagreed on 11
+        # answers that were correct.
+        assert slm._cell(decimal.Decimal("109398.548387096774")) == pytest.approx(
+            109398.548387096774)
+
+    def test_dates_render_as_iso_not_python_repr(self):
+        assert slm._cell(datetime.date(2012, 8, 26)) == "2012-08-26"
+
+    def test_plain_values_pass_through(self):
+        assert (slm._cell(1), slm._cell("a"), slm._cell(None)) == (1, "a", None)

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -150,6 +150,76 @@ def test_attach_facts_inserts_block_after_table_line():
     assert other.card == "TABLE party\nCOLUMNS:"
 
 
+def test_attach_facts_keeps_ddl_parseable():
+    """The block cannot go after the FIRST line when the first line is `CREATE TABLE x (`.
+
+    That splice put `GRAIN:`/`GOTCHAS:` between the header and the first column and handed
+    the generator malformed DDL -- the one thing the ddl form exists to avoid. Review caught
+    it before it landed; no TEST could have, because the default-style assertion in
+    `test_attach_facts_inserts_block_after_table_line` was the only fact assertion here.
+    """
+    import sqlite3
+
+    from mnemiq.contract import TableFacts
+    from mnemiq.semantic.retrieval import RetrievedCard, _attach_facts
+
+    ddl = 'CREATE TABLE frpm (\n    cdscode text,\n    "Enrollment (K-12)" real\n);'
+    card = RetrievedCard(object_id="frpm", card=ddl, score=1.0)
+    _attach_facts(
+        [card],
+        [TableFacts(object_id="frpm", grain="one row per school-year",
+                    gotchas=["nulls in enrollment"])],
+        card_style="ddl",
+    )
+
+    assert "GRAIN" in card.card, "the facts have to arrive at all, or this proves nothing"
+    header, _, body = card.card.partition("\n")
+    assert header == "CREATE TABLE frpm ("
+    assert body.startswith("    cdscode text,"), "facts spliced ahead of the first column"
+    # The strongest available check: SQLite is the authority on whether it is legal DDL.
+    sqlite3.connect(":memory:").executescript(card.card)
+
+
+def test_retrieve_hands_attach_facts_the_style_it_rendered_with(tmp_path):
+    """`retrieve` is the only thing that can reach `_attach_facts` in a deployment.
+
+    Asserting the helper leaves the wiring open: dropping the third argument at the call
+    site sends every ddl card back down the splice path, and the helper's own guard stays
+    green because it passes `card_style` itself. Two things have to agree here -- the form
+    `build_cards` rendered and the placement `_attach_facts` chose -- and only the real
+    function decides both.
+    """
+    import sqlite3
+
+    from mnemiq.contract import TableFacts
+
+    con, snapshot = _con(tmp_path), _snapshot()
+    facts = [TableFacts(object_id="claim", grain="one row per claim",
+                        gotchas=["settled claims are excluded"])]
+
+    def claim_card(**kwargs):
+        packet = retrieve(con, "claim_identifier", _identity(),
+                          _StaticAuthz("claim", "policy"), FakeEmbedder(),
+                          table_facts=facts, snapshot=snapshot, **kwargs)
+        return next(c.card for c in packet.cards if c.object_id == "claim")
+
+    ddl = claim_card(card_style="ddl")
+    assert ddl.startswith("CREATE TABLE claim ("), "the ddl style did not reach the render"
+    assert "GRAIN" in ddl, "the facts did not arrive, so placement proves nothing"
+    sqlite3.connect(":memory:").executescript(ddl)
+
+    # The negative half. Without it, hardcoding either side to "ddl" satisfies everything
+    # above: the two halves agree, on a form nobody asked for, and the default operator is
+    # served it with nothing on screen saying so. No number belongs in this comment -- the
+    # 50.5%/35.7% pair was measured for one external model, and which form is BETTER is not
+    # what is wrong with serving the form that was not configured.
+    cards = claim_card()
+    assert "CREATE TABLE" not in cards
+    # `in cards` would pass on `-- GRAIN: ...` too, so it cannot tell spliced from commented
+    # -- the exact thing this half exists to pin. Anchor it to the position instead.
+    assert cards.startswith("TABLE claim\nGRAIN: one row per claim")
+
+
 def test_retrieve_examples_by_question_similarity_and_access_scope(tmp_path):
     from mnemiq.contract import Column, Example, Snapshot
     from mnemiq.llm.embeddings import FakeEmbedder

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -302,7 +302,7 @@ def test_ask_threads_ontology_index_columns_and_definitions(monkeypatch):
 
     def fake_retrieve(con, question, identity, authz, embedder, k=5, table_facts=(),
                       definitions=(), metrics=(), dimensions=(), columns=(), ontology_index=None,
-                      snapshot=None):
+                      snapshot=None, card_style="cards"):
         seen["definitions"] = list(definitions)
         # Certified metrics and dimensions were the next pair to reach the snapshot and stop
         # there -- five of the fs corpus's records, carrying the certified SQL for settled, gross
@@ -316,6 +316,7 @@ def test_ask_threads_ontology_index_columns_and_definitions(monkeypatch):
         # retrieve cannot re-render a card against the caller's column policy and silently
         # serves the unscoped one. That is the same gap this test was written for.
         seen["snapshot"] = snapshot
+        seen["card_style"] = card_style
         from mnemiq.semantic.retrieval import ContextPacket
 
         return ContextPacket(question=question, cards=[], grant_fingerprint="f",
@@ -350,6 +351,9 @@ def test_ask_threads_ontology_index_columns_and_definitions(monkeypatch):
     assert [d.term for d in seen["definitions"]] == ["ICD-10-CM"]  # glossary seam fed
     assert seen["metrics"] == ["patient_count"]      # ...and the certified measures
     assert seen["dimensions"] == ["patient.icd10_cd"]
+    # The card FORM is the same kind of thing: settable for eval, and the product path has
+    # to be able to reach the same value or the flag measures a prompt `ask` cannot emit.
+    assert seen["card_style"] == "cards"
 
 
 def test_the_eval_door_and_the_product_door_ground_identically():
@@ -403,7 +407,45 @@ def test_the_eval_door_and_the_product_door_ground_identically():
     # Named explicitly as well as compared, because two doors that BOTH stopped passing the
     # certified measures would agree with each other and ground nothing -- the equality above
     # cannot tell that from two doors that are both right.
-    assert {"metrics", "dimensions", "snapshot", "definitions", "ontology_index"} <= eval_door
+    assert {
+        "metrics", "dimensions", "snapshot", "definitions", "ontology_index", "card_style",
+    } <= eval_door
+
+
+def test_ask_hands_retrieval_the_configured_card_style(monkeypatch, tmp_path):
+    """The equality above only proves both doors pass the keyword, not that a value arrives.
+
+    `card_style` is the settable one: an eval measuring `ddl` is measuring a prompt form the
+    product must be able to emit, and `Runtime.ask` reads it off `Settings`. Passing a
+    hardcoded `"cards"` at the product door satisfies the scan and grounds nothing.
+    """
+    import mnemiq.runtime as rt_mod
+    from mnemiq.agent.loop import AgentAnswer
+    from mnemiq.contract import Snapshot
+    from mnemiq.semantic.retrieval import ContextPacket
+
+    seen = {}
+
+    def fake_retrieve(con, question, identity, authz, embedder, **kwargs):
+        seen["card_style"] = kwargs.get("card_style")
+        return ContextPacket(question=question, cards=[], grant_fingerprint="fp",
+                             enrichment_version=None)
+
+    class _Agent:
+        def answer(self, packet, snapshot, grants, identity, emit=None):
+            return AgentAnswer(answer="A")
+
+    monkeypatch.setattr(rt_mod, "retrieve", fake_retrieve)
+    settings = Settings(
+        llm_base_url=None, llm_api_key=None, llm_model=None, pg_dsn="x", acme_data_dir=None,
+        store_path=str(tmp_path / "s.duckdb"), card_style="ddl",
+    )
+    rt = Runtime(con=None, snapshot=Snapshot(version="v", source_id="s", created_at="t"),
+                 adapter=None, agent=_Agent(), embedder=None, authz=_StaticAuthz("claim"),
+                 settings=settings)
+    rt.ask("q", _identity())
+
+    assert seen["card_style"] == "ddl"
 
 
 def test_allow_all_clears_the_pii_levels_the_snapshot_tags():


### PR DESCRIPTION
Evaluates two external text-to-SQL models (Arctic-Text2SQL-R1-7B, OmniSQL-7B)
against this engine's numbers, and adds the one engine seam that measurement
turned out to require.

## What this adds

- **`scripts/run_native_slm.py`** — runs a model through *its own* published
  prompt and schema serialization rather than this engine's, which is the only
  way a published score is comparable. Grades with `results_match` and also
  records BIRD's own `set(pred) == set(gold)` rule, because the two disagree.
- **`scripts/slm-pipeline-env.sh`** — sourced-only env helper. The endpoint URL
  stays in shell env, never in a tracked file. Its guard is portable across
  `bash` and `zsh`: the `BASH_SOURCE` version was inert in the shell it was
  written for, so it refused nothing.
- **`tests/test_native_slm_harness.py`** — 17 tests. Every case is a defect
  that shipped in that script and changed a reported number, which is why they
  are pinned rather than described.
- **`card_style: Literal["cards", "ddl"]`** — a Settings field, so it reaches
  both the eval door and `Runtime.ask`. Measured: 50.5% through a
  `CREATE TABLE` prompt vs 35.7% through `TABLE x / COLUMNS:` on identical
  content, for one DDL-fine-tuned external model. `build_index` keeps the
  default, so the embedded text and top-k stay the form every retrieval number
  in this repo was measured on.

## The finding that touches this repo's published numbers

`results_match(allow_extra_columns=False)` is **stricter than BIRD's own
rule**. BIRD compares `set(pred) == set(gold)`, which collapses duplicate
rows; this engine does not. On the same predictions that is worth **+3.7
points on the 14B stack and +6.2 on Arctic**. Any number in the README graded
this way is not comparable to a published BIRD score in either direction — the
stricter rule is defensible as a product choice, but it has to be labelled.

## Merge method

**Merge commit, not squash.** The four commit messages carry the measurement
history — which defect changed which number, and the mutation that proves each
guard — and squashing them into one destroys the only record of that.

## Advisories deferred, not dropped

Review raised these and I left them. None changes a number here, and each is a
separate change:

1. **Gold-execution failures divide into the score.** A gold query that fails
   to run counts against the model. Affects the denominator, not the ordering.
2. **4xx responses fold into `empty-sql`.** A rejected request and a model that
   answered nothing are distinguishable at the transport layer and are not
   distinguished in the report.
3. **`finish_reason` is discarded.** A truncated generation looks like a wrong
   answer.
4. **The Postgres result construction is untested.** Only the SQLite path has
   coverage, so the duplicate-column fix is asserted on one backend.
5. **A `ROWS_PREVIEW` comment describes behaviour the code no longer has.**
6. **Per-column sampling failures are swallowed.**
7. **`build_cards(style="ddl")` drops a table's joins when a policy denies
   every column** — the empty-column early return emits `CREATE TABLE x (\n);`
   and returns before the relationships block. Reachable, and the cards form
   still emits them.

Two others were raised and **closed** rather than deferred, because the fix was
a line and the hole was real: the `ddl` fact-placement branch had no test at
all (`Cover the fact-placement path review caught before it landed`), and
`card_style` initially reached the eval door only — the shape the two-doors
derivation scan exists to catch.
