### PR TITLE
A link alias must refuse a call without claiming the source defines functions

### DIFF
--- a/src/mnemiq/adapters/oracle.py
+++ b/src/mnemiq/adapters/oracle.py
@@ -736,10 +736,31 @@ class OracleAdapter:
             "  AND procedure_name IS NOT NULL",
             owner=self._schema,
         )
-        return sorted({r[0] for r in direct} | self._synonyms_reaching_functions())
+        resolvable, _links = self._synonyms_reaching_functions()
+        return sorted({r[0] for r in direct} | resolvable)
 
-    def _synonyms_reaching_functions(self) -> set[str]:
-        """Aliases that end at a function, following chains, keyed by full identity.
+    def unresolvable_aliases(self) -> list[str]:
+        """Aliases over a DB LINK: they must refuse a call, and prove nothing about functions.
+
+        Kept out of `user_functions` because `calls_are_confirmable` is `licensed and not
+        names`, so any name there downgrades the whole source. Measured (M104): a schema
+        defining nothing of its own, plus one `PUBLIC orders FOR orders@ERP_LINK` over a
+        remote TABLE, flipped that flag from True to False -- `completeness='unknown'` on every
+        answer carrying a call. A link to a table is the common enterprise shape.
+
+        The alias still refuses a call spelling it, through `FunctionInventory.unresolvable`:
+        nothing local can tell a remote table from a remote function, so the refusal stands
+        and only the completeness claim is withdrawn.
+        """
+        _resolvable, links = self._synonyms_reaching_functions()
+        return sorted(links)
+
+    def _synonyms_reaching_functions(self) -> tuple[set[str], set[str]]:
+        """(aliases that end at a function, aliases over a DB LINK), following chains.
+
+        TWO sets because they answer different questions -- see `unresolvable_aliases`.
+        Both refuse a call spelling them; only the first is evidence this schema defines
+        functions, and only that claim reaches `calls_are_confirmable`.
 
         Oracle resolves `a -> b -> udf` at call time: measured, all three of `chain_udf(1)`,
         `chain_b(1)` and `chain_a(1)` returned 42. A join on the IMMEDIATE target sees only the
@@ -855,7 +876,7 @@ class OracleAdapter:
                 continue
             edges[(owner, name)] = (target_owner, target_name)
         if not edges and not over_a_link:
