### PR TITLE
Pin the narrowed field on the MCP write and read surfaces

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -103,3 +103,55 @@ def test_db_write_reports_rows_on_approval():
 
     out = _db_write(_RT(), _identity(), "INSERT INTO claim (id) VALUES (1)")
     assert out["approved"] is True and out["target"] == "claim" and out["rows_affected"] == 1
+
+
+# ---------------------------------------------------------------------------
+# The `narrowed` field tells a governing agent that an access decision scoped the result.
+# Without it, `rows_affected=3` on a DELETE of 47 reads as an ordinary success — there is
+# nothing saying why, and 3 of 47 deleted reads as correct.  These tests pin the field on
+# both the write and read MCP surfaces, which had no coverage for it at all.
+# ---------------------------------------------------------------------------
+
+
+def test_db_write_carries_narrowed_when_scoped():
+    """A governed write that was scoped down must surface what was narrowed, not just the count."""
+    from mnemiq.contract.seams import Narrowed
+    from mnemiq.mcp.server import _db_write
+    from mnemiq.runtime import WriteResult
+
+    class _RT:
+        def write(self, sql, identity):
+            return WriteResult(
+                approved=True, target="claim", rows_affected=3,
+                target_sql="DELETE FROM claim WHERE ...",
+                narrowed=[Narrowed(object="claim", rows=True, columns=False)],
+            )
+
+    out = _db_write(_RT(), _identity(), "DELETE FROM claim WHERE status = 'closed'")
+    assert out["narrowed"] == [{"object": "claim", "rows": True, "columns": False}]
+
+
+def test_db_write_narrowed_is_none_when_not_evaluated():
+    """None means the decision was not evaluated — distinct from [] which means nothing was scoped."""
+    from mnemiq.mcp.server import _db_write
+    from mnemiq.runtime import WriteResult
+
+    class _RT:
+        def write(self, sql, identity):
+            return WriteResult(approved=False, refusal="denied", narrowed=None)
+
+    out = _db_write(_RT(), _identity(), "DELETE FROM claim")
+    assert out["narrowed"] is None
+
+
+def test_db_read_carries_narrowed_from_trace():
+    """The read path had the same gap: narrowed sits on the trace and must reach the MCP consumer."""
+    from mnemiq.contract.seams import Narrowed
+
+    trace = _trace()
+    trace = trace.model_copy(update={
+        "narrowed": [Narrowed(object="claim", rows=True, columns=False)],
+    })
+    rt = _RT(AgentAnswer(answer="3 claims.", trace=trace, deferred=False), [])
+    out = _db_read(rt, _identity(), "how many claims?")
+    assert out["trace"]["narrowed"] == [{"object": "claim", "rows": True, "columns": False}]


### PR DESCRIPTION
`_db_write` serialises a `narrowed` list beside `rows_affected`, and `_db_read` carries one on the trace, but neither had a test. Without one, a refactor can drop or misformat the field silently, and a governing agent stops learning that 44 of 47 rows were withheld while the rest of the payload looks healthy.

The gap matters because `narrowed` is the only thing that distinguishes "3 rows deleted, as requested" from "3 rows deleted, out of 47 the identity was allowed to touch". `rows_affected=3` reads as success either way; the `narrowed` record is what says why.

Three tests:

| test | what it pins |
|---|---|
| `test_db_write_carries_narrowed_when_scoped` | the list serialises to the expected dict shape |
| `test_db_write_narrowed_is_none_when_not_evaluated` | None (not evaluated) is distinct from [] (nothing scoped) |
| `test_db_read_carries_narrowed_from_trace` | the read surface carries the same field from the trace |

12 passed, `ruff check` clean.