-            return set()
+            return set(), set()
         oracle_owned = {
             r[0] for r in self._rows(
                 "SELECT lower(username) FROM all_users WHERE oracle_maintained = 'Y'")
@@ -949,12 +970,28 @@ class OracleAdapter:
         # divergences all in that direction. Kept because the alternative is special-casing the
         # link aliases at the return, and a second code path for the shape this function most
         # recently got wrong is the worse trade.
-        return {
-            name
+        reported = {
+            (owner, name)
             for owner, name in set(edges) | over_a_link
             if (owner == mine and (owner, name) in reaches_any)
             or (owner == "public" and (owner, name) in reaches_free)
         }
+        # SPLIT, because the two answer different questions (M104). An alias that resolves to
+        # a function is evidence this schema defines functions; one over a DB LINK is evidence
+        # of nothing -- the target may be a table, and nothing local can tell. Both must refuse
+        # a call spelling them; only the first may downgrade the source's completeness.
+        resolvable = {name for owner, name in reported if (owner, name) not in over_a_link}
+        links = {name for owner, name in reported if (owner, name) in over_a_link}
+        # `names` WINS an overlap. These are sets of bare NAMES drawn from (owner, name)
+        # pairs, so one name can be both -- `app.orders` resolving to a function while
+        # `PUBLIC orders` goes over a link. Verified: the split returned `orders` in both
+        # halves. The guard checks `unresolvable` first, so a deployer who owns a real
+        # `app.orders` was told it "reaches this source through a synonym it cannot resolve",
+        # which is the wrong-object message this split was made to stop sending.
+        #
+        # Completeness is unaffected either way: the name is in `names`, which is what
+        # `calls_are_confirmable` reads.
+        return resolvable, links - resolvable
 
     def virtual_columns(self) -> list[tuple[str, str, str]]:
         """(table, column, expression) for every VIRTUAL column in this schema.

--- a/src/mnemiq/sql/authz_guard.py
+++ b/src/mnemiq/sql/authz_guard.py
@@ -213,7 +213,7 @@ def check_unmodelled_calls(
         # guard written to use it: measured, a raising `user_functions()` on a source holding a
         # `median` macro left `SELECT median(id) FROM claim` approved.
         return _cannot_resolve(inventory)
-    if not inventory.names:
+    if not (inventory.names or inventory.unresolvable):
         return None
 
     if inventory.may_shadow_a_builtin:
@@ -235,6 +235,20 @@ def check_unmodelled_calls(
         # sentence: this one is about THIS statement, and blaming the adapter for it would
         # send the deployer to fix a catalogue method that is working.
         return _cannot_resolve(inventory, unreadable=True)
+
+    # UNRESOLVABLE FIRST, and with its own sentence. "Defined by this source itself" is false
+    # of a synonym over a database link -- the source cannot see the target either -- and a
+    # deployer told to rename their function will look for one that is not there.
+    for name in sorted(called & inventory.unresolvable):
+        return Refusal(
+            code=RefusalCode.UNMODELLED_CALL,
+            message=(
+                f"{name}() reaches this source through a synonym it cannot resolve, so this "
+                "engine cannot confirm what the query reads. Answer using only the listed "
+                "tables and columns and standard SQL functions."
+            ),
+            subject=name,
+        )
 
     for name in sorted(called & inventory.names):
         return Refusal(
@@ -358,12 +372,23 @@ def _cannot_resolve(inventory: FunctionInventory, *, unreadable: bool = False) -
     someone to fix working code. That is the failure this list is arranged against.
     """
     if unreadable:
+        # "defines functions of its own" is FALSE where only `unresolvable` is populated -- a
+        # synonym over a database link is not the source's function, and the source cannot see
+        # its target either. Widening the gate to `names or unresolvable` made this arm
+        # reachable in that state, and a deployer reading it goes looking for a UDF that does
+        # not exist. The same argument the sibling arm's own sentence rests on.
+        has_own = bool(inventory.names)
+        why = (
+            "this source defines functions of its own"
+            if has_own
+            else "this source has names this engine cannot resolve"
+        )
         return Refusal(
             code=RefusalCode.UNRESOLVABLE_CALLS,
             message=(
                 "This query could not be rendered, so this engine cannot confirm which "
-                "functions it asks the source for, and this source defines functions of its "
-                "own. Answer using only the listed tables and columns and standard SQL."
+                f"functions it asks the source for, and {why}. "
+                "Answer using only the listed tables and columns and standard SQL."
             ),
             # The one arrival that is about the STATEMENT, so the one a rewrite can fix -- and
             # the message asks for one. The code alone would send it to the no-retry path with

--- a/src/mnemiq/sql/functions.py
+++ b/src/mnemiq/sql/functions.py
@@ -118,6 +118,21 @@ class FunctionInventory:
     # Defaults FALSE: an engine nobody measured is assumed to behave like DuckDB, which is the
     # conservative half. Forgetting yields a refusal, not a leak.
     binder_prefers_builtins: bool = False
+    # Names that must REFUSE A CALL without being evidence this source defines functions.
+    # The third category, and `names` was doing both jobs: `calls_are_confirmable` is
+    # `licensed and not names`, so ANY name downgrades the whole source's completeness.
+    #
+    # M104, measured: an Oracle schema defining nothing of its own, plus one
+    # `PUBLIC orders FOR orders@ERP_LINK` over a remote TABLE, put `orders` in `names` and
+    # flipped `calls_are_confirmable` from True to False -- `completeness='unknown'` on every
+    # answer carrying any call. A link to a table is the common enterprise shape and nothing
+    # local can tell it from a link to a function, so the alias must still refuse a call; what
+    # it must not do is assert the source has functions, which is a different claim.
+    #
+    # Not read by `may_shadow_a_builtin`: an unresolvable alias cannot be reached by a binder
+    # rename, because the binder would have to resolve it to do that, and the one engine that
+    # produces these sets `binder_prefers_builtins` anyway.
+    unresolvable: frozenset[str] = field(default_factory=frozenset)
 
     def __post_init__(self) -> None:
         # Normalised HERE, not only in `of()`. A dataclass hands out its plain constructor
@@ -134,6 +149,12 @@ class FunctionInventory:
         if isinstance(names, str):
             names = [names]
         object.__setattr__(self, "names", frozenset(n.lower() for n in names))
+        # Same normalisation, same reasons: a bare string splayed into characters, and a
+        # case-sensitive set reading a UDF as a builtin.
+        unresolvable = self.unresolvable
+        if isinstance(unresolvable, str):
+            unresolvable = [unresolvable]
+        object.__setattr__(self, "unresolvable", frozenset(n.lower() for n in unresolvable))
         reachable = self.reachable
         if reachable is not None:
             if isinstance(reachable, str):
@@ -247,6 +268,10 @@ def inventory_from(adapter) -> FunctionInventory:
         return FunctionInventory.never_asked()
     try:
         names = adapter.user_functions()
+        # SAME try, so one outage decides one way. Both are live dictionary reads carrying the
+        # same security property, and handling them separately let a raise on this one fall
+        # through to an empty set while the same raise on the other refused every statement.
+        unresolvable = _unresolvable_from(adapter)
     except Exception as exc:
         # The TYPE, not the message. A source's exception text is made of the caller's schema
         # and can carry a DSN, and this reason reaches an audit record (M94).
@@ -259,6 +284,7 @@ def inventory_from(adapter) -> FunctionInventory:
         builtins_asked=builtins_asked,
         reachable=_reachable_from(adapter),
         binder_prefers_builtins=getattr(adapter, "binder_prefers_builtins", False),
+        unresolvable=unresolvable,
     )
 
 
@@ -274,6 +300,30 @@ def _reachable_from(adapter) -> frozenset[str] | None:
         return frozenset(n.lower() for n in adapter.reachable_user_functions())
     except Exception:
         return None
+
+
+def _unresolvable_from(adapter) -> frozenset[str]:
+    """Aliases this source can neither resolve nor rule out. RAISES if the source cannot say.
+
+    Absence and FAILURE are opposite here, and an earlier version of this collapsed them into
+    an empty set with the justification that "forgetting it only means such names stay in
+    `names`, where they already refuse a call". That was disproven by the same diff: the
+    Oracle adapter stopped putting link aliases in `user_functions`, so an empty return leaves
+    such a name in NEITHER set and the guard clears the call. Measured with a stub whose
+    `unresolvable_aliases()` raised ORA-03113: `decide` APPROVED
+    `SELECT add_days(1) FROM dbl_claim` -- the exact statement M102 measured returning an
+    ungranted SSN, re-approved through the new door.
+
+    So a raise PROPAGATES, and `inventory_from` turns it into `unavailable` exactly as it does
+    for `user_functions`. Two live dictionary reads deciding opposite ways on one outage was
+    the asymmetry that made this unsafe.
+
+    ABSENCE still means empty, and that stays safe: an adapter without the method has no
+    concept of an unresolvable alias, so whatever it knows is already in `names`.
+    """
+    if adapter is None or not hasattr(adapter, "unresolvable_aliases"):
+        return frozenset()
+    return frozenset(n.lower() for n in adapter.unresolvable_aliases())
 
 
 def _builtins_from(adapter) -> tuple[frozenset[str] | None, bool]:
@@ -336,7 +386,16 @@ def opaque_columns(adapter, inventory: FunctionInventory) -> frozenset[tuple[str
     return frozenset(
         (table, column)
         for table, column, expression in columns
-        if names_called_in(expression) & inventory.names
+        # BOTH sets. A link alias left `names` when M104 split the two categories, so a
+        # virtual column whose stored expression reaches one stopped being flagged -- the
+        # M100 route back, for that one shape, in the same diff that moved the name.
+        #
+        # MEASURED: Oracle refuses `GENERATED ALWAYS AS (link_syn(id))` with ORA-02069,
+        # "global_names parameter must be set to TRUE for this operation", while the same DDL
+        # over a LOCAL function is accepted -- so the refusal is about the link and no such
+        # column can exist on a default instance. But that error names a SETTING, so with
+        # `global_names=TRUE` it may be permitted, and the union costs nothing where it is not.
+        if names_called_in(expression) & (inventory.names | inventory.unresolvable)
     )
 
 

--- a/tests/test_function_inventory.py
+++ b/tests/test_function_inventory.py
@@ -13,7 +13,11 @@ import duckdb
 import pytest
 
 from mnemiq.adapters.duckdb import DuckDBAdapter
-from mnemiq.sql.functions import FunctionInventory, calls_are_confirmable
+from mnemiq.sql.functions import (
+    FunctionInventory,
+    calls_are_confirmable,
+    inventory_from,
+)
 
 
 def test_an_empty_answer_is_not_a_failed_lookup():
@@ -819,8 +823,8 @@ def test_every_adapter_the_resolver_hands_out_can_answer_the_inventory():
 # --------------------------------------------------------------------------------------------
 
 
-def _oracle_walk(synonyms, functions, oracle_owned=("sys",), schema="APP", asked=None):
-    """`_synonyms_reaching_functions` over a stubbed data dictionary.
+def _oracle_adapter(synonyms, functions, oracle_owned=("sys",), schema="APP", asked=None):
+    """An OracleAdapter over a stubbed data dictionary. NO DATABASE.
 
     `asked` collects the owners the object read binds, because WHICH owners it asks about is
     where the cost lives and no stub can time it.
@@ -851,7 +855,28 @@ def _oracle_walk(synonyms, functions, oracle_owned=("sys",), schema="APP", asked
         return [(o, n) for o, n in functions if o in wanted]
 
     adapter._rows = rows
-    return adapter._synonyms_reaching_functions()
+    return adapter
+
+
+def _oracle_walk(*a, **kw) -> set[str]:
+    """The UNION -- which aliases get reported at all, what nearly every test here asks.
+
+    `_oracle_walk_split` returns the two halves, for the tests about which side a name lands
+    on (M104).
+    """
+    resolvable, links = _oracle_adapter(*a, **kw)._synonyms_reaching_functions()
+    return resolvable | links
+
+
+def _oracle_walk_split(*a, **kw) -> tuple[set[str], set[str]]:
+    """(reported as functions, reported as unresolvable link aliases).
+
+    Calls the method DIRECTLY rather than swapping it on the class and letting `_oracle_walk`
+    invoke it. That version left the captured pair unset whenever anything inside the walk
+    raised -- the stub's own `assert "where" not in sql.lower()` among them -- so a real
+    failure came back as a KeyError from the capture dict and said nothing about the cause.
+    """
+    return _oracle_adapter(*a, **kw)._synonyms_reaching_functions()
 
 
 def test_a_name_shared_by_a_private_and_a_public_synonym_resolves_the_same_way_every_time():
@@ -1081,27 +1106,42 @@ def test_a_chain_reaching_a_PUBLIC_db_link_synonym_reports_both():
     ], []) == {"via_pub", "pub_link"}
 
 
-def test_reporting_a_link_alias_downgrades_completeness_on_a_schema_that_defines_nothing():
-    """The COST of the M102 fix, pinned rather than described, because the comment describing
-    it was wrong twice.
+def test_a_link_alias_no_longer_downgrades_a_schema_that_defines_nothing():
+    """M104 CLOSED. The same measurement that opened it, now the other way round.
 
-    `calls_are_confirmable` is `licensed and not inventory.names`, so any name at all makes it
-    false. The first note on the fix argued the cost was bounded to queries spelling the alias,
-    on the grounds that a schema defining a function is already downgraded -- true, and silent
-    about the schema that defines NONE, which is the case this measures. A link over a remote
-    TABLE is the common enterprise shape and produces a name here regardless, because nothing
-    local can tell a remote table from a remote function.
+    `calls_are_confirmable` is `licensed and not names`, so any name there downgrades the
+    whole source. A schema defining nothing of its own, plus one
+    `PUBLIC orders FOR orders@ERP_LINK` over a remote TABLE, used to put `orders` in `names`
+    and flip that flag from True to False -- `completeness='unknown'` on every answer carrying
+    any call, for what is the common enterprise shape.
 
-    Same issue-#5 downgrade the PUBLIC/Oracle-maintained filter exists to avoid, accepted here
-    because the alternative is approving a call that returns an ungranted row.
+    The alias is reported as UNRESOLVABLE now: it still refuses a call spelling it, because
+    nothing local can tell a remote table from a remote function, but it no longer asserts
+    that this source defines functions. That was two claims wearing one name.
     """
-    names = _oracle_walk([("public", "orders", None, "orders", "ERP_LINK")], [])
-    assert names == {"orders"}, "a remote table is indistinguishable from a remote function"
+    resolvable, links = _oracle_walk_split([("public", "orders", None, "orders", "ERP_LINK")], [])
+    assert resolvable == set(), "a link alias is not evidence of a function"
+    assert links == {"orders"}
 
-    downgraded = FunctionInventory(names=frozenset(names))
-    assert calls_are_confirmable(downgraded, in_view_body=False) is False
-    # The control: without the link alias this source certifies, so the flip is the alias's.
-    assert calls_are_confirmable(FunctionInventory(names=frozenset()), in_view_body=False) is True
+    downgraded = FunctionInventory(names=frozenset(resolvable), unresolvable=frozenset(links))
+    assert calls_are_confirmable(downgraded, in_view_body=False) is True
+    # The control: a REAL function still downgrades, which is the behaviour being preserved.
+    assert calls_are_confirmable(
+        FunctionInventory(names=frozenset({"udf"})), in_view_body=False
+    ) is False
+
+
+def test_an_alias_that_resolves_to_a_function_still_counts_as_one():
+    """The other half. Splitting the two categories must not quietly move a real function into
+    the harmless bucket -- an alias whose chain ends at a FUNCTION is evidence, and downgrades
+    completeness exactly as it did."""
+    resolvable, links = _oracle_walk_split(
+        [("app", "add_days", "app", "udf")], [("app", "udf")]
+    )
+    assert resolvable == {"add_days"} and links == set()
+    assert calls_are_confirmable(
+        FunctionInventory(names=frozenset(resolvable)), in_view_body=False
+    ) is False
 
 
 def test_keying_the_report_on_the_alias_over_reports_through_the_public_fallback():
@@ -1168,7 +1208,8 @@ def test_the_owner_read_is_chunked_under_oracles_in_list_cap():
         return [(o, "udf") for o in binds.values()]
 
     adapter._rows = rows
-    got = adapter._synonyms_reaching_functions()
+    resolvable, links = adapter._synonyms_reaching_functions()
+    got = resolvable | links
 
     assert len(got) == 2500
     assert reads and max(reads) <= 900, f"one read bound {max(reads)} owners"
@@ -1351,3 +1392,181 @@ def test_an_alias_cannot_spell_its_way_past_the_guard(sql):
     refusal = check_opaque_columns(sqlglot.parse_one(sql, read="oracle"),
                                    frozenset({("vc_t", "leaked")}), "oracle")
     assert refusal is not None, sql
+
+
+def test_an_unresolvable_alias_still_refuses_a_call_that_spells_it():
+    """The refusal is the half M104 must NOT relax. Nothing local can tell a remote table from
+    a remote function, so a statement calling the alias is still unconfirmable -- only the
+    claim that the source defines functions was withdrawn."""
+    import sqlglot
+
+    from mnemiq.sql.authz_guard import check_unmodelled_calls
+
+    inventory = FunctionInventory(names=frozenset(), unresolvable=frozenset({"add_days"}))
+    refusal = check_unmodelled_calls(
+        sqlglot.parse_one("SELECT add_days(1) AS x FROM claim", read="oracle"),
+        inventory, "oracle",
+    )
+    assert refusal is not None, "a call through an unresolvable alias was cleared"
+    assert refusal.subject == "add_days"
+    # Its OWN sentence: "defined by this source itself" is false of a synonym over a link --
+    # the source cannot see the target either -- and would send a deployer looking for a
+    # function that is not there.
+    assert "cannot resolve" in refusal.message, refusal.message
+    assert "defined by this source itself" not in refusal.message
+
+
+def test_a_statement_calling_nothing_is_cleared_even_with_an_unresolvable_alias():
+    """The early return reads the UNION now. Widening it must not start refusing statements
+    that spell no alias at all -- that is the blast radius M104 exists to bound."""
+    import sqlglot
+
+    from mnemiq.sql.authz_guard import check_unmodelled_calls
+
+    inventory = FunctionInventory(names=frozenset(), unresolvable=frozenset({"orders"}))
+    assert check_unmodelled_calls(
+        sqlglot.parse_one("SELECT id FROM orders", read="oracle"), inventory, "oracle"
+    ) is None
+
+
+# --------------------------------------------------------------------------------------------
+# The WIRING from adapter to decision. Rebinding `_unresolvable_from` to return empty left the
+# whole suite green while `decide` APPROVED the statement M102 measured returning an ungranted
+# SSN -- the security property had moved to a seam nothing runnable crossed. These stubs need
+# no database, so they run wherever the suite does.
+# --------------------------------------------------------------------------------------------
+
+
+class _LinkAliasSource:
+    """An Oracle-shaped source that defines no functions and has one unresolvable alias."""
+
+    dialect = "oracle"
+    binder_prefers_builtins = True
+
+    def __init__(self, aliases=("add_days",), raise_aliases=False):
+        self._aliases = aliases
+        self._raise = raise_aliases
+
+    def user_functions(self):
+        return []
+
+    def unresolvable_aliases(self):
+        if self._raise:
+            raise RuntimeError("ORA-03113: end-of-file on communication channel")
+        return list(self._aliases)
+
+    def list_columns(self):
+        return [("dbl_claim", "id", "NUMBER")]
+
+
+def test_an_unresolvable_alias_reaches_the_DECISION_not_just_the_inventory():
+    """The seam the mutation crossed. `inventory_from` -> `FunctionInventory.unresolvable` ->
+    `check_unmodelled_calls` is what stops the call, and the only assertion on
+    `unresolvable_aliases()` before this one was inside an integration-gated Oracle test."""
+    from mnemiq.sql.decide import decide
+
+    source = _LinkAliasSource()
+    inv = inventory_from(source)
+    assert inv.names == frozenset() and inv.unresolvable == frozenset({"add_days"})
+
+    verdict = decide("SELECT add_days(1) AS x FROM dbl_claim", {"dbl_claim": {"id"}},
+                     adapter=source, dialect="oracle", target="oracle")
+    assert getattr(verdict, "code", None) is not None, f"APPROVED the call: {verdict}"
+    assert verdict.code.value == "unmodelled_call", verdict
+    # And completeness is NOT downgraded, which is the whole of M104.
+    assert calls_are_confirmable(inv, in_view_body=False) is True
+
+
+def test_a_source_that_CANNOT_SAY_refuses_rather_than_clearing():
+    """FAIL CLOSED. `unresolvable_aliases()` raising used to return an empty set, and since
+    the alias had also left `user_functions` it was then in NEITHER set: measured, `decide`
+    APPROVED `SELECT add_days(1) FROM dbl_claim` with no completeness marker.
+
+    A raise on either live dictionary read now yields the same `unavailable` inventory, so one
+    outage decides one way."""
+    from mnemiq.sql.decide import decide
+
+    source = _LinkAliasSource(raise_aliases=True)
+    inv = inventory_from(source)
+    assert inv.asked and not inv.available, inv
+    assert inv.reason == "RuntimeError", inv.reason  # the TYPE, never the message (M94)
+
+    verdict = decide("SELECT add_days(1) AS x FROM dbl_claim", {"dbl_claim": {"id"}},
+                     adapter=source, dialect="oracle", target="oracle")
+    # THE SPECIFIC CODE. `_LinkAliasSource` has no `execute`, so a statement the inventory
+    # CLEARS still ends in `explain_failed` -- measured. Asserting only "some refusal" was
+    # therefore satisfied by a mechanism this test is not about, and would have passed with
+    # the fail-open restored.
+    assert verdict.code.value == "unresolvable_calls", verdict
+
+    # The control that proves the assertion above discriminates: with nothing unresolvable the
+    # inventory clears the call and the stub's missing `execute` is what refuses instead.
+    cleared = decide("SELECT add_days(1) AS x FROM dbl_claim", {"dbl_claim": {"id"}},
+                     adapter=_LinkAliasSource(aliases=()), dialect="oracle", target="oracle")
+    assert cleared.code.value == "explain_failed", cleared
+
+
+def test_an_adapter_without_the_method_is_unaffected():
+    """Absence is not failure. An adapter with no concept of an unresolvable alias has
+    everything it knows in `names` already, so empty is right and must not refuse."""
+    class NoAliases:
+        dialect = "duckdb"
+
+        def user_functions(self):
+            return ["udf"]
+
+    inv = inventory_from(NoAliases())
+    assert inv.unresolvable == frozenset()
+    assert inv.available and inv.asked and inv.names == frozenset({"udf"})
+
+
+def test_a_name_that_is_BOTH_a_function_and_a_link_alias_counts_as_the_function():
+    """These are sets of bare NAMES drawn from (owner, name) pairs, so one name can be both:
+    `app.orders` resolving to a function while `PUBLIC orders` goes over a link. The split
+    returned `orders` in both halves, and because the guard checks `unresolvable` first a
+    deployer who owns a real `app.orders` was told it "reaches this source through a synonym
+    it cannot resolve" -- the wrong-object message this split exists to stop sending."""
+    resolvable, links = _oracle_walk_split(
+        [("app", "orders", "app", "udf"),
+         ("public", "orders", None, "orders", "ERP_LINK")],
+        [("app", "udf")],
+    )
+    assert "orders" in resolvable
+    assert "orders" not in links, "one name in both halves; the guard reports the wrong one"
+
+
+def test_the_unreadable_refusal_does_not_claim_functions_the_source_lacks():
+    """Widening the gate to `names or unresolvable` made this arm reachable with an empty
+    `names`, where "this source defines functions of its own" is false twice -- of a link
+    synonym, and of the inventory's own data."""
+    from mnemiq.sql.authz_guard import _cannot_resolve
+
+    only_links = FunctionInventory(names=frozenset(), unresolvable=frozenset({"orders"}))
+    assert "cannot resolve" in _cannot_resolve(only_links, unreadable=True).message
+    assert "defines functions of its own" not in _cannot_resolve(
+        only_links, unreadable=True).message
+
+    # The control: a source that DOES define functions still says so.
+    own = FunctionInventory(names=frozenset({"udf"}))
+    assert "defines functions of its own" in _cannot_resolve(own, unreadable=True).message
+
+
+def test_a_virtual_column_reaching_a_link_alias_is_still_opaque():
+    """`opaque_columns` intersects the stored expression's names with the inventory, and a link
+    alias left `names` when M104 split the categories -- so a `DATA_DEFAULT` of
+    `"ORDERS"("ID")` reaching `orders@ERP_LINK` stopped being flagged, giving the M100
+    no-call-in-the-text route back for that shape.
+
+    MEASURED on the container: Oracle refuses `GENERATED ALWAYS AS (link_syn(id))` with
+    ORA-02069 while the same DDL over a LOCAL function is accepted, so no such column exists
+    on a default instance. That error names a SETTING (`global_names`), so the union costs
+    nothing where the DDL is refused and closes it where it is not.
+    """
+    from mnemiq.sql.functions import opaque_columns
+
+    class Source:
+        def virtual_columns(self):
+            return [("orders_t", "c", '"ORDERS"("ID")')]
+
+    inv = FunctionInventory(names=frozenset(), unresolvable=frozenset({"orders"}))
+    assert opaque_columns(Source(), inv) == frozenset({("orders_t", "c")})

--- a/tests/test_oracle_adapter.py
+++ b/tests/test_oracle_adapter.py
@@ -2061,14 +2061,22 @@ def test_a_synonym_over_a_db_link_is_a_route_to_a_udf_this_engine_cannot_resolve
         cur.execute("SELECT add_days(1) FROM dual")
         assert cur.fetchone()[0] == "123-45-6789", "no leak, so nothing below proves anything"
 
-        assert "add_days" in set(adapter.user_functions()), "the alias a query would spell"
+        # UNRESOLVABLE, not `user_functions` (M104). The alias must still refuse a call --
+        # nothing local can tell a remote table from a remote function -- but it is not
+        # evidence this schema defines functions, and `calls_are_confirmable` is
+        # `licensed and not names`, so putting it there downgraded every answer's completeness
+        # on a schema that defines nothing else.
+        assert "add_days" in set(adapter.unresolvable_aliases()), "the alias a query spells"
+        assert "add_days" not in set(adapter.user_functions()), "back in the wrong bucket"
 
         refused = decide("SELECT add_days(1) AS x FROM dbl_claim", {"dbl_claim": {"id"}},
                          adapter=adapter, dialect="oracle", target="oracle")
         assert refused.code.value == "unmodelled_call", refused
         # From the INVENTORY branch, not the allowlist. They share a code and differ in what
         # they say, and asserting only the code is how the sibling test passed while reverted.
-        assert "defined by this source itself" in refused.message, refused.message
+        # Its own sentence: "defined by this source itself" is false of a link synonym.
+        assert "cannot resolve" in refused.message, refused.message
+        assert "defined by this source itself" not in refused.message
 
         for clean in ("SELECT count(*) AS n FROM dbl_claim", "SELECT id FROM dbl_claim"):
             v = decide(clean, {"dbl_claim": {"id"}}, adapter=adapter,


### PR DESCRIPTION
Closes **M104**, which the review of the M102 fix opened.

## The two claims wearing one name

`names` decided two different things: which calls the guard refuses, and — through
`calls_are_confirmable`, which is `licensed and not names` — whether the source's answers carry
a completeness label. M102 put unresolvable DB-link aliases in there, right for the refusal and
wrong for everything else.

Measured when it was filed: a schema defining nothing of its own, plus one
`PUBLIC orders FOR orders@ERP_LINK` over a remote **table**, gave `user_functions() == ['orders']`
and flipped `calls_are_confirmable` True → False — `completeness='unknown'` on every answer
carrying any call. A link to a table is the common enterprise shape, and nothing local
distinguishes it from a link to a function.

So there is a third category: `FunctionInventory.unresolvable` — a name that must refuse a **call**
without being evidence the source defines functions. The guard reads the union and gives such an
alias its own sentence; `calls_are_confirmable` still reads `names` alone.

## Two blockers, both places my own diff disproved my own reasoning

**The new read failed open.** `_unresolvable_from` swallowed every exception and returned empty,
justified in its docstring by *"forgetting it only means such names stay in `names`, where they
already refuse a call"*. That stopped being true **in the same diff** — the adapter no longer puts
link aliases in `user_functions`, so an empty return leaves the name in *neither* set. Measured
with a stub whose `unresolvable_aliases()` raises `ORA-03113`: `decide` **approved**
`SELECT add_days(1) FROM dbl_claim` — the exact statement M102 measured returning an ungranted
SSN, re-approved through the new door. A raise now lands in the same `unavailable` handler as
`user_functions`, so one outage decides one way.

**The wiring had no runnable test**, and it had just inherited the property a runnable test used to
carry. Rebinding `_unresolvable_from` to return empty left the whole suite green. Three stub tests
cross the seam now — adapter → inventory → decision — with no database.

## Four more

- The widened gate made the `UnreadableCalls` arm reachable with an empty `names`, where *"this
  source defines functions of its own"* is false twice over.
- **`opaque_columns` had narrowed**, giving the M100 no-call-in-the-text route back for one shape.
  Measured on the container: Oracle refuses `GENERATED ALWAYS AS (link_syn(id))` with `ORA-02069`,
  *"global_names parameter must be set to TRUE"*, while the same DDL over a **local** function is
  accepted — so the refusal is about the link and no such column exists by default. That error
  names a *setting*, so the intersection reads both sets: free where the DDL is refused, closed
  where `global_names=TRUE` permits it.
- The split keyed bare names taken from `(owner, name)` pairs, so one name could land in **both**
  halves — `app.orders` resolving to a function while `PUBLIC orders` goes over a link. The guard
  checks `unresolvable` first, so a deployer owning a real `app.orders` got the wrong-object
  message this split exists to prevent. `names` wins an overlap.
- A test helper captured its result by swapping a method on the class, so any failure inside the
  walk came back as a `KeyError` saying nothing about the cause.

## And one test satisfied by the wrong mechanism

`_LinkAliasSource` has no `execute`, so `decide` refuses with `explain_failed` whatever the
inventory decides. The fail-closed test asserted only *"some refusal"* — it would have passed with
the fail-open restored. It asserts `unresolvable_calls` now, with a control proving the assertion
discriminates: with nothing unresolvable the inventory **clears** the call and the missing
`execute` is what refuses instead.

## Verified

Live, with a link over a table: the alias is out of `names`, in `unresolvable`, and `decide`
refuses with *"reaches this source through a synonym it cannot resolve"*. `calls_are_confirmable`
is still False on that container and correctly so — its APPUSER really does define functions, so
`names` is non-empty whatever the alias does. The flip M104 is about needs a schema defining
nothing, which the unit test covers: **the live run proves the mechanism, not the flip.**

Local suite `2058 passed`; Oracle integration `59 passed, 7 skipped` live. Every fix
mutation-checked, each red on its own test.
